### PR TITLE
fix(test): skip sanitizeDBError strings in SQL extraction

### DIFF
--- a/internal/db/migration_test.go
+++ b/internal/db/migration_test.go
@@ -750,6 +750,11 @@ func ExtractSQLQueries() ([]SQLQuery, error) {
 					continue
 				}
 
+				// Skip strings passed to sanitizeDBError() - these are operation descriptions, not SQL
+				if strings.Contains(fileContent, fmt.Sprintf(`sanitizeDBError(%q`, sql)) {
+					continue
+				}
+
 				// Clean up the SQL
 				sql = cleanSQL(sql)
 


### PR DESCRIPTION
## Summary

Fixes test failures introduced by PR #217 where the SQL query extraction logic incorrectly identified operation description strings as SQL queries.

## Problem

After merging PR #217, the migration tests began failing because the SQL query extraction regex was picking up strings passed to `sanitizeDBError()` as if they were actual SQL queries:

- `"update scan job status"` (from `sanitizeDBError("update scan job status", err)`)
- `"delete scan target"` (from `sanitizeDBError("delete scan target", err)`)

These strings contain SQL keywords (UPDATE, DELETE) so they passed the `containsSQLKeywords()` check, but they're not actual queries—they're error message descriptions.

## Solution

Added a filter in `ExtractSQLQueries()` to skip any string that appears in a `sanitizeDBError()` call:

```go
// Skip strings passed to sanitizeDBError() - these are operation descriptions, not SQL
if strings.Contains(fileContent, fmt.Sprintf(`sanitizeDBError(%q`, sql)) {
    continue
}
```

## Testing

- ✅ All tests now pass
- ✅ Linting passed (fixed gocritic warning about using %q)
- ✅ No regressions introduced

## Related

- Addresses test failures caused by PR #217
- Related to issue #215 (Codex review - Priority 2 implementation)