### PR TITLE
fix: resolve flaky websocket test causing CI failures

### DIFF
--- a/internal/api/handlers/websocket_test.go
+++ b/internal/api/handlers/websocket_test.go
@@ -957,8 +957,11 @@ func TestWebSocketHandler_CloseWithActiveConnections(t *testing.T) {
 		conns[i] = conn
 	}
 
-	// Give time for registration
-	time.Sleep(200 * time.Millisecond)
+	// Wait for all clients to be registered with proper synchronization
+	require.Eventually(t, func() bool {
+		clients := handler.GetConnectedClients()
+		return clients["scan"] == 3
+	}, 2*time.Second, 50*time.Millisecond, "should have 3 scan clients")
 
 	// Verify clients are registered
 	clients := handler.GetConnectedClients()


### PR DESCRIPTION
## Problem
The main CI pipeline has been failing due to a flaky test `TestWebSocketHandler_CloseWithActiveConnections` in the WebSocket handler tests.

## Root Cause
The test was using a fixed `time.Sleep(200ms)` to wait for WebSocket clients to register. In CI environments, this timeout is sometimes insufficient, causing the test to fail with:
```
Error: Condition never satisfied
Messages: should have 3 scan clients
```

## Solution
- Replace fixed sleep with `require.Eventually` for proper polling
- Wait up to 2 seconds for clients to register (with 50ms polling interval)
- Prevents race condition failures in CI environments

## Testing
- Tested locally with multiple runs
- Should resolve the intermittent CI failures on main branch

Fixes the failing integration tests in the main pipeline.

Cherry-picked from renovate branch: 062d76f4