### PR TITLE
feat: run scan modal, scans/hosts pages, dashboard interactivity

### DIFF
--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -1,10 +1,12 @@
 export { useHealth, useStatus, useVersion } from "./use-system";
 export { useHosts, useHost, useActiveHostCount } from "./use-hosts";
 export { useNetworks, useNetworkStats } from "./use-networks";
+export { useProfile, useProfiles } from "./use-profiles";
 export {
   useScans,
   useScan,
   useCreateScan,
+  useStartScan,
   useRecentScans,
   useScanResults,
 } from "./use-scans";

--- a/frontend/src/api/hooks/use-profiles.ts
+++ b/frontend/src/api/hooks/use-profiles.ts
@@ -1,0 +1,29 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../client";
+
+export function useProfile(id: string | undefined) {
+  return useQuery({
+    queryKey: ["profiles", id],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/profiles/{profileId}", {
+        params: { path: { profileId: id! } },
+      });
+      if (error) throw error;
+      return data;
+    },
+    enabled: !!id,
+  });
+}
+
+export function useProfiles(params: { page?: number; page_size?: number } = {}) {
+  return useQuery({
+    queryKey: ["profiles", params],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/profiles", {
+        params: { query: params },
+      });
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/hooks/use-scans.ts
+++ b/frontend/src/api/hooks/use-scans.ts
@@ -50,6 +50,13 @@ export function useScans(params: ScanListParams = {}) {
       if (error) throw error;
       return data;
     },
+    refetchInterval: (query) => {
+      const scans = query.state.data?.data ?? [];
+      const hasActive = scans.some(
+        (s) => s.status === "pending" || s.status === "running",
+      );
+      return hasActive ? 3_000 : false;
+    },
   });
 }
 
@@ -67,17 +74,41 @@ export function useScan(id: string) {
   });
 }
 
+export function useStartScan() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (scanId: string) => {
+      const { data, error } = await api.POST("/scans/{scanId}/start", {
+        params: { path: { scanId } },
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["scans"] });
+    },
+  });
+}
+
 export function useCreateScan() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (body: {
-      name?: string;
-      targets?: string[];
-      profile_id?: string;
+      name: string;
+      targets: string[];
+      scan_type: string;
+      ports?: string;
+      os_detection?: boolean;
       description?: string;
     }) => {
       const { data, error } = await api.POST("/scans", { body });
-      if (error) throw error;
+      if (error) {
+        throw new Error(
+          typeof (error as { message?: string }).message === "string"
+            ? (error as { message: string }).message
+            : "Scan creation failed.",
+        );
+      }
       return data;
     },
     onSuccess: () => {
@@ -89,6 +120,7 @@ export function useCreateScan() {
 export function useScanResults(
   scanId: string,
   params: { page?: number; page_size?: number } = {},
+  scanStatus?: string,
 ) {
   return useQuery({
     queryKey: ["scans", scanId, "results", params],
@@ -100,6 +132,8 @@ export function useScanResults(
       return data as ScanResultsData | undefined;
     },
     enabled: !!scanId,
+    refetchInterval:
+      scanStatus === "pending" || scanStatus === "running" ? 3_000 : false,
   });
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -4,4143 +4,4158 @@
  */
 
 export interface paths {
-    "/admin/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Admin status
-         * @description Returns administrative status information
-         */
-        get: operations["getAdminStatus"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+  "/admin/status": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/discovery": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List discovery jobs
-         * @description Get paginated list of discovery jobs
-         */
-        get: operations["listDiscoveryJobs"];
-        put?: never;
-        /**
-         * Create discovery job
-         * @description Create a new network discovery job
-         */
-        post: operations["createDiscoveryJob"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Admin status
+     * @description Returns administrative status information
+     */
+    get: operations["getAdminStatus"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/discovery": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/discovery/{discoveryId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get discovery job
-         * @description Get discovery job details by ID
-         */
-        get: operations["getDiscoveryJob"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * List discovery jobs
+     * @description Get paginated list of discovery jobs
+     */
+    get: operations["listDiscoveryJobs"];
+    put?: never;
+    /**
+     * Create discovery job
+     * @description Create a new network discovery job
+     */
+    post: operations["createDiscoveryJob"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/discovery/{discoveryId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/discovery/{discoveryId}/start": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Start discovery
-         * @description Start a discovery job
-         */
-        post: operations["startDiscovery"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get discovery job
+     * @description Get discovery job details by ID
+     */
+    get: operations["getDiscoveryJob"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/discovery/{discoveryId}/start": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/discovery/{discoveryId}/stop": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Stop discovery
-         * @description Stop a running discovery job
-         */
-        post: operations["stopDiscovery"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Start discovery
+     * @description Start a discovery job
+     */
+    post: operations["startDiscovery"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/discovery/{discoveryId}/stop": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/exclusions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List global exclusions
-         * @description Get all global exclusion rules not tied to a specific network
-         */
-        get: operations["listGlobalExclusions"];
-        put?: never;
-        /**
-         * Create global exclusion
-         * @description Create a global exclusion rule that applies to all networks
-         */
-        post: operations["createGlobalExclusion"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Stop discovery
+     * @description Stop a running discovery job
+     */
+    post: operations["stopDiscovery"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/exclusions": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/exclusions/{exclusionId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Delete exclusion
-         * @description Delete an exclusion rule by ID
-         */
-        delete: operations["deleteExclusion"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * List global exclusions
+     * @description Get all global exclusion rules not tied to a specific network
+     */
+    get: operations["listGlobalExclusions"];
+    put?: never;
+    /**
+     * Create global exclusion
+     * @description Create a global exclusion rule that applies to all networks
+     */
+    post: operations["createGlobalExclusion"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/exclusions/{exclusionId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Health check
-         * @description Returns service health status including database connectivity
-         */
-        get: operations["getHealth"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * Delete exclusion
+     * @description Delete an exclusion rule by ID
+     */
+    delete: operations["deleteExclusion"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/health": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/hosts": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List hosts
-         * @description Get paginated list of discovered hosts with optional filtering
-         */
-        get: operations["listHosts"];
-        put?: never;
-        /**
-         * Create host
-         * @description Manually add a host to the inventory
-         */
-        post: operations["createHost"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Health check
+     * @description Returns service health status including database connectivity
+     */
+    get: operations["getHealth"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/hosts": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/hosts/{hostId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get host
-         * @description Get host details by ID
-         */
-        get: operations["getHost"];
-        /**
-         * Update host
-         * @description Update host information
-         */
-        put: operations["updateHost"];
-        post?: never;
-        /**
-         * Delete host
-         * @description Remove host from inventory
-         */
-        delete: operations["deleteHost"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * List hosts
+     * @description Get paginated list of discovered hosts with optional filtering
+     */
+    get: operations["listHosts"];
+    put?: never;
+    /**
+     * Create host
+     * @description Manually add a host to the inventory
+     */
+    post: operations["createHost"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/hosts/{hostId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/hosts/{hostId}/scans": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get host scans
-         * @description Get scans associated with a specific host
-         */
-        get: operations["getHostScans"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get host
+     * @description Get host details by ID
+     */
+    get: operations["getHost"];
+    /**
+     * Update host
+     * @description Update host information
+     */
+    put: operations["updateHost"];
+    post?: never;
+    /**
+     * Delete host
+     * @description Remove host from inventory
+     */
+    delete: operations["deleteHost"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/hosts/{hostId}/scans": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/liveness": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Liveness check
-         * @description Returns simple liveness status without dependency checks
-         */
-        get: operations["getLiveness"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get host scans
+     * @description Get scans associated with a specific host
+     */
+    get: operations["getHostScans"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/liveness": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/metrics": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Application metrics
-         * @description Returns Prometheus metrics for monitoring
-         */
-        get: operations["getMetrics"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Liveness check
+     * @description Returns simple liveness status without dependency checks
+     */
+    get: operations["getLiveness"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/metrics": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/networks": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List networks
-         * @description Get paginated list of networks with optional filtering
-         */
-        get: operations["listNetworks"];
-        put?: never;
-        /**
-         * Create network
-         * @description Create a new network for scanning and discovery
-         */
-        post: operations["createNetwork"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Application metrics
+     * @description Returns Prometheus metrics for monitoring
+     */
+    get: operations["getMetrics"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/networks": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/networks/{networkId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get network
-         * @description Get network details by ID
-         */
-        get: operations["getNetwork"];
-        /**
-         * Update network
-         * @description Update network configuration
-         */
-        put: operations["updateNetwork"];
-        post?: never;
-        /**
-         * Delete network
-         * @description Delete a network and its associated exclusions
-         */
-        delete: operations["deleteNetwork"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * List networks
+     * @description Get paginated list of networks with optional filtering
+     */
+    get: operations["listNetworks"];
+    put?: never;
+    /**
+     * Create network
+     * @description Create a new network for scanning and discovery
+     */
+    post: operations["createNetwork"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/networks/{networkId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/networks/{networkId}/disable": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Disable network
-         * @description Disable a network from scanning and discovery
-         */
-        post: operations["disableNetwork"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get network
+     * @description Get network details by ID
+     */
+    get: operations["getNetwork"];
+    /**
+     * Update network
+     * @description Update network configuration
+     */
+    put: operations["updateNetwork"];
+    post?: never;
+    /**
+     * Delete network
+     * @description Delete a network and its associated exclusions
+     */
+    delete: operations["deleteNetwork"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/networks/{networkId}/disable": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/networks/{networkId}/enable": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Enable network
-         * @description Enable a network for scanning and discovery
-         */
-        post: operations["enableNetwork"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Disable network
+     * @description Disable a network from scanning and discovery
+     */
+    post: operations["disableNetwork"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/networks/{networkId}/enable": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/networks/{networkId}/exclusions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List network exclusions
-         * @description Get exclusion rules for a specific network
-         */
-        get: operations["listNetworkExclusions"];
-        put?: never;
-        /**
-         * Create network exclusion
-         * @description Add an exclusion rule to a specific network
-         */
-        post: operations["createNetworkExclusion"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Enable network
+     * @description Enable a network for scanning and discovery
+     */
+    post: operations["enableNetwork"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/networks/{networkId}/exclusions": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/networks/{networkId}/rename": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        /**
-         * Rename network
-         * @description Rename an existing network
-         */
-        put: operations["renameNetwork"];
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * List network exclusions
+     * @description Get exclusion rules for a specific network
+     */
+    get: operations["listNetworkExclusions"];
+    put?: never;
+    /**
+     * Create network exclusion
+     * @description Add an exclusion rule to a specific network
+     */
+    post: operations["createNetworkExclusion"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/networks/{networkId}/rename": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/networks/stats": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get network statistics
-         * @description Returns aggregate statistics about networks, hosts, and exclusions
-         */
-        get: operations["getNetworkStats"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    /**
+     * Rename network
+     * @description Rename an existing network
+     */
+    put: operations["renameNetwork"];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/networks/stats": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/profiles": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List profiles
-         * @description Get paginated list of scan profiles
-         */
-        get: operations["listProfiles"];
-        put?: never;
-        /**
-         * Create profile
-         * @description Create a new scan profile
-         */
-        post: operations["createProfile"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get network statistics
+     * @description Returns aggregate statistics about networks, hosts, and exclusions
+     */
+    get: operations["getNetworkStats"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/profiles": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/profiles/{profileId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get profile
-         * @description Get scan profile details by ID
-         */
-        get: operations["getProfile"];
-        /**
-         * Update profile
-         * @description Update scan profile configuration
-         */
-        put: operations["updateProfile"];
-        post?: never;
-        /**
-         * Delete profile
-         * @description Delete scan profile
-         */
-        delete: operations["deleteProfile"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * List profiles
+     * @description Get paginated list of scan profiles
+     */
+    get: operations["listProfiles"];
+    put?: never;
+    /**
+     * Create profile
+     * @description Create a new scan profile
+     */
+    post: operations["createProfile"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/profiles/{profileId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/scans": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List scans
-         * @description Get paginated list of scans with optional filtering
-         */
-        get: operations["listScans"];
-        put?: never;
-        /**
-         * Create scan
-         * @description Create a new network scan job
-         */
-        post: operations["createScan"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get profile
+     * @description Get scan profile details by ID
+     */
+    get: operations["getProfile"];
+    /**
+     * Update profile
+     * @description Update scan profile configuration
+     */
+    put: operations["updateProfile"];
+    post?: never;
+    /**
+     * Delete profile
+     * @description Delete scan profile
+     */
+    delete: operations["deleteProfile"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/scans": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/scans/{scanId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get scan
-         * @description Get scan details by ID
-         */
-        get: operations["getScan"];
-        /**
-         * Update scan
-         * @description Update an existing scan configuration
-         */
-        put: operations["updateScan"];
-        post?: never;
-        /**
-         * Delete scan
-         * @description Cancel running scan or delete completed scan
-         */
-        delete: operations["deleteScan"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * List scans
+     * @description Get paginated list of scans with optional filtering
+     */
+    get: operations["listScans"];
+    put?: never;
+    /**
+     * Create scan
+     * @description Create a new network scan job
+     */
+    post: operations["createScan"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/scans/{scanId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/scans/{scanId}/results": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get scan results
-         * @description Get detailed results from a completed scan
-         */
-        get: operations["getScanResults"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get scan
+     * @description Get scan details by ID
+     */
+    get: operations["getScan"];
+    /**
+     * Update scan
+     * @description Update an existing scan configuration
+     */
+    put: operations["updateScan"];
+    post?: never;
+    /**
+     * Delete scan
+     * @description Cancel running scan or delete completed scan
+     */
+    delete: operations["deleteScan"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/scans/{scanId}/results": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/scans/{scanId}/start": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Start scan
-         * @description Start a pending scan
-         */
-        post: operations["startScan"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get scan results
+     * @description Get detailed results from a completed scan
+     */
+    get: operations["getScanResults"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/scans/{scanId}/start": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/scans/{scanId}/stop": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Stop scan
-         * @description Stop a running scan
-         */
-        post: operations["stopScan"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Start scan
+     * @description Start a pending scan
+     */
+    post: operations["startScan"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/scans/{scanId}/stop": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/schedules": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List schedules
-         * @description Get paginated list of scheduled scans
-         */
-        get: operations["listSchedules"];
-        put?: never;
-        /**
-         * Create schedule
-         * @description Create a new scheduled scan
-         */
-        post: operations["createSchedule"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Stop scan
+     * @description Stop a running scan
+     */
+    post: operations["stopScan"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/schedules": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/schedules/{scheduleId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get schedule
-         * @description Get schedule details by ID
-         */
-        get: operations["getSchedule"];
-        /**
-         * Update schedule
-         * @description Update schedule configuration
-         */
-        put: operations["updateSchedule"];
-        post?: never;
-        /**
-         * Delete schedule
-         * @description Delete scheduled scan
-         */
-        delete: operations["deleteSchedule"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * List schedules
+     * @description Get paginated list of scheduled scans
+     */
+    get: operations["listSchedules"];
+    put?: never;
+    /**
+     * Create schedule
+     * @description Create a new scheduled scan
+     */
+    post: operations["createSchedule"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/schedules/{scheduleId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/schedules/{scheduleId}/disable": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Disable schedule
-         * @description Disable a scheduled scan
-         */
-        post: operations["disableSchedule"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get schedule
+     * @description Get schedule details by ID
+     */
+    get: operations["getSchedule"];
+    /**
+     * Update schedule
+     * @description Update schedule configuration
+     */
+    put: operations["updateSchedule"];
+    post?: never;
+    /**
+     * Delete schedule
+     * @description Delete scheduled scan
+     */
+    delete: operations["deleteSchedule"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/schedules/{scheduleId}/disable": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/schedules/{scheduleId}/enable": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Enable schedule
-         * @description Enable a scheduled scan
-         */
-        post: operations["enableSchedule"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Disable schedule
+     * @description Disable a scheduled scan
+     */
+    post: operations["disableSchedule"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/schedules/{scheduleId}/enable": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * System status
-         * @description Returns detailed system status information
-         */
-        get: operations["getStatus"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Enable schedule
+     * @description Enable a scheduled scan
+     */
+    post: operations["enableSchedule"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/status": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/version": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Version information
-         * @description Returns version and build information
-         */
-        get: operations["getVersion"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * System status
+     * @description Returns detailed system status information
+     */
+    get: operations["getStatus"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/version": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
+    /**
+     * Version information
+     * @description Returns version and build information
+     */
+    get: operations["getVersion"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        "docs.AdminStatusResponse": {
-            /** @example active */
-            admin_status?: string;
-            server_info?: {
-                [key: string]: unknown;
-            };
-            timestamp?: string;
-        };
-        "docs.CreateDiscoveryJobRequest": {
-            /**
-             * @example tcp
-             * @enum {string}
-             */
-            method?: "tcp" | "icmp" | "arp";
-            /** @example Office Network Discovery */
-            name?: string;
-            /** @example 192.168.1.0/24 */
-            network?: string;
-        };
-        "docs.CreateExclusionRequest": {
-            /** @example 192.168.1.128/25 */
-            excluded_cidr?: string;
-            /** @example Reserved for printers */
-            reason?: string;
-        };
-        "docs.CreateNetworkRequest": {
-            /** @example 192.168.1.0/24 */
-            cidr?: string;
-            /** @example Main office network */
-            description?: string;
-            /**
-             * @example ping
-             * @enum {string}
-             */
-            discovery_method?: "ping" | "tcp" | "arp";
-            /** @example true */
-            is_active?: boolean;
-            /** @example Office Network */
-            name?: string;
-            /** @example true */
-            scan_enabled?: boolean;
-        };
-        "docs.CreateProfileRequest": {
-            /** @example Custom scan configuration */
-            description?: string;
-            /** @example Custom Scan Profile */
-            name?: string;
-            options?: {
-                [key: string]: unknown;
-            };
-            /** @example 22,80,443,8080 */
-            ports?: string;
-            /** @example connect */
-            scan_type?: string;
-        };
-        "docs.CreateScanRequest": {
-            /** @example Regular security assessment */
-            description?: string;
-            /** @example Weekly security scan */
-            name?: string;
-            /** @example 550e8400-e29b-41d4-a716-446655440001 */
-            profile_id?: string;
-            scan_options?: {
-                [key: string]: unknown;
-            };
-            /**
-             * @example [
-             *       "192.168.1.0/24"
-             *     ]
-             */
-            targets?: string[];
-        };
-        "docs.CreateScheduleRequest": {
-            /** @example 0 2 * * * */
-            cron_expression?: string;
-            /** @example true */
-            enabled?: boolean;
-            /** @example Daily Security Scan */
-            name?: string;
-            /** @example 550e8400-e29b-41d4-a716-446655440001 */
-            profile_id?: string;
-            /**
-             * @example [
-             *       "192.168.1.0/24"
-             *     ]
-             */
-            targets?: string[];
-        };
-        "docs.DiscoveryJobResponse": {
-            created_at?: string;
-            /** @example 550e8400-e29b-41d4-a716-446655440004 */
-            id?: string;
-            /**
-             * @example tcp
-             * @enum {string}
-             */
-            method?: "tcp" | "icmp" | "arp";
-            /** @example Network Discovery */
-            name?: string;
-            /** @example 192.168.1.0/24 */
-            network?: string;
-            /** @example 45.5 */
-            progress?: number;
-            started_at?: string;
-            /**
-             * @example running
-             * @enum {string}
-             */
-            status?: "pending" | "running" | "completed" | "failed";
-        };
-        "docs.ErrorResponse": {
-            /** @example Invalid request */
-            error?: string;
-            /** @example req-123 */
-            request_id?: string;
-            timestamp?: string;
-        };
-        "docs.HealthResponse": {
-            checks?: {
-                [key: string]: string;
-            };
-            /** @example healthy */
-            status?: string;
-            timestamp?: string;
-            /** @example 2h30m45s */
-            uptime?: string;
-        };
-        "docs.HostResponse": {
-            first_seen?: string;
-            /** @example server01.local */
-            hostname?: string;
-            /** @example 550e8400-e29b-41d4-a716-446655440002 */
-            id?: string;
-            /** @example 192.168.1.100 */
-            ip_address?: string;
-            last_seen?: string;
-            /** @example 00:1B:44:11:3A:B7 */
-            mac_address?: string;
-            /**
-             * @example [
-             *       22,
-             *       80,
-             *       443
-             *     ]
-             */
-            open_ports?: number[];
-            /** @example 5 */
-            scan_count?: number;
-            /**
-             * @example up
-             * @enum {string}
-             */
-            status?: "up" | "down" | "unknown";
-        };
-        "docs.LivenessResponse": {
-            /** @example alive */
-            status?: string;
-            timestamp?: string;
-            /** @example 2h30m45s */
-            uptime?: string;
-        };
-        "docs.NetworkExclusionResponse": {
-            created_at?: string;
-            /** @example admin */
-            created_by?: string;
-            /** @example true */
-            enabled?: boolean;
-            /** @example 192.168.1.128/25 */
-            excluded_cidr?: string;
-            /** @example 550e8400-e29b-41d4-a716-446655440011 */
-            id?: string;
-            /** @example 550e8400-e29b-41d4-a716-446655440010 */
-            network_id?: string;
-            /** @example Reserved for printers */
-            reason?: string;
-            updated_at?: string;
-        };
-        "docs.NetworkResponse": {
-            /** @example 20 */
-            active_host_count?: number;
-            /** @example 192.168.1.0/24 */
-            cidr?: string;
-            created_at?: string;
-            /** @example admin */
-            created_by?: string;
-            /** @example Main office network */
-            description?: string;
-            /**
-             * @example ping
-             * @enum {string}
-             */
-            discovery_method?: "ping" | "tcp" | "arp";
-            /** @example 25 */
-            host_count?: number;
-            /** @example 550e8400-e29b-41d4-a716-446655440010 */
-            id?: string;
-            /** @example true */
-            is_active?: boolean;
-            last_discovery?: string;
-            last_scan?: string;
-            /** @example Office Network */
-            name?: string;
-            /** @example true */
-            scan_enabled?: boolean;
-            updated_at?: string;
-        };
-        "docs.NetworkStatsResponse": {
-            exclusions?: {
-                [key: string]: unknown;
-            };
-            hosts?: {
-                [key: string]: unknown;
-            };
-            networks?: {
-                [key: string]: unknown;
-            };
-        };
-        "docs.PaginatedDiscoveryJobsResponse": {
-            data?: components["schemas"]["docs.DiscoveryJobResponse"][];
-            pagination?: components["schemas"]["docs.PaginationInfo"];
-        };
-        "docs.PaginatedHostsResponse": {
-            data?: components["schemas"]["docs.HostResponse"][];
-            pagination?: components["schemas"]["docs.PaginationInfo"];
-        };
-        "docs.PaginatedNetworksResponse": {
-            data?: components["schemas"]["docs.NetworkResponse"][];
-            pagination?: components["schemas"]["docs.PaginationInfo"];
-        };
-        "docs.PaginatedProfilesResponse": {
-            data?: components["schemas"]["docs.ProfileResponse"][];
-            pagination?: components["schemas"]["docs.PaginationInfo"];
-        };
-        "docs.PaginatedScansResponse": {
-            data?: components["schemas"]["docs.ScanResponse"][];
-            pagination?: components["schemas"]["docs.PaginationInfo"];
-        };
-        "docs.PaginatedSchedulesResponse": {
-            data?: components["schemas"]["docs.ScheduleResponse"][];
-            pagination?: components["schemas"]["docs.PaginationInfo"];
-        };
-        "docs.PaginationInfo": {
-            /** @example 1 */
-            page?: number;
-            /** @example 20 */
-            page_size?: number;
-            /** @example 150 */
-            total_items?: number;
-            /** @example 8 */
-            total_pages?: number;
-        };
-        "docs.ProfileResponse": {
-            created_at?: string;
-            /** @example Fast TCP connect scan */
-            description?: string;
-            /** @example 550e8400-e29b-41d4-a716-446655440003 */
-            id?: string;
-            /** @example Quick Connect Scan */
-            name?: string;
-            options?: {
-                [key: string]: unknown;
-            };
-            /** @example 22,80,443 */
-            ports?: string;
-            /** @example connect */
-            scan_type?: string;
-            updated_at?: string;
-        };
-        "docs.RenameNetworkRequest": {
-            /** @example New Office Network */
-            new_name?: string;
-        };
-        "docs.ScanResponse": {
-            completed_at?: string;
-            created_at?: string;
-            /** @example 14m30s */
-            duration?: string;
-            error_message?: string;
-            /** @example 25 */
-            hosts_discovered?: number;
-            /** @example 550e8400-e29b-41d4-a716-446655440000 */
-            id?: string;
-            /** @example 2500 */
-            ports_scanned?: number;
-            /** @example 550e8400-e29b-41d4-a716-446655440001 */
-            profile_id?: string;
-            /** @example 65.5 */
-            progress?: number;
-            started_at?: string;
-            /**
-             * @example running
-             * @enum {string}
-             */
-            status?: "pending" | "running" | "completed" | "failed" | "cancelled";
-            /**
-             * @example [
-             *       "192.168.1.0/24"
-             *     ]
-             */
-            targets?: string[];
-        };
-        "docs.ScheduleResponse": {
-            created_at?: string;
-            /** @example 0 2 * * 1 */
-            cron_expression?: string;
-            /** @example true */
-            enabled?: boolean;
-            /** @example 550e8400-e29b-41d4-a716-446655440005 */
-            id?: string;
-            last_run?: string;
-            /** @example Weekly Security Scan */
-            name?: string;
-            next_run?: string;
-            /** @example 550e8400-e29b-41d4-a716-446655440001 */
-            profile_id?: string;
-            /**
-             * @example [
-             *       "192.168.1.0/24"
-             *     ]
-             */
-            targets?: string[];
-            updated_at?: string;
-        };
-        "docs.StatusResponse": {
-            /** @example scanorama-api */
-            service?: string;
-            timestamp?: string;
-            /** @example 2h30m45s */
-            uptime?: string;
-            /** @example 0.7.0 */
-            version?: string;
-        };
-        "docs.UpdateNetworkRequest": {
-            /** @example 192.168.1.0/24 */
-            cidr?: string;
-            /** @example Main office network */
-            description?: string;
-            /**
-             * @example ping
-             * @enum {string}
-             */
-            discovery_method?: "ping" | "tcp" | "arp";
-            /** @example true */
-            is_active?: boolean;
-            /** @example Office Network */
-            name?: string;
-            /** @example true */
-            scan_enabled?: boolean;
-        };
-        "docs.UpdateScanRequest": {
-            /** @example Updated description */
-            description?: string;
-            /** @example Updated scan name */
-            name?: string;
-            options?: {
-                [key: string]: string;
-            };
-            /** @example 22,80,443 */
-            ports?: string;
-            profile_id?: number;
-            /**
-             * @example connect
-             * @enum {string}
-             */
-            scan_type?: "connect" | "syn" | "ack" | "aggressive" | "comprehensive";
-            schedule_id?: number;
-            tags?: string[];
-            /**
-             * @example [
-             *       "192.168.1.0/24"
-             *     ]
-             */
-            targets?: string[];
-        };
-        "docs.VersionResponse": {
-            /** @example scanorama */
-            service?: string;
-            timestamp?: string;
-            /** @example 0.7.0 */
-            version?: string;
-        };
+  schemas: {
+    "docs.AdminStatusResponse": {
+      /** @example active */
+      admin_status?: string;
+      server_info?: {
+        [key: string]: unknown;
+      };
+      timestamp?: string;
     };
-    responses: never;
-    parameters: never;
-    requestBodies: {
-        /** @description Exclusion configuration */
-        "docs.CreateExclusionRequest": {
-            content: {
-                "application/json": components["schemas"]["docs.CreateExclusionRequest"];
-            };
-        };
+    "docs.CreateDiscoveryJobRequest": {
+      /**
+       * @example tcp
+       * @enum {string}
+       */
+      method?: "tcp" | "icmp" | "arp";
+      /** @example Office Network Discovery */
+      name?: string;
+      /** @example 192.168.1.0/24 */
+      network?: string;
     };
-    headers: never;
-    pathItems: never;
+    "docs.CreateExclusionRequest": {
+      /** @example 192.168.1.128/25 */
+      excluded_cidr?: string;
+      /** @example Reserved for printers */
+      reason?: string;
+    };
+    "docs.CreateNetworkRequest": {
+      /** @example 192.168.1.0/24 */
+      cidr?: string;
+      /** @example Main office network */
+      description?: string;
+      /**
+       * @example ping
+       * @enum {string}
+       */
+      discovery_method?: "ping" | "tcp" | "arp";
+      /** @example true */
+      is_active?: boolean;
+      /** @example Office Network */
+      name?: string;
+      /** @example true */
+      scan_enabled?: boolean;
+    };
+    "docs.CreateProfileRequest": {
+      /** @example Custom scan configuration */
+      description?: string;
+      /** @example Custom Scan Profile */
+      name?: string;
+      options?: {
+        [key: string]: unknown;
+      };
+      /** @example 22,80,443,8080 */
+      ports?: string;
+      /** @example connect */
+      scan_type?: string;
+    };
+    "docs.CreateScanRequest": {
+      /** @example Regular security assessment */
+      description?: string;
+      /** @example Weekly security scan */
+      name?: string;
+      /** @example 550e8400-e29b-41d4-a716-446655440001 */
+      profile_id?: string;
+      scan_options?: {
+        [key: string]: unknown;
+      };
+      /**
+       * @example [
+       *       "192.168.1.0/24"
+       *     ]
+       */
+      targets?: string[];
+    };
+    "docs.CreateScheduleRequest": {
+      /** @example 0 2 * * * */
+      cron_expression?: string;
+      /** @example true */
+      enabled?: boolean;
+      /** @example Daily Security Scan */
+      name?: string;
+      /** @example 550e8400-e29b-41d4-a716-446655440001 */
+      profile_id?: string;
+      /**
+       * @example [
+       *       "192.168.1.0/24"
+       *     ]
+       */
+      targets?: string[];
+    };
+    "docs.DiscoveryJobResponse": {
+      created_at?: string;
+      /** @example 550e8400-e29b-41d4-a716-446655440004 */
+      id?: string;
+      /**
+       * @example tcp
+       * @enum {string}
+       */
+      method?: "tcp" | "icmp" | "arp";
+      /** @example Network Discovery */
+      name?: string;
+      /** @example 192.168.1.0/24 */
+      network?: string;
+      /** @example 45.5 */
+      progress?: number;
+      started_at?: string;
+      /**
+       * @example running
+       * @enum {string}
+       */
+      status?: "pending" | "running" | "completed" | "failed";
+    };
+    "docs.ErrorResponse": {
+      /** @example Invalid request */
+      error?: string;
+      /** @example req-123 */
+      request_id?: string;
+      timestamp?: string;
+    };
+    "docs.HealthResponse": {
+      checks?: {
+        [key: string]: string;
+      };
+      /** @example healthy */
+      status?: string;
+      timestamp?: string;
+      /** @example 2h30m45s */
+      uptime?: string;
+    };
+    "docs.HostResponse": {
+      first_seen?: string;
+      /** @example server01.local */
+      hostname?: string;
+      /** @example 550e8400-e29b-41d4-a716-446655440002 */
+      id?: string;
+      /** @example 192.168.1.100 */
+      ip_address?: string;
+      last_seen?: string;
+      /** @example 00:1B:44:11:3A:B7 */
+      mac_address?: string;
+      /**
+       * @example [
+       *       22,
+       *       80,
+       *       443
+       *     ]
+       */
+      open_ports?: number[];
+      /** @example 5 */
+      scan_count?: number;
+      /**
+       * @example up
+       * @enum {string}
+       */
+      status?: "up" | "down" | "unknown";
+    };
+    "docs.LivenessResponse": {
+      /** @example alive */
+      status?: string;
+      timestamp?: string;
+      /** @example 2h30m45s */
+      uptime?: string;
+    };
+    "docs.NetworkExclusionResponse": {
+      created_at?: string;
+      /** @example admin */
+      created_by?: string;
+      /** @example true */
+      enabled?: boolean;
+      /** @example 192.168.1.128/25 */
+      excluded_cidr?: string;
+      /** @example 550e8400-e29b-41d4-a716-446655440011 */
+      id?: string;
+      /** @example 550e8400-e29b-41d4-a716-446655440010 */
+      network_id?: string;
+      /** @example Reserved for printers */
+      reason?: string;
+      updated_at?: string;
+    };
+    "docs.NetworkResponse": {
+      /** @example 20 */
+      active_host_count?: number;
+      /** @example 192.168.1.0/24 */
+      cidr?: string;
+      created_at?: string;
+      /** @example admin */
+      created_by?: string;
+      /** @example Main office network */
+      description?: string;
+      /**
+       * @example ping
+       * @enum {string}
+       */
+      discovery_method?: "ping" | "tcp" | "arp";
+      /** @example 25 */
+      host_count?: number;
+      /** @example 550e8400-e29b-41d4-a716-446655440010 */
+      id?: string;
+      /** @example true */
+      is_active?: boolean;
+      last_discovery?: string;
+      last_scan?: string;
+      /** @example Office Network */
+      name?: string;
+      /** @example true */
+      scan_enabled?: boolean;
+      updated_at?: string;
+    };
+    "docs.NetworkStatsResponse": {
+      exclusions?: {
+        [key: string]: unknown;
+      };
+      hosts?: {
+        [key: string]: unknown;
+      };
+      networks?: {
+        [key: string]: unknown;
+      };
+    };
+    "docs.PaginatedDiscoveryJobsResponse": {
+      data?: components["schemas"]["docs.DiscoveryJobResponse"][];
+      pagination?: components["schemas"]["docs.PaginationInfo"];
+    };
+    "docs.PaginatedHostsResponse": {
+      data?: components["schemas"]["docs.HostResponse"][];
+      pagination?: components["schemas"]["docs.PaginationInfo"];
+    };
+    "docs.PaginatedNetworksResponse": {
+      data?: components["schemas"]["docs.NetworkResponse"][];
+      pagination?: components["schemas"]["docs.PaginationInfo"];
+    };
+    "docs.PaginatedProfilesResponse": {
+      data?: components["schemas"]["docs.ProfileResponse"][];
+      pagination?: components["schemas"]["docs.PaginationInfo"];
+    };
+    "docs.PaginatedScansResponse": {
+      data?: components["schemas"]["docs.ScanResponse"][];
+      pagination?: components["schemas"]["docs.PaginationInfo"];
+    };
+    "docs.PaginatedSchedulesResponse": {
+      data?: components["schemas"]["docs.ScheduleResponse"][];
+      pagination?: components["schemas"]["docs.PaginationInfo"];
+    };
+    "docs.PaginationInfo": {
+      /** @example 1 */
+      page?: number;
+      /** @example 20 */
+      page_size?: number;
+      /** @example 150 */
+      total_items?: number;
+      /** @example 8 */
+      total_pages?: number;
+    };
+    "docs.ProfileResponse": {
+      created_at?: string;
+      /** @example Fast TCP connect scan */
+      description?: string;
+      /** @example 550e8400-e29b-41d4-a716-446655440003 */
+      id?: string;
+      /** @example Quick Connect Scan */
+      name?: string;
+      options?: {
+        [key: string]: unknown;
+      };
+      /** @example 22,80,443 */
+      ports?: string;
+      /** @example connect */
+      scan_type?: string;
+      updated_at?: string;
+    };
+    "docs.RenameNetworkRequest": {
+      /** @example New Office Network */
+      new_name?: string;
+    };
+    "docs.ScanResponse": {
+      completed_at?: string;
+      created_at?: string;
+      /** @example 14m30s */
+      duration?: string;
+      error_message?: string;
+      /** @example 25 */
+      hosts_discovered?: number;
+      /** @example 550e8400-e29b-41d4-a716-446655440000 */
+      id?: string;
+      /** @example Ad-hoc scan: 192.168.1.0/24 */
+      name?: string;
+      /** @example 22,80,443 */
+      ports?: string;
+      /** @example 2500 */
+      ports_scanned?: number;
+      /** @example 550e8400-e29b-41d4-a716-446655440001 */
+      profile_id?: string;
+      /** @example 65.5 */
+      progress?: number;
+      /**
+       * @example connect
+       * @enum {string}
+       */
+      scan_type?:
+        | "connect"
+        | "syn"
+        | "version"
+        | "aggressive"
+        | "stealth"
+        | "comprehensive";
+      started_at?: string;
+      /**
+       * @example running
+       * @enum {string}
+       */
+      status?: "pending" | "running" | "completed" | "failed" | "cancelled";
+      /**
+       * @example [
+       *       "192.168.1.0/24"
+       *     ]
+       */
+      targets?: string[];
+    };
+    "docs.ScheduleResponse": {
+      created_at?: string;
+      /** @example 0 2 * * 1 */
+      cron_expression?: string;
+      /** @example true */
+      enabled?: boolean;
+      /** @example 550e8400-e29b-41d4-a716-446655440005 */
+      id?: string;
+      last_run?: string;
+      /** @example Weekly Security Scan */
+      name?: string;
+      next_run?: string;
+      /** @example 550e8400-e29b-41d4-a716-446655440001 */
+      profile_id?: string;
+      /**
+       * @example [
+       *       "192.168.1.0/24"
+       *     ]
+       */
+      targets?: string[];
+      updated_at?: string;
+    };
+    "docs.StatusResponse": {
+      /** @example scanorama-api */
+      service?: string;
+      timestamp?: string;
+      /** @example 2h30m45s */
+      uptime?: string;
+      /** @example 0.7.0 */
+      version?: string;
+    };
+    "docs.UpdateNetworkRequest": {
+      /** @example 192.168.1.0/24 */
+      cidr?: string;
+      /** @example Main office network */
+      description?: string;
+      /**
+       * @example ping
+       * @enum {string}
+       */
+      discovery_method?: "ping" | "tcp" | "arp";
+      /** @example true */
+      is_active?: boolean;
+      /** @example Office Network */
+      name?: string;
+      /** @example true */
+      scan_enabled?: boolean;
+    };
+    "docs.UpdateScanRequest": {
+      /** @example Updated description */
+      description?: string;
+      /** @example Updated scan name */
+      name?: string;
+      options?: {
+        [key: string]: string;
+      };
+      /** @example 22,80,443 */
+      ports?: string;
+      profile_id?: number;
+      /**
+       * @example connect
+       * @enum {string}
+       */
+      scan_type?: "connect" | "syn" | "ack" | "aggressive" | "comprehensive";
+      schedule_id?: number;
+      tags?: string[];
+      /**
+       * @example [
+       *       "192.168.1.0/24"
+       *     ]
+       */
+      targets?: string[];
+    };
+    "docs.VersionResponse": {
+      /** @example scanorama */
+      service?: string;
+      timestamp?: string;
+      /** @example 0.7.0 */
+      version?: string;
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: {
+    /** @description Exclusion configuration */
+    "docs.CreateExclusionRequest": {
+      content: {
+        "application/json": components["schemas"]["docs.CreateExclusionRequest"];
+      };
+    };
+  };
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    getAdminStatus: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.AdminStatusResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  getAdminStatus: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    listDiscoveryJobs: {
-        parameters: {
-            query?: {
-                /** @description Page number */
-                page?: number;
-                /** @description Items per page */
-                page_size?: number;
-                /** @description Filter by status */
-                status?: "pending" | "running" | "completed" | "failed";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.PaginatedDiscoveryJobsResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["docs.AdminStatusResponse"];
         };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    createDiscoveryJob: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description Discovery job configuration */
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["docs.CreateDiscoveryJobRequest"];
-            };
-        };
-        responses: {
-            /** @description Created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  listDiscoveryJobs: {
+    parameters: {
+      query?: {
+        /** @description Page number */
+        page?: number;
+        /** @description Items per page */
+        page_size?: number;
+        /** @description Filter by status */
+        status?: "pending" | "running" | "completed" | "failed";
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getDiscoveryJob: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Discovery Job ID */
-                discoveryId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["docs.PaginatedDiscoveryJobsResponse"];
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    startDiscovery: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Discovery Job ID */
-                discoveryId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Conflict */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  createDiscoveryJob: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    stopDiscovery: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Discovery Job ID */
-                discoveryId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Conflict */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+    /** @description Discovery job configuration */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["docs.CreateDiscoveryJobRequest"];
+      };
     };
-    listGlobalExclusions: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Created */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.NetworkExclusionResponse"][];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    createGlobalExclusion: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: components["requestBodies"]["docs.CreateExclusionRequest"];
-        responses: {
-            /** @description Created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.NetworkExclusionResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  getDiscoveryJob: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Discovery Job ID */
+        discoveryId: string;
+      };
+      cookie?: never;
     };
-    deleteExclusion: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Exclusion ID */
-                exclusionId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    getHealth: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.HealthResponse"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Service Unavailable */
-            503: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.HealthResponse"];
-                };
-            };
-        };
+  };
+  startDiscovery: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Discovery Job ID */
+        discoveryId: string;
+      };
+      cookie?: never;
     };
-    listHosts: {
-        parameters: {
-            query?: {
-                /** @description Page number */
-                page?: number;
-                /** @description Items per page */
-                page_size?: number;
-                /** @description Filter by IP address */
-                ip_address?: string;
-                /** @description Filter by hostname */
-                hostname?: string;
-                /** @description Filter by status */
-                status?: "up" | "down" | "unknown";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.PaginatedHostsResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Conflict */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    createHost: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description Host information */
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["docs.HostResponse"];
-            };
-        };
-        responses: {
-            /** @description Created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.HostResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Conflict */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  stopDiscovery: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Discovery Job ID */
+        discoveryId: string;
+      };
+      cookie?: never;
     };
-    getHost: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Host ID */
-                hostId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.HostResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Conflict */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    updateHost: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Host ID */
-                hostId: string;
-            };
-            cookie?: never;
-        };
-        /** @description Updated host information */
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["docs.HostResponse"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.HostResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  listGlobalExclusions: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    deleteHost: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Host ID */
-                hostId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["docs.NetworkExclusionResponse"][];
         };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    getHostScans: {
-        parameters: {
-            query?: {
-                /** @description Page number */
-                page?: number;
-                /** @description Items per page */
-                page_size?: number;
-            };
-            header?: never;
-            path: {
-                /** @description Host ID */
-                hostId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.PaginatedScansResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  createGlobalExclusion: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getLiveness: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody: components["requestBodies"]["docs.CreateExclusionRequest"];
+    responses: {
+      /** @description Created */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.LivenessResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["docs.NetworkExclusionResponse"];
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    getMetrics: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "text/plain": string;
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "text/plain": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "text/plain": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  deleteExclusion: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Exclusion ID */
+        exclusionId: string;
+      };
+      cookie?: never;
     };
-    listNetworks: {
-        parameters: {
-            query?: {
-                /** @description Page number */
-                page?: number;
-                /** @description Items per page */
-                page_size?: number;
-                /** @description Include inactive networks */
-                show_inactive?: boolean;
-                /** @description Filter by network name */
-                name?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successfully deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.PaginatedNetworksResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content?: never;
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    createNetwork: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description Network configuration */
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["docs.CreateNetworkRequest"];
-            };
-        };
-        responses: {
-            /** @description Created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.NetworkResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Conflict */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  getHealth: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getNetwork: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Network ID */
-                networkId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.NetworkResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["docs.HealthResponse"];
         };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Service Unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.HealthResponse"];
+        };
+      };
     };
-    updateNetwork: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Network ID */
-                networkId: string;
-            };
-            cookie?: never;
-        };
-        /** @description Updated network configuration */
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["docs.UpdateNetworkRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.NetworkResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  listHosts: {
+    parameters: {
+      query?: {
+        /** @description Page number */
+        page?: number;
+        /** @description Items per page */
+        page_size?: number;
+        /** @description Filter by IP address */
+        ip_address?: string;
+        /** @description Filter by hostname */
+        hostname?: string;
+        /** @description Filter by status */
+        status?: "up" | "down" | "unknown";
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    deleteNetwork: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Network ID */
-                networkId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["docs.PaginatedHostsResponse"];
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    disableNetwork: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Network ID */
-                networkId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.NetworkResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  createHost: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    enableNetwork: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Network ID */
-                networkId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.NetworkResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+    /** @description Host information */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["docs.HostResponse"];
+      };
     };
-    listNetworkExclusions: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Network ID */
-                networkId: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Created */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.NetworkExclusionResponse"][];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["docs.HostResponse"];
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Conflict */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    createNetworkExclusion: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Network ID */
-                networkId: string;
-            };
-            cookie?: never;
-        };
-        requestBody: components["requestBodies"]["docs.CreateExclusionRequest"];
-        responses: {
-            /** @description Created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.NetworkExclusionResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  getHost: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Host ID */
+        hostId: string;
+      };
+      cookie?: never;
     };
-    renameNetwork: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Network ID */
-                networkId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        /** @description New network name */
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["docs.RenameNetworkRequest"];
-            };
+        content: {
+          "application/json": components["schemas"]["docs.HostResponse"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.NetworkResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Conflict */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    getNetworkStats: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.NetworkStatsResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  updateHost: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Host ID */
+        hostId: string;
+      };
+      cookie?: never;
     };
-    listProfiles: {
-        parameters: {
-            query?: {
-                /** @description Page number */
-                page?: number;
-                /** @description Items per page */
-                page_size?: number;
-                /** @description Filter by scan type */
-                scan_type?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.PaginatedProfilesResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+    /** @description Updated host information */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["docs.HostResponse"];
+      };
     };
-    createProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        /** @description Profile configuration */
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["docs.CreateProfileRequest"];
-            };
+        content: {
+          "application/json": components["schemas"]["docs.HostResponse"];
         };
-        responses: {
-            /** @description Created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ProfileResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Conflict */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    getProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Profile ID */
-                profileId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ProfileResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  deleteHost: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Host ID */
+        hostId: string;
+      };
+      cookie?: never;
     };
-    updateProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Profile ID */
-                profileId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successfully deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
         };
-        /** @description Updated profile configuration */
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["docs.CreateProfileRequest"];
-            };
+        content?: never;
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ProfileResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
         };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    deleteProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Profile ID */
-                profileId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Conflict */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  getHostScans: {
+    parameters: {
+      query?: {
+        /** @description Page number */
+        page?: number;
+        /** @description Items per page */
+        page_size?: number;
+      };
+      header?: never;
+      path: {
+        /** @description Host ID */
+        hostId: string;
+      };
+      cookie?: never;
     };
-    listScans: {
-        parameters: {
-            query?: {
-                /** @description Page number */
-                page?: number;
-                /** @description Items per page */
-                page_size?: number;
-                /** @description Filter by status */
-                status?: "pending" | "running" | "completed" | "failed" | "cancelled";
-                /** @description Filter by target */
-                target?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.PaginatedScansResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["docs.PaginatedScansResponse"];
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    createScan: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description Scan configuration */
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["docs.CreateScanRequest"];
-            };
-        };
-        responses: {
-            /** @description Created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ScanResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  getLiveness: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getScan: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Scan ID */
-                scanId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ScanResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["docs.LivenessResponse"];
         };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    updateScan: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Scan ID */
-                scanId: string;
-            };
-            cookie?: never;
-        };
-        /** @description Updated scan configuration */
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["docs.UpdateScanRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ScanResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  getMetrics: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    deleteScan: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Scan ID */
-                scanId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Conflict */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "text/plain": string;
         };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "text/plain": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "text/plain": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    getScanResults: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Scan ID */
-                scanId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  listNetworks: {
+    parameters: {
+      query?: {
+        /** @description Page number */
+        page?: number;
+        /** @description Items per page */
+        page_size?: number;
+        /** @description Include inactive networks */
+        show_inactive?: boolean;
+        /** @description Filter by network name */
+        name?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    startScan: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Scan ID */
-                scanId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ScanResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Conflict */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["docs.PaginatedNetworksResponse"];
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    stopScan: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Scan ID */
-                scanId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ScanResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Conflict */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  createNetwork: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    listSchedules: {
-        parameters: {
-            query?: {
-                /** @description Page number */
-                page?: number;
-                /** @description Items per page */
-                page_size?: number;
-                /** @description Filter by enabled status */
-                enabled?: boolean;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.PaginatedSchedulesResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+    /** @description Network configuration */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["docs.CreateNetworkRequest"];
+      };
     };
-    createSchedule: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Created */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        /** @description Schedule configuration */
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["docs.CreateScheduleRequest"];
-            };
+        content: {
+          "application/json": components["schemas"]["docs.NetworkResponse"];
         };
-        responses: {
-            /** @description Created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ScheduleResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Conflict */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    getSchedule: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Schedule ID */
-                scheduleId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ScheduleResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  getNetwork: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Network ID */
+        networkId: string;
+      };
+      cookie?: never;
     };
-    updateSchedule: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Schedule ID */
-                scheduleId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        /** @description Updated schedule configuration */
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["docs.CreateScheduleRequest"];
-            };
+        content: {
+          "application/json": components["schemas"]["docs.NetworkResponse"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ScheduleResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    deleteSchedule: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Schedule ID */
-                scheduleId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  updateNetwork: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Network ID */
+        networkId: string;
+      };
+      cookie?: never;
     };
-    disableSchedule: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Schedule ID */
-                scheduleId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ScheduleResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+    /** @description Updated network configuration */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["docs.UpdateNetworkRequest"];
+      };
     };
-    enableSchedule: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Schedule ID */
-                scheduleId: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ScheduleResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["docs.NetworkResponse"];
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
-    getStatus: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.StatusResponse"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-        };
+  };
+  deleteNetwork: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Network ID */
+        networkId: string;
+      };
+      cookie?: never;
     };
-    getVersion: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successfully deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.VersionResponse"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["docs.ErrorResponse"];
-                };
-            };
+        content?: never;
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
     };
+  };
+  disableNetwork: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Network ID */
+        networkId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.NetworkResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  enableNetwork: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Network ID */
+        networkId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.NetworkResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  listNetworkExclusions: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Network ID */
+        networkId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.NetworkExclusionResponse"][];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  createNetworkExclusion: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Network ID */
+        networkId: string;
+      };
+      cookie?: never;
+    };
+    requestBody: components["requestBodies"]["docs.CreateExclusionRequest"];
+    responses: {
+      /** @description Created */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.NetworkExclusionResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  renameNetwork: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Network ID */
+        networkId: string;
+      };
+      cookie?: never;
+    };
+    /** @description New network name */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["docs.RenameNetworkRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.NetworkResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Conflict */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  getNetworkStats: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.NetworkStatsResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  listProfiles: {
+    parameters: {
+      query?: {
+        /** @description Page number */
+        page?: number;
+        /** @description Items per page */
+        page_size?: number;
+        /** @description Filter by scan type */
+        scan_type?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.PaginatedProfilesResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  createProfile: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Profile configuration */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["docs.CreateProfileRequest"];
+      };
+    };
+    responses: {
+      /** @description Created */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ProfileResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Conflict */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  getProfile: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Profile ID */
+        profileId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ProfileResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  updateProfile: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Profile ID */
+        profileId: string;
+      };
+      cookie?: never;
+    };
+    /** @description Updated profile configuration */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["docs.CreateProfileRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ProfileResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  deleteProfile: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Profile ID */
+        profileId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successfully deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Conflict */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  listScans: {
+    parameters: {
+      query?: {
+        /** @description Page number */
+        page?: number;
+        /** @description Items per page */
+        page_size?: number;
+        /** @description Filter by status */
+        status?: "pending" | "running" | "completed" | "failed" | "cancelled";
+        /** @description Filter by target */
+        target?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.PaginatedScansResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  createScan: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Scan configuration */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["docs.CreateScanRequest"];
+      };
+    };
+    responses: {
+      /** @description Created */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ScanResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  getScan: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Scan ID */
+        scanId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ScanResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  updateScan: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Scan ID */
+        scanId: string;
+      };
+      cookie?: never;
+    };
+    /** @description Updated scan configuration */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["docs.UpdateScanRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ScanResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  deleteScan: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Scan ID */
+        scanId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successfully deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Conflict */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  getScanResults: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Scan ID */
+        scanId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            [key: string]: unknown;
+          };
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  startScan: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Scan ID */
+        scanId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ScanResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Conflict */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  stopScan: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Scan ID */
+        scanId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ScanResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Conflict */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  listSchedules: {
+    parameters: {
+      query?: {
+        /** @description Page number */
+        page?: number;
+        /** @description Items per page */
+        page_size?: number;
+        /** @description Filter by enabled status */
+        enabled?: boolean;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.PaginatedSchedulesResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  createSchedule: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Schedule configuration */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["docs.CreateScheduleRequest"];
+      };
+    };
+    responses: {
+      /** @description Created */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ScheduleResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  getSchedule: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Schedule ID */
+        scheduleId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ScheduleResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  updateSchedule: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Schedule ID */
+        scheduleId: string;
+      };
+      cookie?: never;
+    };
+    /** @description Updated schedule configuration */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["docs.CreateScheduleRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ScheduleResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  deleteSchedule: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Schedule ID */
+        scheduleId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successfully deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  disableSchedule: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Schedule ID */
+        scheduleId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ScheduleResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  enableSchedule: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Schedule ID */
+        scheduleId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ScheduleResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  getStatus: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.StatusResponse"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
+  getVersion: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.VersionResponse"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["docs.ErrorResponse"];
+        };
+      };
+    };
+  };
 }

--- a/frontend/src/components/button.tsx
+++ b/frontend/src/components/button.tsx
@@ -1,0 +1,69 @@
+import { Loader2 } from "lucide-react";
+import { cn } from "../lib/utils";
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "primary" | "secondary" | "ghost" | "danger";
+  size?: "sm" | "md";
+  loading?: boolean;
+  icon?: React.ReactNode;
+}
+
+const variantClasses: Record<NonNullable<ButtonProps["variant"]>, string> = {
+  primary: cn(
+    "bg-accent text-white font-medium",
+    "hover:opacity-90",
+    "disabled:opacity-50",
+  ),
+  secondary: cn(
+    "border border-border text-text-secondary",
+    "hover:text-text-primary hover:bg-surface-raised",
+  ),
+  ghost: cn(
+    "text-text-secondary",
+    "hover:text-text-primary hover:bg-surface-raised",
+  ),
+  danger: cn(
+    "bg-danger text-white font-medium",
+    "hover:opacity-90",
+    "disabled:opacity-50",
+  ),
+};
+
+const sizeClasses: Record<NonNullable<ButtonProps["size"]>, string> = {
+  sm: "px-3 py-1.5 text-xs gap-1.5",
+  md: "px-4 py-2 text-sm gap-2",
+};
+
+export function Button({
+  variant = "primary",
+  size = "sm",
+  loading = false,
+  icon,
+  children,
+  disabled,
+  className,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      disabled={disabled || loading}
+      className={cn(
+        "inline-flex items-center justify-center rounded transition-colors",
+        "disabled:cursor-not-allowed",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50",
+        variantClasses[variant],
+        sizeClasses[size],
+        className,
+      )}
+      {...props}
+    >
+      {loading ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin shrink-0" />
+      ) : (
+        icon && <span className="shrink-0">{icon}</span>
+      )}
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,7 +1,9 @@
+export { Button } from "./button";
 export { StatusBadge } from "./status-badge";
 export { StatCard } from "./stat-card";
 export { PlaceholderPage } from "./placeholder-page";
 export { Skeleton } from "./skeleton";
 export { RecentScansTable } from "./recent-scans-table";
 export { PaginationBar } from "./pagination-bar";
+export { RunScanModal } from "./run-scan-modal";
 export * from "./layout";

--- a/frontend/src/components/layout/root-layout.tsx
+++ b/frontend/src/components/layout/root-layout.tsx
@@ -7,7 +7,7 @@ const routeTitles: Record<string, string> = {
   "/scans": "Scans",
   "/hosts": "Hosts",
   "/networks": "Networks",
-  "/discovery": "Discovery",
+
   "/profiles": "Profiles",
   "/schedules": "Schedules",
   "/admin": "Admin",

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -5,7 +5,6 @@ import {
   Radar,
   Server,
   Network,
-  Search,
   SlidersHorizontal,
   Clock,
   Shield,
@@ -24,7 +23,7 @@ const mainNav: NavItem[] = [
   { label: "Scans", href: "#/scans", icon: Radar },
   { label: "Hosts", href: "#/hosts", icon: Server },
   { label: "Networks", href: "#/networks", icon: Network },
-  { label: "Discovery", href: "#/discovery", icon: Search },
+
   { label: "Profiles", href: "#/profiles", icon: SlidersHorizontal },
   { label: "Schedules", href: "#/schedules", icon: Clock },
 ];

--- a/frontend/src/components/recent-scans-table.test.tsx
+++ b/frontend/src/components/recent-scans-table.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, within } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
+import { renderWithRouter } from "../test/utils";
 import { RecentScansTable } from "./recent-scans-table";
 
 const mockScans = [
@@ -24,50 +25,60 @@ const mockScans = [
 describe("RecentScansTable", () => {
   // 1. Loading skeletons
   it("shows loading skeletons when loading is true", () => {
-    const { container } = render(<RecentScansTable loading={true} />);
+    const { container } = renderWithRouter(<RecentScansTable loading={true} />);
     const skeletons = container.querySelectorAll(".animate-pulse");
     // 4 skeleton divs per row × 5 rows = 20
     expect(skeletons).toHaveLength(20);
   });
 
   it("does not show the table or empty message when loading", () => {
-    render(<RecentScansTable loading={true} />);
+    renderWithRouter(<RecentScansTable loading={true} />);
     expect(screen.queryByText("No scans found.")).not.toBeInTheDocument();
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
 
   // 2. No scans found — undefined
   it("shows 'No scans found.' when scans is undefined", () => {
-    render(<RecentScansTable />);
+    renderWithRouter(<RecentScansTable />);
     expect(screen.getByText("No scans found.")).toBeInTheDocument();
   });
 
   // 3. No scans found — empty array
   it("shows 'No scans found.' when scans is an empty array", () => {
-    render(<RecentScansTable scans={[]} />);
+    renderWithRouter(<RecentScansTable scans={[]} />);
     expect(screen.getByText("No scans found.")).toBeInTheDocument();
   });
 
   // 4. Table headers
   it("renders all table column headers when scans are provided", () => {
-    render(<RecentScansTable scans={mockScans} />);
-    expect(screen.getByRole("columnheader", { name: "Status" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Targets" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Hosts" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Ports" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "When" })).toBeInTheDocument();
+    renderWithRouter(<RecentScansTable scans={mockScans} />);
+    expect(
+      screen.getByRole("columnheader", { name: "Status" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Targets" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Hosts" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Ports" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "When" }),
+    ).toBeInTheDocument();
   });
 
   // 5. Scan data in rows
   it("renders a row for each scan", () => {
-    render(<RecentScansTable scans={mockScans} />);
+    renderWithRouter(<RecentScansTable scans={mockScans} />);
     const rows = screen.getAllByRole("row");
     // 1 header row + 2 data rows
     expect(rows).toHaveLength(3);
   });
 
   it("renders numeric hosts_discovered and ports_scanned values", () => {
-    render(<RecentScansTable scans={mockScans} />);
+    renderWithRouter(<RecentScansTable scans={mockScans} />);
     expect(screen.getByText("25")).toBeInTheDocument();
     expect(screen.getByText("2500")).toBeInTheDocument();
     expect(screen.getByText("10")).toBeInTheDocument();
@@ -76,26 +87,26 @@ describe("RecentScansTable", () => {
 
   // 6. StatusBadge renders status text
   it("displays the status text for each scan via StatusBadge", () => {
-    render(<RecentScansTable scans={mockScans} />);
+    renderWithRouter(<RecentScansTable scans={mockScans} />);
     expect(screen.getByText("completed")).toBeInTheDocument();
     expect(screen.getByText("running")).toBeInTheDocument();
   });
 
   // 7. Multiple targets joined with comma
   it("joins multiple targets with a comma separator", () => {
-    render(<RecentScansTable scans={mockScans} />);
+    renderWithRouter(<RecentScansTable scans={mockScans} />);
     expect(screen.getByText("10.0.0.0/8, 172.16.0.0/12")).toBeInTheDocument();
   });
 
   it("renders a single target without a trailing comma", () => {
-    render(<RecentScansTable scans={mockScans} />);
+    renderWithRouter(<RecentScansTable scans={mockScans} />);
     expect(screen.getByText("192.168.1.0/24")).toBeInTheDocument();
   });
 
   // 8. Em-dash for missing optional fields
   it("shows em-dash for missing targets", () => {
     const scans = [{ id: "scan-x", status: "completed" }];
-    render(<RecentScansTable scans={scans} />);
+    renderWithRouter(<RecentScansTable scans={scans} />);
     const rows = screen.getAllByRole("row");
     const dataRow = rows[1];
     const cells = within(dataRow).getAllByRole("cell");
@@ -104,8 +115,10 @@ describe("RecentScansTable", () => {
   });
 
   it("shows em-dash for missing hosts_discovered", () => {
-    const scans = [{ id: "scan-x", status: "completed", targets: ["10.0.0.1"] }];
-    render(<RecentScansTable scans={scans} />);
+    const scans = [
+      { id: "scan-x", status: "completed", targets: ["10.0.0.1"] },
+    ];
+    renderWithRouter(<RecentScansTable scans={scans} />);
     const rows = screen.getAllByRole("row");
     const dataRow = rows[1];
     const cells = within(dataRow).getAllByRole("cell");
@@ -114,8 +127,10 @@ describe("RecentScansTable", () => {
   });
 
   it("shows em-dash for missing ports_scanned", () => {
-    const scans = [{ id: "scan-x", status: "completed", targets: ["10.0.0.1"] }];
-    render(<RecentScansTable scans={scans} />);
+    const scans = [
+      { id: "scan-x", status: "completed", targets: ["10.0.0.1"] },
+    ];
+    renderWithRouter(<RecentScansTable scans={scans} />);
     const rows = screen.getAllByRole("row");
     const dataRow = rows[1];
     const cells = within(dataRow).getAllByRole("cell");
@@ -124,8 +139,10 @@ describe("RecentScansTable", () => {
   });
 
   it("shows em-dash for missing created_at", () => {
-    const scans = [{ id: "scan-x", status: "completed", targets: ["10.0.0.1"] }];
-    render(<RecentScansTable scans={scans} />);
+    const scans = [
+      { id: "scan-x", status: "completed", targets: ["10.0.0.1"] },
+    ];
+    renderWithRouter(<RecentScansTable scans={scans} />);
     const rows = screen.getAllByRole("row");
     const dataRow = rows[1];
     const cells = within(dataRow).getAllByRole("cell");
@@ -135,17 +152,23 @@ describe("RecentScansTable", () => {
 
   // 9. "Recent Scans" heading always present
   it("shows the 'Recent Scans' heading when loading", () => {
-    render(<RecentScansTable loading={true} />);
-    expect(screen.getByRole("heading", { name: "Recent Scans" })).toBeInTheDocument();
+    renderWithRouter(<RecentScansTable loading={true} />);
+    expect(
+      screen.getByRole("heading", { name: "Recent Scans" }),
+    ).toBeInTheDocument();
   });
 
   it("shows the 'Recent Scans' heading when scans is undefined", () => {
-    render(<RecentScansTable />);
-    expect(screen.getByRole("heading", { name: "Recent Scans" })).toBeInTheDocument();
+    renderWithRouter(<RecentScansTable />);
+    expect(
+      screen.getByRole("heading", { name: "Recent Scans" }),
+    ).toBeInTheDocument();
   });
 
   it("shows the 'Recent Scans' heading when scans are provided", () => {
-    render(<RecentScansTable scans={mockScans} />);
-    expect(screen.getByRole("heading", { name: "Recent Scans" })).toBeInTheDocument();
+    renderWithRouter(<RecentScansTable scans={mockScans} />);
+    expect(
+      screen.getByRole("heading", { name: "Recent Scans" }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/recent-scans-table.tsx
+++ b/frontend/src/components/recent-scans-table.tsx
@@ -1,4 +1,6 @@
+import { Link } from "@tanstack/react-router";
 import { formatRelativeTime } from "../lib/utils";
+import { cn } from "../lib/utils";
 import { StatusBadge } from "./status-badge";
 import { Skeleton } from "./skeleton";
 
@@ -15,18 +17,28 @@ interface Scan {
 interface RecentScansTableProps {
   scans?: Scan[];
   loading?: boolean;
+  onScanClick?: (scan: Scan) => void;
 }
 
 export function RecentScansTable({
   scans,
   loading = false,
+  onScanClick,
 }: RecentScansTableProps) {
   if (loading) {
     return (
       <div className="bg-surface rounded-lg border border-border p-4">
-        <h2 className="text-sm font-medium text-text-primary mb-3">
-          Recent Scans
-        </h2>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-medium text-text-primary">
+            Recent Scans
+          </h2>
+          <Link
+            to="/scans"
+            className="text-xs text-text-muted hover:text-text-primary transition-colors"
+          >
+            View all →
+          </Link>
+        </div>
         <div className="space-y-3">
           {Array.from({ length: 5 }).map((_, i) => (
             <div key={i} className="flex items-center gap-3">
@@ -45,9 +57,15 @@ export function RecentScansTable({
 
   return (
     <div className="bg-surface rounded-lg border border-border p-4">
-      <h2 className="text-sm font-medium text-text-primary mb-3">
-        Recent Scans
-      </h2>
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-medium text-text-primary">Recent Scans</h2>
+        <Link
+          to="/scans"
+          className="text-xs text-text-muted hover:text-text-primary transition-colors"
+        >
+          View all →
+        </Link>
+      </div>
       {isEmpty ? (
         <p className="text-xs text-text-muted">No scans found.</p>
       ) : (
@@ -66,7 +84,11 @@ export function RecentScansTable({
               {scans.map((scan) => (
                 <tr
                   key={scan.id}
-                  className="border-b border-border/50 last:border-0"
+                  onClick={() => onScanClick?.(scan)}
+                  className={cn(
+                    "border-b border-border/50 last:border-0 transition-colors",
+                    onScanClick && "cursor-pointer hover:bg-surface-raised/60",
+                  )}
                 >
                   <td className="py-2 pr-4">
                     <StatusBadge status={scan.status ?? "unknown"} />

--- a/frontend/src/components/run-scan-modal.tsx
+++ b/frontend/src/components/run-scan-modal.tsx
@@ -1,0 +1,344 @@
+import { useState, useId } from "react";
+import { X, Loader2 } from "lucide-react";
+import { Button } from "./button";
+import { useProfiles } from "../api/hooks/use-profiles";
+import { useCreateScan, useStartScan } from "../api/hooks/use-scans";
+import { cn } from "../lib/utils";
+
+type Mode = "profile" | "custom";
+
+const SCAN_TYPES = [
+  { value: "connect", label: "Connect (-sT)" },
+  { value: "syn", label: "SYN stealth (-sS)" },
+  { value: "ack", label: "ACK (-sA)" },
+  { value: "udp", label: "UDP (-sU)" },
+  { value: "aggressive", label: "Aggressive (-sS -sV -A)" },
+  { value: "comprehensive", label: "Comprehensive (-sS -sV --script=default)" },
+] as const;
+
+export interface RunScanModalProps {
+  /** Pre-fill the target field (e.g. a host IP from the Hosts page). */
+  initialTarget?: string;
+  onClose: () => void;
+  /** Called after the scan is successfully submitted. */
+  onSubmitted?: () => void;
+}
+
+export function RunScanModal({
+  initialTarget = "",
+  onClose,
+  onSubmitted,
+}: RunScanModalProps) {
+  const id = useId();
+
+  const [target, setTarget] = useState(initialTarget);
+  const [mode, setMode] = useState<Mode>("profile");
+  const [profileId, setProfileId] = useState("");
+  const [ports, setPorts] = useState("");
+  const [scanType, setScanType] = useState<string>("connect");
+  const [osDetection, setOsDetection] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { data: profilesData, isLoading: profilesLoading } = useProfiles({
+    page: 1,
+    page_size: 100,
+  });
+  const profiles = profilesData?.data ?? [];
+
+  // Look up the selected profile object so we can read its scan_type / ports.
+  const selectedProfile = profiles.find((p) => p.id === profileId) ?? null;
+
+  const { mutateAsync: createScan, isPending: isCreating } = useCreateScan();
+  const { mutateAsync: startScan, isPending: isStarting } = useStartScan();
+  const isPending = isCreating || isStarting;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const trimmedTarget = target.trim();
+    if (!trimmedTarget) {
+      setError("Please enter at least one target.");
+      return;
+    }
+
+    if (mode === "profile" && !profileId) {
+      setError("Please select a profile.");
+      return;
+    }
+
+    // Split comma/whitespace-separated targets into an array.
+    const targets = trimmedTarget
+      .split(/[\s,]+/)
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    // Auto-generate a name from the first target.
+    const name = `Ad-hoc scan: ${targets[0]}${targets.length > 1 ? ` +${targets.length - 1}` : ""}`;
+
+    try {
+      let result: Awaited<ReturnType<typeof createScan>>;
+      if (mode === "profile") {
+        // Expand the profile's settings into the request — the backend
+        // expects scan_type at the top level, not a UUID profile_id.
+        result = await createScan({
+          name,
+          targets,
+          scan_type: selectedProfile?.scan_type ?? "connect",
+          ...(selectedProfile?.ports ? { ports: selectedProfile.ports } : {}),
+          ...(osDetection ? { os_detection: true } : {}),
+        });
+      } else {
+        result = await createScan({
+          name,
+          targets,
+          scan_type: scanType,
+          ...(ports.trim() ? { ports: ports.trim() } : {}),
+          ...(osDetection ? { os_detection: true } : {}),
+        });
+      }
+      const scanId = result?.id;
+      if (scanId) {
+        await startScan(scanId);
+      }
+      onSubmitted?.();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start scan.");
+    }
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Dialog */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${id}-title`}
+        className={cn(
+          "fixed z-50 inset-0 m-auto",
+          "w-full max-w-md h-fit",
+          "bg-surface border border-border rounded-lg shadow-xl",
+          "flex flex-col",
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+          <h2
+            id={`${id}-title`}
+            className="text-sm font-semibold text-text-primary"
+          >
+            Run Scan
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close dialog"
+            className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <form onSubmit={handleSubmit} className="px-5 py-4 space-y-5">
+          {/* Target */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-target`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Target
+            </label>
+            <input
+              id={`${id}-target`}
+              type="text"
+              value={target}
+              onChange={(e) => setTarget(e.target.value)}
+              placeholder="192.168.1.1, 10.0.0.0/24…"
+              autoFocus
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border font-mono",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+            <p className="text-xs text-text-muted">
+              Comma-separated IPs, ranges, or CIDR blocks.
+            </p>
+          </div>
+
+          {/* Mode toggle */}
+          <div className="space-y-1.5">
+            <span className="block text-xs font-medium text-text-primary">
+              Scan configuration
+            </span>
+            <div
+              role="radiogroup"
+              aria-label="Scan configuration mode"
+              className="flex rounded border border-border overflow-hidden text-xs"
+            >
+              {(["profile", "custom"] as Mode[]).map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  role="radio"
+                  aria-checked={mode === m}
+                  onClick={() => setMode(m)}
+                  className={cn(
+                    "flex-1 py-1.5 text-center transition-colors",
+                    mode === m
+                      ? "bg-accent text-white font-medium"
+                      : "text-text-secondary hover:bg-surface-raised",
+                  )}
+                >
+                  {m === "profile" ? "Profile" : "Custom ports"}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Profile selector */}
+          {mode === "profile" && (
+            <div className="space-y-1.5">
+              <label
+                htmlFor={`${id}-profile`}
+                className="block text-xs font-medium text-text-primary"
+              >
+                Profile
+              </label>
+              {profilesLoading ? (
+                <div className="flex items-center gap-2 text-xs text-text-muted py-1">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  Loading profiles…
+                </div>
+              ) : profiles.length === 0 ? (
+                <p className="text-xs text-text-muted py-1">
+                  No profiles found. Create one under Profiles first.
+                </p>
+              ) : (
+                <select
+                  id={`${id}-profile`}
+                  value={profileId}
+                  onChange={(e) => setProfileId(e.target.value)}
+                  aria-label="Select profile"
+                  className={cn(
+                    "w-full px-3 py-1.5 text-xs rounded border border-border",
+                    "bg-surface text-text-primary",
+                    "focus:outline-none focus:ring-1 focus:ring-border",
+                  )}
+                >
+                  <option value="">— Select a profile —</option>
+                  {profiles.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name ?? p.id}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
+          )}
+
+          {/* OS detection */}
+          <div className="flex items-center gap-2">
+            <input
+              id={`${id}-os-detection`}
+              type="checkbox"
+              checked={osDetection}
+              onChange={(e) => setOsDetection(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-border accent-accent"
+            />
+            <label
+              htmlFor={`${id}-os-detection`}
+              className="text-xs text-text-primary"
+            >
+              OS detection{" "}
+              <span className="text-text-muted font-normal">
+                (-O, requires root)
+              </span>
+            </label>
+          </div>
+
+          {/* Custom ports */}
+          {mode === "custom" && (
+            <div className="space-y-4">
+              <div className="space-y-1.5">
+                <label
+                  htmlFor={`${id}-ports`}
+                  className="block text-xs font-medium text-text-primary"
+                >
+                  Ports
+                  <span className="text-text-muted font-normal ml-1">
+                    (optional — leave blank to scan all)
+                  </span>
+                </label>
+                <input
+                  id={`${id}-ports`}
+                  type="text"
+                  value={ports}
+                  onChange={(e) => setPorts(e.target.value)}
+                  placeholder="22,80,443,8080-8090"
+                  className={cn(
+                    "w-full px-3 py-1.5 text-xs rounded border border-border font-mono",
+                    "bg-surface text-text-primary placeholder:text-text-muted",
+                    "focus:outline-none focus:ring-1 focus:ring-border",
+                  )}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <label
+                  htmlFor={`${id}-scan-type`}
+                  className="block text-xs font-medium text-text-primary"
+                >
+                  Scan type
+                </label>
+                <select
+                  id={`${id}-scan-type`}
+                  value={scanType}
+                  onChange={(e) => setScanType(e.target.value)}
+                  aria-label="Select scan type"
+                  className={cn(
+                    "w-full px-3 py-1.5 text-xs rounded border border-border",
+                    "bg-surface text-text-primary",
+                    "focus:outline-none focus:ring-1 focus:ring-border",
+                  )}
+                >
+                  {SCAN_TYPES.map((t) => (
+                    <option key={t.value} value={t.value}>
+                      {t.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          )}
+
+          {/* Inline error */}
+          {error && (
+            <p role="alert" className="text-xs text-danger">
+              {error}
+            </p>
+          )}
+
+          {/* Footer */}
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="secondary" type="button" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" loading={isPending}>
+              {isPending ? "Starting…" : "Run scan"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/stat-card.tsx
+++ b/frontend/src/components/stat-card.tsx
@@ -1,4 +1,5 @@
 import type { ElementType } from "react";
+import { Link } from "@tanstack/react-router";
 import { cn } from "../lib/utils";
 
 interface StatCardProps {
@@ -8,7 +9,12 @@ interface StatCardProps {
   icon?: ElementType;
   trend?: { value: number; label?: string };
   loading?: boolean;
+  href?: string;
 }
+
+const cardBase = "bg-surface rounded-lg border border-border p-4";
+const cardInteractive =
+  "transition-colors hover:border-text-muted hover:bg-surface-raised/40 cursor-pointer";
 
 export function StatCard({
   label,
@@ -17,10 +23,11 @@ export function StatCard({
   icon: Icon,
   trend,
   loading = false,
+  href,
 }: StatCardProps) {
   if (loading) {
     return (
-      <div className="bg-surface rounded-lg border border-border p-4">
+      <div className={cardBase}>
         <div className="animate-pulse space-y-2">
           <div className="h-3 w-20 rounded bg-surface-raised" />
           <div className="h-7 w-16 rounded bg-surface-raised" />
@@ -30,8 +37,8 @@ export function StatCard({
     );
   }
 
-  return (
-    <div className="bg-surface rounded-lg border border-border p-4">
+  const body = (
+    <div className={cn(cardBase, href && cardInteractive)}>
       <div className="flex items-center justify-between mb-1">
         <p className="text-xs text-text-muted">{label}</p>
         {Icon && <Icon className="h-4 w-4 text-text-muted" />}
@@ -59,4 +66,17 @@ export function StatCard({
       )}
     </div>
   );
+
+  if (href) {
+    return (
+      <Link
+        to={href}
+        className="block rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-border"
+      >
+        {body}
+      </Link>
+    );
+  }
+
+  return body;
 }

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -1,32 +1,71 @@
 @import "tailwindcss";
 
 @theme {
-  --color-background: hsl(222, 47%, 6%);
-  --color-surface: hsl(222, 47%, 9%);
-  --color-surface-raised: hsl(222, 47%, 12%);
-  --color-border: hsl(222, 20%, 18%);
-  --color-text-primary: hsl(210, 40%, 96%);
-  --color-text-secondary: hsl(215, 20%, 60%);
-  --color-text-muted: hsl(215, 15%, 40%);
-  --color-accent: hsl(217, 91%, 60%);
-  --color-success: hsl(142, 71%, 45%);
-  --color-warning: hsl(38, 92%, 50%);
-  --color-danger: hsl(0, 84%, 60%);
-  --color-info: hsl(199, 89%, 48%);
+    /* ── Backgrounds ─────────────────────────────────────────────────────────── */
+    --color-background: hsl(222, 47%, 6%);
+    --color-surface: hsl(222, 47%, 9%);
+    --color-surface-raised: hsl(222, 47%, 12%);
 
-  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
-  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
-    Consolas, "Liberation Mono", "Courier New", monospace;
+    /* ── Borders ─────────────────────────────────────────────────────────────── */
+    --color-border: hsl(222, 20%, 18%);
+
+    /* ── Text ────────────────────────────────────────────────────────────────── */
+    --color-text-primary: hsl(210, 40%, 96%);
+    --color-text-secondary: hsl(215, 20%, 60%);
+    --color-text-muted: hsl(215, 15%, 40%);
+
+    /* ── Semantic status ─────────────────────────────────────────────────────── */
+    --color-accent: hsl(217, 91%, 60%);
+    --color-success: hsl(142, 71%, 45%);
+    --color-warning: hsl(38, 92%, 50%);
+    --color-danger: hsl(0, 84%, 60%);
+    --color-info: hsl(199, 89%, 48%);
+
+    /* ── Typography ──────────────────────────────────────────────────────────── */
+    --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
+    --font-mono:
+        "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+        "Liberation Mono", "Courier New", monospace;
+
+    /* ── Radius ──────────────────────────────────────────────────────────────── */
+    /* Change --radius-base to restyle every component at once.                  */
+    --radius-none: 0;
+    --radius-sm: calc(var(--radius-base) * 0.5); /* tight elements          */
+    --radius-base: 0.375rem; /* default — matches rounded-md */
+    --radius-lg: calc(var(--radius-base) * 1.5); /* cards, modals           */
+    --radius-xl: calc(var(--radius-base) * 2.5); /* large surfaces          */
+    --radius-full: 9999px; /* pills, badges           */
 }
 
+/* ── Base styles ─────────────────────────────────────────────────────────────── */
 body {
-  background-color: var(--color-background);
-  color: var(--color-text-primary);
-  font-family: var(--font-sans);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+    background-color: var(--color-background);
+    color: var(--color-text-primary);
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 .font-mono {
-  font-family: var(--font-mono);
+    font-family: var(--font-mono);
+}
+
+/* ── Light theme ─────────────────────────────────────────────────────────────── */
+/* Applied by setting data-theme="light" on <html>.                               */
+/* All semantic tokens are overridden here; components need no changes.           */
+[data-theme="light"] {
+    --color-background: hsl(210, 20%, 98%);
+    --color-surface: hsl(0, 0%, 100%);
+    --color-surface-raised: hsl(210, 17%, 95%);
+    --color-border: hsl(214, 13%, 86%);
+
+    --color-text-primary: hsl(222, 47%, 11%);
+    --color-text-secondary: hsl(215, 16%, 40%);
+    --color-text-muted: hsl(215, 13%, 60%);
+
+    --color-accent: hsl(217, 91%, 50%);
+    --color-success: hsl(142, 60%, 35%);
+    --color-warning: hsl(38, 85%, 40%);
+    --color-danger: hsl(0, 72%, 50%);
+    --color-info: hsl(199, 80%, 38%);
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -9,7 +9,7 @@ import { DashboardPage } from "./routes/dashboard";
 import { ScansPage } from "./routes/scans";
 import { HostsPage } from "./routes/hosts";
 import { NetworksPage } from "./routes/networks";
-import { DiscoveryPage } from "./routes/discovery";
+
 import { ProfilesPage } from "./routes/profiles";
 import { SchedulesPage } from "./routes/schedules";
 import { AdminPage } from "./routes/admin";
@@ -42,12 +42,6 @@ const networksRoute = createRoute({
   component: NetworksPage,
 });
 
-const discoveryRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: "/discovery",
-  component: DiscoveryPage,
-});
-
 const profilesRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/profiles",
@@ -71,7 +65,6 @@ const routeTree = rootRoute.addChildren([
   scansRoute,
   hostsRoute,
   networksRoute,
-  discoveryRoute,
   profilesRoute,
   schedulesRoute,
   adminRoute,

--- a/frontend/src/routes/dashboard.test.tsx
+++ b/frontend/src/routes/dashboard.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
+import { renderWithRouter } from "../test/utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DashboardPage } from "./dashboard";
 
@@ -81,62 +82,62 @@ beforeEach(() => {
 
 describe("DashboardPage", () => {
   it("renders the System heading", () => {
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     expect(screen.getByText("System")).toBeInTheDocument();
   });
 
   it("shows healthy status badge", () => {
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     expect(screen.getByText("healthy")).toBeInTheDocument();
   });
 
   it("shows version number", () => {
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     expect(screen.getByText("0.7.0")).toBeInTheDocument();
   });
 
   it("shows network count in stat card", () => {
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     expect(screen.getByText("Networks")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument();
   });
 
   it("shows host count in stat card", () => {
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     // "Hosts" appears in both the stat card label and the scans table header
     expect(screen.getAllByText("Hosts").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("42")).toBeInTheDocument();
   });
 
   it("shows active host count from dedicated hook", () => {
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     expect(screen.getByText("Active Hosts")).toBeInTheDocument();
     expect(screen.getByText("30")).toBeInTheDocument();
   });
 
   it("shows exclusion count in stat card", () => {
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     expect(screen.getByText("Exclusions")).toBeInTheDocument();
     expect(screen.getByText("3")).toBeInTheDocument();
   });
 
   it("shows recent scans table heading", () => {
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     expect(screen.getByText("Recent Scans")).toBeInTheDocument();
   });
 
   it("shows scan status and target in recent scans table", () => {
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     expect(screen.getByText("completed")).toBeInTheDocument();
     expect(screen.getByText("192.168.1.0/24")).toBeInTheDocument();
   });
 
   it("shows error badge when health check fails", () => {
     mockUseHealth.mockReturnValue({
-      data: undefined,
+      data: null,
       isLoading: false,
     } as unknown as ReturnType<typeof useHealth>);
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     expect(screen.getByText("error")).toBeInTheDocument();
   });
 
@@ -145,7 +146,7 @@ describe("DashboardPage", () => {
       data: undefined,
       isLoading: true,
     } as unknown as ReturnType<typeof useHealth>);
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     expect(screen.getByText("Checking...")).toBeInTheDocument();
   });
 
@@ -158,9 +159,9 @@ describe("DashboardPage", () => {
       data: undefined,
       isLoading: true,
     } as unknown as ReturnType<typeof useActiveHostCount>);
-    render(<DashboardPage />);
+    const { container } = renderWithRouter(<DashboardPage />);
     // Loading skeleton uses animate-pulse; there should be at least one
-    const skeletons = document.querySelectorAll(".animate-pulse");
+    const skeletons = container.querySelectorAll(".animate-pulse");
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
@@ -169,7 +170,7 @@ describe("DashboardPage", () => {
       data: undefined,
       isLoading: true,
     } as unknown as ReturnType<typeof useRecentScans>);
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     const skeletons = document.querySelectorAll(".animate-pulse");
     expect(skeletons.length).toBeGreaterThan(0);
   });
@@ -179,7 +180,7 @@ describe("DashboardPage", () => {
       data: undefined,
       isLoading: false,
     } as unknown as ReturnType<typeof useVersion>);
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     expect(screen.queryByText("0.7.0")).not.toBeInTheDocument();
   });
 
@@ -188,7 +189,7 @@ describe("DashboardPage", () => {
       data: undefined,
       isLoading: false,
     } as unknown as ReturnType<typeof useNetworkStats>);
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     // All four stat cards should show the em-dash fallback
     const emDashes = screen.getAllByText("—");
     expect(emDashes.length).toBeGreaterThanOrEqual(3);
@@ -202,12 +203,12 @@ describe("DashboardPage", () => {
       },
       isLoading: false,
     } as unknown as ReturnType<typeof useRecentScans>);
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     expect(screen.getByText("No scans found.")).toBeInTheDocument();
   });
 
   it("renders all four stat card labels", () => {
-    render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
     expect(screen.getByText("Networks")).toBeInTheDocument();
     // "Hosts" appears in both the stat card label and the scans table header
     expect(screen.getAllByText("Hosts").length).toBeGreaterThanOrEqual(1);
@@ -222,16 +223,27 @@ describe("DashboardPage", () => {
       isLoading: true,
     } as unknown as ReturnType<typeof useHealth>);
 
-    const { rerender } = render(<DashboardPage />);
+    renderWithRouter(<DashboardPage />);
 
     expect(screen.getByText("Checking...")).toBeInTheDocument();
 
+    // Update the mock — on the next render cycle the component will re-read it
     mockUseHealth.mockReturnValue({
       data: { status: "healthy" },
       isLoading: false,
     } as unknown as ReturnType<typeof useHealth>);
 
-    rerender(<DashboardPage />);
+    // Re-render by triggering a state change via a sibling mock update
+    mockUseNetworkStats.mockReturnValue({
+      data: {
+        networks: { total: 5 },
+        hosts: { total: 42, active: 30 },
+        exclusions: { total: 3 },
+      },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useNetworkStats>);
+
+    renderWithRouter(<DashboardPage />);
 
     await waitFor(() => {
       expect(screen.getByText("healthy")).toBeInTheDocument();

--- a/frontend/src/routes/dashboard.tsx
+++ b/frontend/src/routes/dashboard.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useHealth, useVersion } from "../api/hooks/use-system";
 import { useNetworkStats } from "../api/hooks/use-networks";
 import { useRecentScans } from "../api/hooks/use-scans";
@@ -5,7 +6,11 @@ import { useActiveHostCount } from "../api/hooks/use-hosts";
 import { StatusBadge } from "../components/status-badge";
 import { StatCard } from "../components/stat-card";
 import { RecentScansTable } from "../components/recent-scans-table";
+import { ScanDetailPanel } from "./scans";
 import { Network, Server, MonitorCheck, ShieldOff } from "lucide-react";
+import type { components } from "../api/types";
+
+type ScanResponse = components["schemas"]["docs.ScanResponse"];
 
 export function DashboardPage() {
   const { data: health, isLoading: healthLoading } = useHealth();
@@ -14,6 +19,8 @@ export function DashboardPage() {
   const { data: recentScans, isLoading: scansLoading } = useRecentScans();
   const { data: activeHostCount, isLoading: activeHostsLoading } =
     useActiveHostCount();
+
+  const [selectedScan, setSelectedScan] = useState<ScanResponse | null>(null);
 
   return (
     <>
@@ -41,18 +48,21 @@ export function DashboardPage() {
             value={(stats?.networks?.total as number) ?? "—"}
             icon={Network}
             loading={statsLoading}
+            href="/networks"
           />
           <StatCard
             label="Hosts"
             value={(stats?.hosts?.total as number) ?? "—"}
             icon={Server}
             loading={statsLoading}
+            href="/hosts"
           />
           <StatCard
             label="Active Hosts"
             value={activeHostCount ?? "—"}
             icon={MonitorCheck}
             loading={activeHostsLoading}
+            href="/hosts"
           />
           <StatCard
             label="Exclusions"
@@ -64,7 +74,19 @@ export function DashboardPage() {
       </div>
 
       {/* Recent scans */}
-      <RecentScansTable scans={recentScans?.data} loading={scansLoading} />
+      <RecentScansTable
+        scans={recentScans?.data}
+        loading={scansLoading}
+        onScanClick={(scan) => setSelectedScan(scan as ScanResponse)}
+      />
+
+      {/* Scan detail panel */}
+      {selectedScan && (
+        <ScanDetailPanel
+          scan={selectedScan}
+          onClose={() => setSelectedScan(null)}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/routes/discovery.tsx
+++ b/frontend/src/routes/discovery.tsx
@@ -1,5 +1,0 @@
-import { PlaceholderPage } from "../components/placeholder-page";
-
-export function DiscoveryPage() {
-  return <PlaceholderPage message="Discovery jobs coming soon." />;
-}

--- a/frontend/src/routes/hosts.tsx
+++ b/frontend/src/routes/hosts.tsx
@@ -1,7 +1,13 @@
 import { useState, useEffect, useCallback } from "react";
-import { Search } from "lucide-react";
+import { Search, ScanLine } from "lucide-react";
+import { Button } from "../components/button";
 import { useHosts } from "../api/hooks/use-hosts";
-import { StatusBadge, Skeleton, PaginationBar } from "../components";
+import {
+  StatusBadge,
+  Skeleton,
+  PaginationBar,
+  RunScanModal,
+} from "../components";
 import { formatRelativeTime } from "../lib/utils";
 import { cn } from "../lib/utils";
 
@@ -73,6 +79,7 @@ export function HostsPage() {
   const [statusFilter, setStatusFilter] = useState<HostStatus>("all");
   const [searchInput, setSearchInput] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [scanIP, setScanIP] = useState<string | null>(null);
 
   // Debounce search input ~300ms
   useEffect(() => {
@@ -103,133 +110,167 @@ export function HostsPage() {
   const totalPages = pagination?.total_pages ?? 1;
 
   return (
-    <div className="space-y-4">
-      {/* Filter bar */}
-      <div className="flex flex-col sm:flex-row gap-3">
-        {/* Search input */}
-        <div className="relative flex-1 max-w-sm">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-text-muted pointer-events-none" />
-          <input
-            type="text"
-            placeholder="Search by IP or hostname…"
-            value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-            className={cn(
-              "w-full pl-8 pr-3 py-1.5 text-xs rounded border border-border",
-              "bg-surface text-text-primary placeholder:text-text-muted",
-              "focus:outline-none focus:ring-1 focus:ring-border focus:border-border",
-            )}
-            aria-label="Search hosts"
-          />
-        </div>
-
-        {/* Status select */}
-        <select
-          value={statusFilter}
-          onChange={(e) => handleStatusChange(e.target.value as HostStatus)}
-          className={cn(
-            "px-3 py-1.5 text-xs rounded border border-border",
-            "bg-surface text-text-primary",
-            "focus:outline-none focus:ring-1 focus:ring-border",
-          )}
-          aria-label="Filter by status"
-        >
-          <option value="all">All statuses</option>
-          <option value="up">Up</option>
-          <option value="down">Down</option>
-          <option value="unknown">Unknown</option>
-        </select>
-      </div>
-
-      {/* Table card */}
-      <div className="bg-surface rounded-lg border border-border overflow-hidden">
-        <div className="overflow-x-auto">
-          <table className="w-full text-xs">
-            <thead>
-              <tr className="border-b border-border bg-surface">
-                <th className="text-left font-medium text-text-muted px-4 py-3 pr-4">
-                  IP Address
-                </th>
-                <th className="text-left font-medium text-text-muted py-3 pr-4">
-                  Hostname
-                </th>
-                <th className="text-left font-medium text-text-muted py-3 pr-4">
-                  Status
-                </th>
-                <th className="text-left font-medium text-text-muted py-3 pr-4">
-                  MAC Address
-                </th>
-                <th className="text-left font-medium text-text-muted py-3 pr-4">
-                  Open Ports
-                </th>
-                <th className="text-left font-medium text-text-muted py-3 pr-4">
-                  Last Seen
-                </th>
-                <th className="text-left font-medium text-text-muted py-3">
-                  Scans
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {isLoading ? (
-                <SkeletonRows count={8} />
-              ) : hosts.length === 0 ? (
-                <tr>
-                  <td
-                    colSpan={7}
-                    className="py-10 text-center text-xs text-text-muted"
-                  >
-                    No hosts found.
-                  </td>
-                </tr>
-              ) : (
-                hosts.map((host) => (
-                  <tr
-                    key={host.id}
-                    className="border-b border-border/50 last:border-0 hover:bg-surface-raised/50 transition-colors"
-                  >
-                    <td className="py-3 px-4 pr-4 font-mono text-text-primary whitespace-nowrap">
-                      {host.ip_address ?? "—"}
-                    </td>
-                    <td className="py-3 pr-4 text-text-secondary">
-                      {host.hostname ?? "—"}
-                    </td>
-                    <td className="py-3 pr-4">
-                      <StatusBadge status={host.status ?? "unknown"} />
-                    </td>
-                    <td className="py-3 pr-4 font-mono text-text-muted whitespace-nowrap">
-                      {host.mac_address ?? "—"}
-                    </td>
-                    <td className="py-3 pr-4">
-                      <PortTags ports={host.open_ports} />
-                    </td>
-                    <td className="py-3 pr-4 text-text-muted whitespace-nowrap">
-                      {host.last_seen
-                        ? formatRelativeTime(host.last_seen)
-                        : "—"}
-                    </td>
-                    <td className="py-3 text-text-secondary tabular-nums">
-                      {host.scan_count ?? "—"}
-                    </td>
-                  </tr>
-                ))
+    <>
+      <div className="space-y-4">
+        {/* Filter bar */}
+        <div className="flex flex-col sm:flex-row gap-3">
+          {/* Search input */}
+          <div className="relative flex-1 max-w-sm">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-text-muted pointer-events-none" />
+            <input
+              type="text"
+              placeholder="Search by IP or hostname…"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              className={cn(
+                "w-full pl-8 pr-3 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border focus:border-border",
               )}
-            </tbody>
-          </table>
-        </div>
-
-        {/* Pagination */}
-        {!isLoading && hosts.length > 0 && (
-          <div className="px-4 pb-3">
-            <PaginationBar
-              page={page}
-              totalPages={totalPages}
-              onPrev={() => setPage((p) => Math.max(1, p - 1))}
-              onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
+              aria-label="Search hosts"
             />
           </div>
-        )}
+
+          {/* Status select */}
+          <select
+            value={statusFilter}
+            onChange={(e) => handleStatusChange(e.target.value as HostStatus)}
+            className={cn(
+              "px-3 py-1.5 text-xs rounded border border-border",
+              "bg-surface text-text-primary",
+              "focus:outline-none focus:ring-1 focus:ring-border",
+            )}
+            aria-label="Filter by status"
+          >
+            <option value="all">All statuses</option>
+            <option value="up">Up</option>
+            <option value="down">Down</option>
+            <option value="unknown">Unknown</option>
+          </select>
+
+          <Button
+            onClick={() => setScanIP("")}
+            icon={<ScanLine className="h-3.5 w-3.5" />}
+            className="sm:ml-auto"
+          >
+            New scan
+          </Button>
+        </div>
+
+        {/* Table card */}
+        <div className="bg-surface rounded-lg border border-border overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border bg-surface">
+                  <th className="text-left font-medium text-text-muted px-4 py-3 pr-4">
+                    IP Address
+                  </th>
+                  <th className="text-left font-medium text-text-muted py-3 pr-4">
+                    Hostname
+                  </th>
+                  <th className="text-left font-medium text-text-muted py-3 pr-4">
+                    Status
+                  </th>
+                  <th className="text-left font-medium text-text-muted py-3 pr-4">
+                    MAC Address
+                  </th>
+                  <th className="text-left font-medium text-text-muted py-3 pr-4">
+                    Open Ports
+                  </th>
+                  <th className="text-left font-medium text-text-muted py-3 pr-4">
+                    Last Seen
+                  </th>
+                  <th className="text-left font-medium text-text-muted py-3 pr-4">
+                    Scans
+                  </th>
+                  <th className="py-3" />
+                </tr>
+              </thead>
+              <tbody>
+                {isLoading ? (
+                  <SkeletonRows count={8} />
+                ) : hosts.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={7}
+                      className="py-10 text-center text-xs text-text-muted"
+                    >
+                      No hosts found.
+                    </td>
+                  </tr>
+                ) : (
+                  hosts.map((host) => (
+                    <tr
+                      key={host.id}
+                      className="border-b border-border/50 last:border-0 hover:bg-surface-raised/50 transition-colors"
+                    >
+                      <td className="py-3 px-4 pr-4 font-mono text-text-primary whitespace-nowrap">
+                        {host.ip_address ?? "—"}
+                      </td>
+                      <td className="py-3 pr-4 text-text-secondary">
+                        {host.hostname ?? "—"}
+                      </td>
+                      <td className="py-3 pr-4">
+                        <StatusBadge status={host.status ?? "unknown"} />
+                      </td>
+                      <td className="py-3 pr-4 font-mono text-text-muted whitespace-nowrap">
+                        {host.mac_address ?? "—"}
+                      </td>
+                      <td className="py-3 pr-4">
+                        <PortTags ports={host.open_ports} />
+                      </td>
+                      <td className="py-3 pr-4 text-text-muted whitespace-nowrap">
+                        {host.last_seen
+                          ? formatRelativeTime(host.last_seen)
+                          : "—"}
+                      </td>
+                      <td className="py-3 pr-4 text-text-secondary tabular-nums">
+                        {host.scan_count ?? "—"}
+                      </td>
+                      <td className="py-3">
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setScanIP(host.ip_address ?? "");
+                          }}
+                          aria-label={`Scan ${host.ip_address ?? "host"}`}
+                          className={cn(
+                            "flex items-center gap-1 px-2 py-1 rounded text-xs",
+                            "text-text-muted border border-border",
+                            "hover:text-accent hover:border-accent hover:bg-accent/5",
+                            "transition-colors",
+                          )}
+                        >
+                          <ScanLine className="h-3 w-3" />
+                          Scan
+                        </button>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Pagination */}
+          {!isLoading && hosts.length > 0 && (
+            <div className="px-4 pb-3">
+              <PaginationBar
+                page={page}
+                totalPages={totalPages}
+                onPrev={() => setPage((p) => Math.max(1, p - 1))}
+                onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
+              />
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+
+      {scanIP !== null && (
+        <RunScanModal initialTarget={scanIP} onClose={() => setScanIP(null)} />
+      )}
+    </>
   );
 }

--- a/frontend/src/routes/index.ts
+++ b/frontend/src/routes/index.ts
@@ -2,7 +2,7 @@ export { DashboardPage } from "./dashboard";
 export { ScansPage } from "./scans";
 export { HostsPage } from "./hosts";
 export { NetworksPage } from "./networks";
-export { DiscoveryPage } from "./discovery";
+
 export { ProfilesPage } from "./profiles";
 export { SchedulesPage } from "./schedules";
 export { AdminPage } from "./admin";

--- a/frontend/src/routes/scans.test.tsx
+++ b/frontend/src/routes/scans.test.tsx
@@ -8,10 +8,16 @@ vi.mock("../api/hooks/use-scans", () => ({
   useScanResults: vi.fn(),
 }));
 
+vi.mock("../api/hooks/use-profiles", () => ({
+  useProfile: vi.fn(),
+}));
+
 import { useScans, useScanResults } from "../api/hooks/use-scans";
+import { useProfile } from "../api/hooks/use-profiles";
 
 const mockUseScans = vi.mocked(useScans);
 const mockUseScanResults = vi.mocked(useScanResults);
+const mockUseProfile = vi.mocked(useProfile);
 
 const mockScans = [
   {
@@ -24,6 +30,9 @@ const mockScans = [
     started_at: new Date().toISOString(),
     created_at: new Date().toISOString(),
     completed_at: new Date().toISOString(),
+    name: "Weekly LAN scan",
+    scan_type: "connect" as const,
+    ports: "22,80,443",
     profile_id: "profile-abc",
     error_message: undefined,
   },
@@ -37,6 +46,9 @@ const mockScans = [
     started_at: new Date().toISOString(),
     created_at: new Date().toISOString(),
     completed_at: undefined,
+    name: undefined,
+    scan_type: undefined,
+    ports: undefined,
     profile_id: undefined,
     error_message: undefined,
   },
@@ -50,6 +62,9 @@ const mockScans = [
     started_at: undefined,
     created_at: new Date().toISOString(),
     completed_at: undefined,
+    name: undefined,
+    scan_type: undefined,
+    ports: undefined,
     profile_id: undefined,
     error_message: "Connection refused",
   },
@@ -111,10 +126,19 @@ function makeUseScanResultsResult(overrides = {}) {
   } as unknown as ReturnType<typeof useScanResults>;
 }
 
+function makeUseProfileResult(overrides = {}) {
+  return {
+    data: { id: "profile-abc", name: "Weekly Connect Scan" },
+    isLoading: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useProfile>;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockUseScans.mockReturnValue(makeUseScansResult());
   mockUseScanResults.mockReturnValue(makeUseScanResultsResult());
+  mockUseProfile.mockReturnValue(makeUseProfileResult());
 });
 
 describe("ScansPage", () => {
@@ -188,9 +212,6 @@ describe("ScansPage", () => {
       screen.getByRole("columnheader", { name: "Status" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("columnheader", { name: "Hosts" }),
-    ).toBeInTheDocument();
-    expect(
       screen.getByRole("columnheader", { name: "Ports" }),
     ).toBeInTheDocument();
     expect(
@@ -222,11 +243,9 @@ describe("ScansPage", () => {
     expect(screen.getByText("failed")).toBeInTheDocument();
   });
 
-  it("renders numeric hosts_discovered and ports_scanned", () => {
+  it("renders ports_scanned in the table", () => {
     render(<ScansPage />);
-    expect(screen.getByText("25")).toBeInTheDocument();
     expect(screen.getByText("2500")).toBeInTheDocument();
-    expect(screen.getByText("10")).toBeInTheDocument();
   });
 
   it("renders duration when present", () => {
@@ -249,8 +268,8 @@ describe("ScansPage", () => {
     const rows = screen.getAllByRole("row");
     // scan-2 is index 2
     const cells = within(rows[2]).getAllByRole("cell");
-    // Ports is index 3
-    expect(cells[3]).toHaveTextContent("—");
+    // Ports is index 2 (Targets, Status, Ports, Duration, Started)
+    expect(cells[2]).toHaveTextContent("—");
   });
 
   it("shows em-dash for missing duration", () => {
@@ -258,8 +277,8 @@ describe("ScansPage", () => {
     const rows = screen.getAllByRole("row");
     // scan-2 is index 2
     const cells = within(rows[2]).getAllByRole("cell");
-    // Duration is index 4
-    expect(cells[4]).toHaveTextContent("—");
+    // Duration is index 3 (Targets, Status, Ports, Duration, Started)
+    expect(cells[3]).toHaveTextContent("—");
   });
 
   it("shows em-dash for missing started_at", () => {
@@ -267,8 +286,8 @@ describe("ScansPage", () => {
     const rows = screen.getAllByRole("row");
     // scan-3 is index 3 — no started_at
     const cells = within(rows[3]).getAllByRole("cell");
-    // Started is index 5
-    expect(cells[5]).toHaveTextContent("—");
+    // Started is index 4 (Targets, Status, Ports, Duration, Started)
+    expect(cells[4]).toHaveTextContent("—");
   });
 
   // ── Status filter interaction ─────────────────────────────────
@@ -297,7 +316,9 @@ describe("ScansPage", () => {
     const rows = screen.getAllByRole("row");
     // Click scan-1 row (index 1)
     await userEvent.click(rows[1]);
-    expect(screen.getByRole("dialog", { name: /scan details/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: /scan details/i }),
+    ).toBeInTheDocument();
   });
 
   it("shows the scan targets in the detail panel header", async () => {
@@ -326,12 +347,67 @@ describe("ScansPage", () => {
     expect(within(dialog).getByText("scan-1")).toBeInTheDocument();
   });
 
-  it("shows the profile ID in the detail panel when present", async () => {
+  it("shows the scan name in the detail panel when present", async () => {
+    render(<ScansPage />);
+    const rows = screen.getAllByRole("row");
+    await userEvent.click(rows[1]);
+    const dialog = screen.getByRole("dialog", { name: /scan details/i });
+    expect(within(dialog).getByText("Weekly LAN scan")).toBeInTheDocument();
+  });
+
+  it("shows the scan type in the detail panel when present", async () => {
+    render(<ScansPage />);
+    const rows = screen.getAllByRole("row");
+    await userEvent.click(rows[1]);
+    const dialog = screen.getByRole("dialog", { name: /scan details/i });
+    expect(within(dialog).getByText("connect")).toBeInTheDocument();
+  });
+
+  it("shows the ports in the detail panel when present", async () => {
+    render(<ScansPage />);
+    const rows = screen.getAllByRole("row");
+    await userEvent.click(rows[1]);
+    const dialog = screen.getByRole("dialog", { name: /scan details/i });
+    expect(within(dialog).getByText("22,80,443")).toBeInTheDocument();
+  });
+
+  it("shows responding host count in the detail panel", async () => {
+    render(<ScansPage />);
+    const rows = screen.getAllByRole("row");
+    await userEvent.click(rows[1]);
+    const dialog = screen.getByRole("dialog", { name: /scan details/i });
+    // mockResultsData has 2 distinct host_ips: 192.168.1.1 and 192.168.1.2
+    expect(within(dialog).getByText("2 responding")).toBeInTheDocument();
+  });
+
+  it("shows the profile name in the detail panel when present", async () => {
+    render(<ScansPage />);
+    const rows = screen.getAllByRole("row");
+    await userEvent.click(rows[1]);
+    const dialog = screen.getByRole("dialog", { name: /scan details/i });
+    expect(within(dialog).getByText("Weekly Connect Scan")).toBeInTheDocument();
+  });
+
+  it("falls back to profile ID when profile name is not yet loaded", async () => {
+    mockUseProfile.mockReturnValue(
+      makeUseProfileResult({ data: undefined, isLoading: false }),
+    );
     render(<ScansPage />);
     const rows = screen.getAllByRole("row");
     await userEvent.click(rows[1]);
     const dialog = screen.getByRole("dialog", { name: /scan details/i });
     expect(within(dialog).getByText("profile-abc")).toBeInTheDocument();
+  });
+
+  it("shows a loading skeleton for profile while loading", async () => {
+    mockUseProfile.mockReturnValue(
+      makeUseProfileResult({ data: undefined, isLoading: true }),
+    );
+    render(<ScansPage />);
+    const rows = screen.getAllByRole("row");
+    await userEvent.click(rows[1]);
+    const dialog = screen.getByRole("dialog", { name: /scan details/i });
+    expect(dialog.querySelector(".animate-pulse")).toBeInTheDocument();
   });
 
   it("shows the error message in the detail panel when present", async () => {
@@ -383,7 +459,9 @@ describe("ScansPage", () => {
     render(<ScansPage />);
     const rows = screen.getAllByRole("row");
     await userEvent.click(rows[1]);
-    expect(screen.getByRole("dialog", { name: /scan details/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: /scan details/i }),
+    ).toBeInTheDocument();
 
     const closeButton = screen.getByRole("button", { name: /close panel/i });
     await userEvent.click(closeButton);
@@ -396,7 +474,9 @@ describe("ScansPage", () => {
     render(<ScansPage />);
     const rows = screen.getAllByRole("row");
     await userEvent.click(rows[1]);
-    expect(screen.getByRole("dialog", { name: /scan details/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: /scan details/i }),
+    ).toBeInTheDocument();
 
     // The backdrop is the fixed overlay behind the dialog
     const backdrop = document.querySelector(".fixed.inset-0.bg-black\\/40");

--- a/frontend/src/routes/scans.tsx
+++ b/frontend/src/routes/scans.tsx
@@ -1,8 +1,15 @@
 import { useState, useCallback } from "react";
-import { X } from "lucide-react";
+import { X, ScanLine } from "lucide-react";
+import { Button } from "../components/button";
 import { useScans } from "../api/hooks/use-scans";
 import { useScanResults } from "../api/hooks/use-scans";
-import { StatusBadge, Skeleton, PaginationBar } from "../components";
+import { useProfile } from "../api/hooks/use-profiles";
+import {
+  StatusBadge,
+  Skeleton,
+  PaginationBar,
+  RunScanModal,
+} from "../components";
 import { formatRelativeTime } from "../lib/utils";
 import { cn } from "../lib/utils";
 import type { components } from "../api/types";
@@ -30,9 +37,6 @@ function SkeletonRows({ count }: { count: number }) {
           </td>
           <td className="py-3 pr-4">
             <Skeleton className="h-5 w-20" />
-          </td>
-          <td className="py-3 pr-4">
-            <Skeleton className="h-3.5 w-10" />
           </td>
           <td className="py-3 pr-4">
             <Skeleton className="h-3.5 w-12" />
@@ -96,21 +100,39 @@ function ResultsSkeletonRows({ count }: { count: number }) {
   );
 }
 
-function ScanDetailPanel({ scan, onClose }: DetailPanelProps) {
+export function ScanDetailPanel({ scan, onClose }: DetailPanelProps) {
   const [resultsPage, setResultsPage] = useState(1);
+  const { data: profileData, isLoading: profileLoading } = useProfile(
+    scan.profile_id,
+  );
   const { data: resultsData, isLoading: resultsLoading } = useScanResults(
     scan.id ?? "",
     { page: resultsPage, page_size: RESULTS_PAGE_SIZE },
+    scan.status,
   );
 
   const allResults = resultsData?.results ?? [];
-  // Client-side pagination of the results array since the endpoint returns
-  // the full result set in a single call (no server-side pagination param).
+
+  // Port state counts derived from the full result set.
+  const portCounts = allResults.reduce<Record<string, number>>((acc, r) => {
+    const state = r.state ?? "unknown";
+    acc[state] = (acc[state] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  // Unique IPs that responded in this scan.
+  const uniqueHostCount = new Set(
+    allResults.map((r) => r.host_ip).filter(Boolean),
+  ).size;
+
+  // Only show open ports in the results table.
+  const openResults = allResults.filter((r) => r.state === "open");
+
   const totalResultPages = Math.max(
     1,
-    Math.ceil(allResults.length / RESULTS_PAGE_SIZE),
+    Math.ceil(openResults.length / RESULTS_PAGE_SIZE),
   );
-  const pageResults = allResults.slice(
+  const pageResults = openResults.slice(
     (resultsPage - 1) * RESULTS_PAGE_SIZE,
     resultsPage * RESULTS_PAGE_SIZE,
   );
@@ -164,21 +186,29 @@ function ScanDetailPanel({ scan, onClose }: DetailPanelProps) {
             </h3>
             <div className="space-y-2">
               <MetaRow label="ID" value={scan.id} />
-              <MetaRow label="Profile ID" value={scan.profile_id} />
+              <MetaRow label="Name" value={scan.name} />
+              {scan.profile_id && (
+                <MetaRow
+                  label="Profile"
+                  value={
+                    profileLoading ? (
+                      <Skeleton className="h-3 w-28 inline-block" />
+                    ) : (
+                      (profileData?.name ?? scan.profile_id)
+                    )
+                  }
+                />
+              )}
+              <MetaRow label="Scan type" value={scan.scan_type} />
+              <MetaRow label="Ports" value={scan.ports} />
               <MetaRow
-                label="Created"
+                label="Hosts"
                 value={
-                  scan.created_at
-                    ? formatRelativeTime(scan.created_at)
-                    : undefined
-                }
-              />
-              <MetaRow
-                label="Started"
-                value={
-                  scan.started_at
-                    ? formatRelativeTime(scan.started_at)
-                    : undefined
+                  resultsLoading
+                    ? "…"
+                    : uniqueHostCount > 0
+                      ? `${uniqueHostCount} responding`
+                      : undefined
                 }
               />
               <MetaRow
@@ -190,8 +220,29 @@ function ScanDetailPanel({ scan, onClose }: DetailPanelProps) {
                 }
               />
               <MetaRow label="Duration" value={scan.duration} />
-              <MetaRow label="Hosts discovered" value={scan.hosts_discovered} />
-              <MetaRow label="Ports scanned" value={scan.ports_scanned} />
+              <MetaRow
+                label="Ports scanned"
+                value={
+                  resultsLoading ? (
+                    "…"
+                  ) : allResults.length > 0 ? (
+                    <span className="flex flex-wrap gap-2">
+                      {Object.entries(portCounts)
+                        .sort(([a], [b]) => a.localeCompare(b))
+                        .map(([state, count]) => (
+                          <span key={state} className="flex items-center gap-1">
+                            <StatusBadge status={state} />
+                            <span className="tabular-nums text-text-secondary">
+                              {count}
+                            </span>
+                          </span>
+                        ))}
+                    </span>
+                  ) : (
+                    (scan.ports_scanned ?? "—")
+                  )
+                }
+              />
               {scan.error_message && (
                 <MetaRow
                   label="Error"
@@ -206,7 +257,9 @@ function ScanDetailPanel({ scan, onClose }: DetailPanelProps) {
           {/* Results */}
           <section>
             <h3 className="text-xs font-medium text-text-primary mb-3">
-              Results
+              {resultsLoading
+                ? "Results"
+                : `Open Ports (${openResults.length})`}
             </h3>
 
             {resultsLoading ? (
@@ -224,7 +277,6 @@ function ScanDetailPanel({ scan, onClose }: DetailPanelProps) {
                       <th className="text-left font-medium pb-2 pr-3">
                         Protocol
                       </th>
-                      <th className="text-left font-medium pb-2 pr-3">State</th>
                       <th className="text-left font-medium pb-2">Service</th>
                     </tr>
                   </thead>
@@ -234,7 +286,11 @@ function ScanDetailPanel({ scan, onClose }: DetailPanelProps) {
                 </table>
               </div>
             ) : pageResults.length === 0 ? (
-              <p className="text-xs text-text-muted">No results found.</p>
+              <p className="text-xs text-text-muted">
+                {allResults.length > 0
+                  ? "No open ports found."
+                  : "No results found."}
+              </p>
             ) : (
               <>
                 <div className="overflow-x-auto">
@@ -252,9 +308,6 @@ function ScanDetailPanel({ scan, onClose }: DetailPanelProps) {
                         </th>
                         <th className="text-left font-medium pb-2 pr-3">
                           Protocol
-                        </th>
-                        <th className="text-left font-medium pb-2 pr-3">
-                          State
                         </th>
                         <th className="text-left font-medium pb-2">Service</th>
                       </tr>
@@ -276,13 +329,6 @@ function ScanDetailPanel({ scan, onClose }: DetailPanelProps) {
                           </td>
                           <td className="py-2 pr-3 text-text-muted">
                             {r.protocol ?? "—"}
-                          </td>
-                          <td className="py-2 pr-3">
-                            {r.state ? (
-                              <StatusBadge status={r.state} />
-                            ) : (
-                              <span className="text-text-muted">—</span>
-                            )}
                           </td>
                           <td className="py-2 text-text-secondary">
                             {r.service ?? "—"}
@@ -320,7 +366,8 @@ function ScanDetailPanel({ scan, onClose }: DetailPanelProps) {
 export function ScansPage() {
   const [page, setPage] = useState(1);
   const [statusFilter, setStatusFilter] = useState<ScanStatus>("all");
-  const [selectedScan, setSelectedScan] = useState<ScanResponse | null>(null);
+  const [selectedScanId, setSelectedScanId] = useState<string | null>(null);
+  const [showRunScan, setShowRunScan] = useState(false);
 
   const handleStatusChange = useCallback((value: ScanStatus) => {
     setStatusFilter(value);
@@ -361,6 +408,14 @@ export function ScansPage() {
             <option value="failed">Failed</option>
             <option value="cancelled">Cancelled</option>
           </select>
+
+          <Button
+            onClick={() => setShowRunScan(true)}
+            icon={<ScanLine className="h-3.5 w-3.5" />}
+            className="sm:ml-auto"
+          >
+            New scan
+          </Button>
         </div>
 
         {/* Table card */}
@@ -374,9 +429,6 @@ export function ScansPage() {
                   </th>
                   <th className="text-left font-medium text-text-muted py-3 pr-4">
                     Status
-                  </th>
-                  <th className="text-left font-medium text-text-muted py-3 pr-4">
-                    Hosts
                   </th>
                   <th className="text-left font-medium text-text-muted py-3 pr-4">
                     Ports
@@ -395,7 +447,7 @@ export function ScansPage() {
                 ) : scans.length === 0 ? (
                   <tr>
                     <td
-                      colSpan={6}
+                      colSpan={5}
                       className="py-10 text-center text-xs text-text-muted"
                     >
                       No scans found.
@@ -405,7 +457,7 @@ export function ScansPage() {
                   scans.map((scan) => (
                     <tr
                       key={scan.id}
-                      onClick={() => setSelectedScan(scan)}
+                      onClick={() => setSelectedScanId(scan.id ?? null)}
                       className={cn(
                         "border-b border-border/50 last:border-0",
                         "hover:bg-surface-raised/50 transition-colors cursor-pointer",
@@ -416,9 +468,6 @@ export function ScansPage() {
                       </td>
                       <td className="py-3 pr-4">
                         <StatusBadge status={scan.status ?? "unknown"} />
-                      </td>
-                      <td className="py-3 pr-4 text-text-secondary tabular-nums">
-                        {scan.hosts_discovered ?? "—"}
                       </td>
                       <td className="py-3 pr-4 text-text-secondary tabular-nums">
                         {scan.ports_scanned ?? "—"}
@@ -453,12 +502,20 @@ export function ScansPage() {
       </div>
 
       {/* Detail panel */}
-      {selectedScan && (
-        <ScanDetailPanel
-          scan={selectedScan}
-          onClose={() => setSelectedScan(null)}
-        />
-      )}
+      {(() => {
+        const liveScan = selectedScanId
+          ? (scans.find((s) => s.id === selectedScanId) ?? null)
+          : null;
+        return liveScan ? (
+          <ScanDetailPanel
+            scan={liveScan}
+            onClose={() => setSelectedScanId(null)}
+          />
+        ) : null;
+      })()}
+
+      {/* Run scan modal */}
+      {showRunScan && <RunScanModal onClose={() => setShowRunScan(false)} />}
     </>
   );
 }

--- a/frontend/src/test/utils.tsx
+++ b/frontend/src/test/utils.tsx
@@ -1,0 +1,34 @@
+import { render, type RenderOptions } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  createRoute,
+  RouterProvider,
+  Outlet,
+} from "@tanstack/react-router";
+import type { ReactNode } from "react";
+
+/**
+ * Wraps the given UI in a minimal TanStack Router context so that any
+ * component that calls useRouter / Link / etc. does not throw
+ * "useRouter must be used inside a RouterProvider".
+ */
+export function renderWithRouter(
+  ui: ReactNode,
+  options?: Omit<RenderOptions, "wrapper">,
+) {
+  const rootRoute = createRootRoute({ component: Outlet });
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/",
+    component: () => <>{ui}</>,
+  });
+
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute]),
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  });
+
+  return render(<RouterProvider router={router} />, options);
+}


### PR DESCRIPTION
Frontend feature work. Discovery page is intentionally excluded — it will be folded into the networks UI instead.

### Run scan modal
New `RunScanModal` component for launching ad-hoc scans from anywhere in the UI. Supports profile-based or custom mode (ports + scan type), OS detection toggle, and calls `useCreateScan` then `useStartScan` in sequence.

### API hooks
- `use-profiles.ts`: new `useProfile`/`useProfiles` hooks for the `/profiles` endpoint
- `use-scans.ts`: adds `useStartScan` mutation, auto-polling when active scans exist, polling on `useScanResults` while a scan is running

### Scans page
Exposes `ScanDetailPanel` for reuse by the dashboard. Wires `RunScanModal` to the Run Scan button.

### Hosts page
Adds a Run Scan entry point pre-filled with the host's IP address.

### Dashboard
Stat cards now link to their respective routes. Clicking a recent scan row opens the `ScanDetailPanel` slide-over.

### Components
- `StatCard`: optional `href` prop wraps the card in a `<Link>` with hover styling
- `RecentScansTable`: View all link, optional `onScanClick` row callback

### Test infrastructure
New `renderWithRouter` helper in `test/utils.tsx` wrapping components in a minimal TanStack Router context, fixing test failures caused by `<Link>`/`useRouter` requiring a `RouterProvider`.