### PR TITLE
chore(deps): update debug to v4.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1104,9 +1104,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Updates the `debug` dependency from v4.4.1 to v4.4.3 in package-lock.json.

This is a **lockfile-only update** for an indirect dependency that was pending in the Renovate Dependency Dashboard.

## Changes

- **Updated:** debug 4.4.1 → 4.4.3
- **Type:** Patch version (bug fixes)
- **Scope:** Indirect dependency (devDependency override)
- **Audit:** ✅ 0 vulnerabilities

## NPM Update Output

```
added 2 packages, removed 28 packages, changed 7 packages
found 0 vulnerabilities
```

## Related

- Resolves pending update from Renovate Dependency Dashboard (Issue #5)
- This was manually triggered as it was marked as pending for manual approval

## Testing

- [x] No vulnerabilities reported by `npm audit`
- [x] Lockfile successfully updated
- [ ] CI checks pending