### PR TITLE
fix(ci): add workflow_call trigger to make CI workflow reusable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main]
+  workflow_call:
 
 env:
   GO_VERSION: "1.24.6"


### PR DESCRIPTION
This PR fixes the release workflow that was failing with an error:

```
Invalid workflow file: .github/workflows/release.yml#L14
error parsing called workflow: workflow is not reusable as it is missing a `on.workflow_call` trigger
```

## Changes
- Add `workflow_call` trigger to `.github/workflows/ci.yml`
- This allows the CI workflow to be used as a reusable workflow from the release pipeline

## Why this fix is needed
The release workflow tries to call the CI workflow using `uses: ./.github/workflows/ci.yml` but GitHub Actions requires workflows to have an explicit `on.workflow_call` trigger to be reusable.

## Testing
- The change is minimal and only adds a trigger that enables reusability
- This should resolve the workflow syntax error and allow the release pipeline to function correctly