### PR TITLE
ci: bump Go to 1.26.0 in all pipelines

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.25.7"
+  GO_VERSION: "1.26.0"
   NODE_VERSION: "22"
 
 permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: "1.25.7"
+  GO_VERSION: "1.26.0"
   NODE_VERSION: "22"
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 env:
-  GO_VERSION: "1.25.7"
+  GO_VERSION: "1.26.0"
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.25.7"
+  GO_VERSION: "1.26.0"
 
 permissions:
   contents: read


### PR DESCRIPTION
Bumps the `GO_VERSION` from `1.25.7` to `1.26.0` across all CI pipelines (`main.yml`, `release.yml`, `docs.yml`, `security.yml`) in preparation for upgrading the codebase itself to Go 1.26.