### PR TITLE
fix: add workflow_call trigger to main.yml for release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  workflow_call:
 
 env:
   GO_VERSION: "1.24.6"


### PR DESCRIPTION
The release workflow calls main.yml as a reusable workflow, but main.yml was missing the workflow_call trigger. This prevents the release workflow from executing properly when tags are pushed.