### PR TITLE
fix: correct PostgreSQL health check database name in e2e-tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,7 +241,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U postgres -d scanorama_test"
+          --health-cmd "pg_isready -U postgres -d postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5


### PR DESCRIPTION
## Problem

The release workflow was failing with `startup_failure` immediately after tag push. Investigation revealed the issue was in the e2e-tests job where the PostgreSQL service health check was misconfigured.

## Root Cause

The PostgreSQL service was configured with:
- **Database created:** `postgres` (default) 
- **Health check:** trying to connect to `scanorama_test` database

This mismatch caused the health check to fail immediately, preventing workflows with `workflow_call` trigger from starting.

## Solution

Fixed the health check to use the default `postgres` database instead of `scanorama_test`, since the `scanorama_test` database is created later in the job steps.

## Testing

- ✅ Workflow syntax validated with act
- ✅ Pre-commit checks pass
- ✅ Ready for release workflow testing after merge

Fixes the release workflow where no jobs were being created due to startup failure.