### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  GO_VERSION: "1.24.6"
+
+jobs:
+  # Run CI pipeline to ensure quality
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: ci
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,44 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - main: ./cmd/scanorama
+    binary: scanorama
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X 'main.version={{.Version}}'
+      - -X 'main.commit={{.Commit}}'
+      - -X 'main.buildTime={{.Date}}'
+
+archives:
+  - format: tar.gz
+    files:
+      - README.md
+      - LICENSE
+      - CHANGELOG.md
+
+checksums:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+
+release:
+  prerelease: auto

--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ go test ./internal -run "Scan"
 
 See `docs/` for technical documentation and contribution guidelines.
 
+## Releases
+
+To create a release:
+
+1. Create and push a git tag:
+   ```bash
+   git tag v0.5.0
+   git push origin v0.5.0
+   ```
+
+2. GitHub Actions will automatically build and create the release with cross-platform binaries
+
+Release artifacts include Linux and macOS binaries built with GoReleaser.
+
 ## License
 
 MIT License - see LICENSE file for details.


### PR DESCRIPTION
This PR adds a simple automated release workflow using GoReleaser.

## What's Added
- GitHub Actions workflow triggered by git tags (v*)
- GoReleaser configuration for cross-platform builds
- Builds for Linux and macOS (amd64/arm64 architectures)
- Automatic generation of checksums and release notes
- Simple documentation in README

## How to Use
1. Create a git tag: `git tag v0.5.0`
2. Push the tag: `git push origin v0.5.0`
3. GitHub Actions automatically builds and creates the release

This provides a foundation for consistent releases that we can build upon as needed.