### PR TITLE
fix(ci): upload integration test coverage to codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,14 +82,8 @@ jobs:
           go test -short -race -coverprofile=coverage.out -covermode=atomic ./...
           go tool cover -func=coverage.out | tail -1
 
-      - name: Upload coverage reports
-        uses: codecov/codecov-action@v5
-        continue-on-error: true
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.out
-          flags: unittests
-          name: codecov-umbrella
+      # Note: Unit test coverage not uploaded to avoid partial coverage reports.
+      # Integration tests run all tests (including unit tests) and upload complete coverage.
 
   # Stage 3: Integration Tests (requires database and services)
   integration-tests:
@@ -221,14 +215,13 @@ jobs:
           go test -v -p 1 -coverprofile=integration_coverage.out -covermode=atomic ./...
           go tool cover -func=integration_coverage.out | tail -1
 
-      - name: Upload integration coverage
+      - name: Upload complete coverage to Codecov
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./integration_coverage.out
-          flags: integration
-          name: codecov-integration
+          name: codecov-umbrella
 
       - name: Run database migration tests
         run: |


### PR DESCRIPTION
## Problem

Unit tests run with `-short` flag and skip database/integration tests, resulting in incomplete coverage reports (~31%). This was causing codecov to show lower coverage than actual.

## Solution

Integration tests run all tests (including unit tests) without `-short` flag and provide complete coverage (~77%). 

This PR removes the duplicate coverage upload from the unit test stage and uploads only the integration test coverage as the primary report, since it includes all test execution paths.

## Changes

- Remove codecov upload step from unit-tests job
- Update integration-tests job to upload coverage as primary report (codecov-umbrella)
- Add explanatory comment about why unit test coverage is not uploaded separately

## Impact

- Codecov will now reflect actual test coverage including database and integration tests
- Coverage percentage should increase from ~31% to ~77%
- No changes to test execution - tests still run in same stages for fast feedback