### PR TITLE
ci: opt integration-tests job into Node.js 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,6 +168,11 @@ jobs:
       TEST_DB_USER: scanorama_test_user
       TEST_DB_PASSWORD: test_password_123
       CI: true
+      # Opt into Node.js 24 for all JavaScript actions in this job.
+      # codecov-action@v5 vendors github-script@v7.0.1 (Node.js 20), which is
+      # deprecated and will break after June 2 2026. This env var silences the
+      # warning and future-proofs the job until codecov ships an updated bundle.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem

`codecov/codecov-action@v5` vendors `actions/github-script@v7.0.1`, which is compiled for Node.js 20. GitHub will switch runners to Node.js 24 by default from June 2 2026.

## What this PR does

Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` on the `integration-tests` job so the action actually *executes* on Node.js 24 now rather than 20. This prevents a runtime breakage after the June deadline.

## Why the annotation still appears

GitHub generates the `Node.js 20 actions are deprecated` annotation during the pre-scan phase by reading the action's `action.yml` metadata (`using: node20`). The annotation is emitted before the runtime env var takes effect, so it persists even when `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` is set. The only way to eliminate it entirely is for `codecov-action` to ship a bundle that uses `actions/github-script@v8` (`using: node24`). As of today no such release exists.

**Runtime status:** ✅ Executes on Node.js 24 (env var applied)
**Annotation status:** ⚠️ Still shown by runner pre-scan (upstream fix required in codecov-action)