### PR TITLE
ci: update Go version to 1.25.6 in all workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.25.5"
+  GO_VERSION: "1.25.6"
   NODE_VERSION: "22"
 
 permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: "1.25.5"
+  GO_VERSION: "1.25.6"
   NODE_VERSION: "22"
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 env:
-  GO_VERSION: "1.25.5"
+  GO_VERSION: "1.25.6"
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.25.5"
+  GO_VERSION: "1.25.6"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

PR #308 (Renovate Go version update) is failing with:
```
go: go.mod requires go >= 1.25.6 (running go 1.25.5; GOTOOLCHAIN=local)
```

**Root cause:** Renovate updated `go.mod` to require Go 1.25.6, but all GitHub Actions workflows still have `GO_VERSION: "1.25.5"` hardcoded.

## Solution

Update `GO_VERSION` to `1.25.6` in all workflow files:
- ✅ `.github/workflows/main.yml` (CI)
- ✅ `.github/workflows/security.yml`
- ✅ `.github/workflows/docs.yml`
- ✅ `.github/workflows/release.yml`

## Impact

After merging this PR:
- PR #308 (Go 1.25.6 upgrade) will pass CI
- All future PRs will use Go 1.25.6
- Fixes security vulnerabilities in Go standard library (GO-2026-4341, GO-2026-4340)

## Testing

- ✅ Linter passes
- ⏳ Will trigger CI on all workflows to verify Go 1.25.6 works

## Related

- Fixes CI failures in PR #308
- Addresses Go standard library security vulnerabilities mentioned in security pipeline