### PR TITLE
fix: correct CI workflow reference in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   # Run CI pipeline to ensure quality
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: ./.github/workflows/main.yml
 
   release:
     name: Release


### PR DESCRIPTION
The release workflow was referencing  which doesn't exist. The actual CI workflow file is . This fix allows the release workflow to run properly when tags are pushed.