### PR TITLE
Revert uax29 v2.5.0 upgrade - fixes Go compilation errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/displaywidth v0.6.2 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
-	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
+	github.com/clipperhouse/uax29/v2 v2.4.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/clipperhouse/displaywidth v0.6.2 h1:ZDpTkFfpHOKte4RG5O/BOyf3ysnvFswpy
 github.com/clipperhouse/displaywidth v0.6.2/go.mod h1:R+kHuzaYWFkTm7xoMmK1lFydbci4X2CicfbGstSGg0o=
 github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=
 github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
-github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w94cO8U=
-github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
+github.com/clipperhouse/uax29/v2 v2.4.0 h1:RXqE/l5EiAbA4u97giimKNlmpvkmz+GrBVTelsoXy9g=
+github.com/clipperhouse/uax29/v2 v2.4.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Problem

The upgrade to `github.com/clipperhouse/uax29/v2@v2.5.0` introduced a breaking change that causes compilation errors across the codebase:

```
cannot use graphemes.FromString(s) (value of type *graphemes.Iterator[string]) 
as graphemes.Iterator[string] value in struct literal
```

This is affecting:
- ❌ Code Quality checks (golangci-lint)
- ❌ Vulnerability Scan (govulncheck)
- ❌ All builds on main branch

## Root Cause

The `uax29@v2.5.0` changed the return type of `graphemes.FromString()` and `graphemes.FromBytes()` from `Iterator[T]` to `*Iterator[T]` (pointer), breaking compatibility with downstream dependency `github.com/clipperhouse/displaywidth@v0.6.2`.

The error originates from a transitive dependency chain:
```
scanorama
  └── github.com/olekukonko/tablewriter@v1.1.3
      └── github.com/clipperhouse/displaywidth@v0.6.2
          └── github.com/clipperhouse/uax29/v2@v2.5.0 ❌
```

## Solution

Revert to `uax29@v2.4.0` which is compatible with `displaywidth@v0.6.2`.

## Verification

```bash
$ go mod tidy
$ go build ./...
# Success! ✅
```

## Impact

- ✅ Fixes all CI/CD pipeline failures
- ✅ Unblocks all open PRs
- ⚠️ Temporary measure until `displaywidth` updates to support `uax29@v2.5.0`

## Reverted Commit

Reverts #db2e0fe0dad7e19400300f798d90c226fe56bedf
- Original PR: deps(deps): bump github.com/clipperhouse/uax29/v2 from 2.4.0 to 2.5.0

## Next Steps

Once `github.com/clipperhouse/displaywidth` releases a version compatible with `uax29@v2.5.0`, we can re-apply this upgrade.