### PR TITLE
fix(scheduler): preallocate networkConditions slice

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -566,7 +566,7 @@ func (s *Scheduler) addHostScanFilters(
 
 	// Filter by networks if specified
 	if len(config.Networks) > 0 {
-		networkConditions := []string{}
+		networkConditions := make([]string, 0, len(config.Networks))
 		for _, network := range config.Networks {
 			argCount++
 			networkConditions = append(networkConditions, fmt.Sprintf("ip_address << $%d", argCount))


### PR DESCRIPTION
Fix linter warning by preallocating slice capacity.

## Issue

Linter warning: Consider preallocating networkConditions with capacity len(config.Networks)

## Changes

- Preallocate networkConditions slice with known capacity
- Avoids reallocation during append operations

## Impact

- Fixes linter warning
- Minor performance improvement for network filtering