### PR TITLE
fix: add missing permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,12 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+  security-events: write
+
 jobs:
   # Run CI pipeline to ensure quality
   ci:


### PR DESCRIPTION
Fixes the release workflow permissions error that prevents releases from working.

## Problem
The release workflow was failing with:


## Root Cause
The release workflow calls  via , but  requires write permissions that weren't declared in the release workflow.

## Solution
Added the missing permissions block to  to match the permissions required by :
- 
-  
- 
- 

This is a critical fix needed before any releases can be created.