### PR TITLE
fix: database SSL mode and column name mismatches

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -473,7 +473,7 @@ func getDatabaseConfigFromEnv() db.Config {
 		Database:        getEnvString("SCANORAMA_DB_NAME", ""),
 		Username:        getEnvString("SCANORAMA_DB_USER", ""),
 		Password:        getEnvString("SCANORAMA_DB_PASSWORD", ""),
-		SSLMode:         getEnvString("SCANORAMA_DB_SSLMODE", "prefer"),
+		SSLMode:         getEnvString("SCANORAMA_DB_SSLMODE", "disable"),
 		MaxOpenConns:    getEnvInt("SCANORAMA_DB_MAX_OPEN_CONNS", DefaultMaxOpenConns),
 		MaxIdleConns:    getEnvInt("SCANORAMA_DB_MAX_IDLE_CONNS", DefaultMaxIdleConns),
 		ConnMaxLifetime: getEnvDuration("SCANORAMA_DB_CONN_MAX_LIFETIME", DefaultConnMaxLifetime),

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -54,7 +54,7 @@ func DefaultConfig() Config {
 		Database:        "", // Must be configured
 		Username:        "", // Must be configured
 		Password:        "", // Must be configured
-		SSLMode:         "prefer",
+		SSLMode:         "disable",
 		MaxOpenConns:    defaultMaxOpenConns,
 		MaxIdleConns:    defaultMaxIdleConns,
 		ConnMaxLifetime: defaultConnMaxLifetime * time.Minute,


### PR DESCRIPTION
- Change default SSL mode from 'prefer' to 'disable'
- Fix scan_target_id -> target_id in hosts query
- Fix is_ignored -> ignore_scanning column references