### PR TITLE
fix: update GoReleaser config for v2 compatibility

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,13 +23,13 @@ builds:
       - -X 'main.buildTime={{.Date}}'
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     files:
       - README.md
       - LICENSE
       - CHANGELOG.md
 
-checksums:
+checksum:
   name_template: "checksums.txt"
 
 changelog:

--- a/GORELEASER_FIX.md
+++ b/GORELEASER_FIX.md
@@ -1,0 +1,57 @@
+# GoReleaser Configuration Fix
+
+## Issue
+The GitHub Actions Release workflow was failing with GoReleaser v2 due to deprecated configuration fields.
+
+## Root Cause
+The `.goreleaser.yml` configuration was using the deprecated `archives.format` field, which was replaced with `archives.formats` (plural) in GoReleaser v2.6.
+
+## Error Message
+```
+• DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
+• .goreleaser.yml error=configuration is valid, but uses deprecated properties
+⨯ check failed error=1 out of 1 configuration file(s) have issues
+```
+
+## Solution Applied
+Updated `.goreleaser.yml` to replace the deprecated field:
+
+**Before:**
+```yaml
+archives:
+  - format: tar.gz
+    files:
+      - README.md
+      - LICENSE
+      - CHANGELOG.md
+```
+
+**After:**
+```yaml
+archives:
+  - formats: [tar.gz]
+    files:
+      - README.md
+      - LICENSE
+      - CHANGELOG.md
+```
+
+## Verification
+1. **Configuration Validation:** `goreleaser check` now passes without warnings
+2. **Local Build Test:** `goreleaser build --snapshot --clean` completed successfully
+3. **Local Release Test:** `goreleaser release --snapshot --clean` completed successfully
+4. **New Tag Created:** v0.5.2 with the fix
+
+## Files Modified
+- `.goreleaser.yml` - Updated deprecated archives.format field
+- `go.mod` - Updated dependencies (from go mod tidy hook)
+
+## Reference
+- [GoReleaser v2.6 Deprecation Notice](https://goreleaser.com/deprecations#archivesformat)
+- [GoReleaser Archives Documentation](https://goreleaser.com/customization/archive/)
+
+## Date
+January 27, 2025
+
+## Status
+✅ **RESOLVED** - GoReleaser configuration updated for v2 compatibility

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
+	go.uber.org/mock v0.5.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -32,7 +33,6 @@ require (
 	github.com/spf13/pflag v1.0.7 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	go.uber.org/mock v0.5.2 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect


### PR DESCRIPTION
## Problem
The GitHub Actions Release workflow was failing due to deprecated GoReleaser configuration fields.

## Root Cause
- The `archives.format` field is deprecated in GoReleaser v2.6+
- Should be replaced with `archives.formats` (plural) which accepts an array

## Changes
- Updated `.goreleaser.yml` to use `formats: [tar.gz]` instead of `format: tar.gz`
- Updated `go.mod` dependencies (from `go mod tidy` hook)
- Added documentation of the fix in `GORELEASER_FIX.md`

## Verification
- ✅ `goreleaser check` passes without warnings
- ✅ `goreleaser build --snapshot --clean` completes successfully
- ✅ `goreleaser release --snapshot --clean` completes successfully

## References
- [GoReleaser v2.6 Deprecation Notice](https://goreleaser.com/deprecations#archivesformat)
- [GoReleaser Archives Documentation](https://goreleaser.com/customization/archive/)

Fixes the release workflow failure described in the conversation context.