### PR TITLE
fix: show correct version in API and frontend

### DIFF
--- a/FRONTEND_PLAN.md
+++ b/FRONTEND_PLAN.md
@@ -1,0 +1,666 @@
+# Scanorama Frontend Development Plan
+
+> **Status:** Draft — not for git commit  
+> **Date:** 2026-03-14  
+> **Starting point:** v0.13.0 (pre-frontend milestone)
+
+---
+
+## Table of Contents
+
+1. [Goals & Constraints](#1-goals--constraints)
+2. [Framework Decision](#2-framework-decision)
+3. [Look & Feel](#3-look--feel)
+4. [Project Structure](#4-project-structure)
+5. [API Client Strategy](#5-api-client-strategy)
+6. [Local Development & Testing](#6-local-development--testing)
+7. [Iteration Plan](#7-iteration-plan)
+8. [Open Questions](#8-open-questions)
+
+---
+
+## 1. Goals & Constraints
+
+### What the frontend needs to do
+
+Scanorama is a network scanning and discovery tool. The frontend is an **operator dashboard** — used by network admins and security engineers to monitor their infrastructure, kick off scans, and investigate results. It is not a consumer-facing app with millions of users; it's a professional tool that prioritizes **clarity, density, and speed** over flash.
+
+### Core use cases
+
+| Priority | Use Case |
+|----------|----------|
+| P0 | View discovered hosts and their open ports/services |
+| P0 | Start/stop scans and monitor progress in real time |
+| P0 | View and manage networks (add, exclude ranges, enable/disable) |
+| P1 | Manage scan profiles and schedules |
+| P1 | Dashboard with aggregate stats (host count, scan activity, network health) |
+| P1 | View scan history and compare results over time |
+| P2 | Admin panel (worker status, config, logs) |
+| P2 | WebSocket-powered live scan progress |
+
+### Constraints
+
+- **Single-page app** served by the Go backend (embedded in the binary for production)
+- **No SSR needed** — this is a tool, not a content site
+- **API is the contract** — 48 REST endpoints already documented in OpenAPI/Swagger 2.0
+- **Auth is optional** — API key auth exists but is off by default in dev
+- **Target browsers:** Latest Chrome, Firefox, Safari (no IE, no legacy)
+- **Solo developer / small team** — framework choice should minimize boilerplate and maximize velocity
+
+---
+
+## 2. Framework Decision
+
+### Candidates evaluated
+
+| | React + Vite | Vue 3 + Vite | Svelte 5 + Vite |
+|---|---|---|---|
+| **Ecosystem size** | Largest | Large | Growing |
+| **Component libraries** | Extensive (shadcn, Radix, etc.) | Good (PrimeVue, Naive UI) | Limited |
+| **TypeScript** | First-class | First-class | First-class |
+| **Bundle size** | ~45 KB (React + ReactDOM) | ~33 KB | ~8 KB |
+| **Learning curve** | Moderate (hooks, JSX) | Low (SFC, template syntax) | Low (runes) |
+| **Data table ecosystem** | TanStack Table (excellent) | TanStack Table / AG Grid | TanStack Table |
+| **Existing project assets** | Reference React hooks in `docs/api/client.js` | Reference Vue composables in `docs/api/client.js` | None |
+| **OpenAPI codegen** | `openapi-typescript` + `openapi-fetch` | Same tooling works | Same tooling works |
+| **Go embed compatibility** | `vite build` → `dist/` → `embed.FS` | Same | Same |
+
+### Decision: **React 19 + Vite 6 + TypeScript**
+
+**Rationale:**
+
+1. **Component library:** We're going with [shadcn/ui](https://ui.shadcn.com/) — it gives us unstyled, composable Radix-based primitives with Tailwind styling. Perfect for a data-dense dashboard. No runtime dependency, components are copied into the project and owned by us.
+
+2. **Data tables:** TanStack Table v8 has first-class React support and handles sorting, filtering, pagination, column resizing, and virtual scrolling — all critical for host/port/scan lists that can have thousands of rows.
+
+3. **Existing assets:** The reference client in `docs/api/client.js` already has React hooks (`useScans`, `useHosts`) and the quickstart guide has React component examples. Less throwaway work.
+
+4. **Ecosystem depth:** For a data-heavy dashboard, React's ecosystem is unmatched — charting (Recharts), maps, virtualization, accessibility.
+
+5. **Hiring/collaboration:** If the team grows, React developers are the easiest to find.
+
+### Key dependencies
+
+| Package | Purpose | Version |
+|---------|---------|---------|
+| `react` / `react-dom` | UI framework | 19.x |
+| `vite` | Build tool / dev server | 6.x |
+| `typescript` | Type safety | 5.x |
+| `tailwindcss` | Utility-first CSS | 4.x |
+| `@tanstack/react-router` | File-based routing, type-safe | 1.x |
+| `@tanstack/react-query` | Server state management, caching, polling | 5.x |
+| `@tanstack/react-table` | Headless data tables | 8.x |
+| `openapi-typescript` | Generate types from Swagger spec | 7.x |
+| `openapi-fetch` | Type-safe fetch client from generated types | 0.x |
+| `recharts` | Charting (dashboard stats) | 2.x |
+| `lucide-react` | Icons | latest |
+| `tailwind-merge` + `clsx` | Conditional class merging (shadcn pattern) | latest |
+| `zod` | Form validation | 3.x |
+
+**Not using:** Redux (TanStack Query handles server state; React context handles the little local state we need), Next.js (no SSR needed), Storybook (overkill for our scale at this stage).
+
+---
+
+## 3. Look & Feel
+
+### Design direction: **Dense, professional, dark-first**
+
+This is a network operations tool. Think Grafana, Datadog, or pgAdmin — not a marketing site.
+
+### Design principles
+
+1. **Information density over whitespace.** Operators want to see data, not padding. Tables should be tight. Cards should pack information.
+
+2. **Dark mode is the default.** Network tools are used in SOCs and server rooms. Light mode available but dark is primary.
+
+3. **Color is functional, not decorative.** Green = healthy/up/open. Red = failed/down/critical. Yellow = warning/pending. Blue = informational/running. Gray = inactive/unknown.
+
+4. **Typography is for scanning, not reading.** Monospace for IPs, ports, CIDRs, timestamps. Sans-serif (Inter) for labels and headings. Small font sizes are fine — this audience is comfortable with dense UIs.
+
+5. **Progressive disclosure.** Summary → detail. Table row → slide-out panel or detail page. Don't dump everything on screen at once, but don't hide it behind too many clicks either.
+
+### Color system
+
+```
+Background:     hsl(222, 47%, 6%)     — near-black navy
+Surface:        hsl(222, 47%, 9%)     — card/panel background  
+Surface raised: hsl(222, 47%, 12%)    — hover states, modals
+Border:         hsl(222, 20%, 18%)    — subtle borders
+
+Text primary:   hsl(210, 40%, 96%)    — almost white
+Text secondary: hsl(215, 20%, 60%)    — muted labels
+Text muted:     hsl(215, 15%, 40%)    — timestamps, metadata
+
+Accent:         hsl(217, 91%, 60%)    — primary actions, links
+Success:        hsl(142, 71%, 45%)    — up, healthy, open
+Warning:        hsl(38, 92%, 50%)     — pending, degraded
+Danger:         hsl(0, 84%, 60%)      — down, failed, error
+Info:           hsl(199, 89%, 48%)    — running, informational
+```
+
+These will be defined as CSS custom properties and mapped to Tailwind's color config so shadcn/ui components inherit them automatically.
+
+### Layout
+
+```
+┌──────────────────────────────────────────────────┐
+│  ┌──────┐  Scanorama          [search] [?] [⚙]  │  ← Top bar (48px)
+├──┤      ├────────────────────────────────────────┤
+│  │ Nav  │                                        │
+│  │      │  Main content area                     │
+│  │ □ Dash│  (tables, detail views, forms)        │
+│  │ □ Scan│                                       │
+│  │ □ Host│                                       │  ← Sidebar (220px, collapsible to 48px icons)
+│  │ □ Net │                                       │
+│  │ □ Disc│                                       │
+│  │ □ Prof│                                       │
+│  │ □ Schd│                                       │
+│  │      │                                        │
+│  │ ──── │                                        │
+│  │ □ Admn│                                       │
+│  └──────┘                                        │
+└──────────────────────────────────────────────────┘
+```
+
+- **Sidebar navigation** with icon + label, collapsible to icon-only
+- **Top bar** with global search, help, and settings
+- **Content area** fills remaining space, scrolls independently
+- **No footer** — every pixel is for content
+
+### Key UI patterns
+
+| Pattern | When to use | Implementation |
+|---------|-------------|----------------|
+| **Data table** | Lists of hosts, scans, networks, etc. | TanStack Table + custom columns |
+| **Stat cards** | Dashboard KPIs (total hosts, active scans, etc.) | Grid of small cards with icon + number + trend |
+| **Detail panel** | Viewing a single host, scan, or network | Either slide-over panel or dedicated route |
+| **Status badge** | Scan status, host status, port state | Colored pill with label |
+| **Action menu** | Row-level actions (start, stop, delete, etc.) | Dropdown menu on row hover or ⋮ button |
+| **Empty state** | No data yet | Illustration + CTA to create first item |
+| **Loading skeleton** | Data fetching | Animated shimmer placeholders matching layout |
+| **Toast notifications** | Action confirmations, errors | Bottom-right stack, auto-dismiss |
+| **Command palette** | Power-user quick navigation | Cmd+K modal with fuzzy search |
+
+---
+
+## 4. Project Structure
+
+```
+frontend/
+├── index.html
+├── package.json
+├── tsconfig.json
+├── vite.config.ts
+├── tailwind.config.ts
+├── postcss.config.js
+├── components.json                 ← shadcn/ui config
+│
+├── public/
+│   └── favicon.svg
+│
+├── src/
+│   ├── main.tsx                    ← Entry point
+│   ├── app.tsx                     ← Root layout + router
+│   ├── globals.css                 ← Tailwind directives + CSS vars
+│   │
+│   ├── api/
+│   │   ├── client.ts              ← openapi-fetch configured instance
+│   │   ├── types.ts               ← Generated from OpenAPI spec (do not edit)
+│   │   └── hooks/
+│   │       ├── use-scans.ts       ← TanStack Query wrappers
+│   │       ├── use-hosts.ts
+│   │       ├── use-networks.ts
+│   │       ├── use-discovery.ts
+│   │       ├── use-profiles.ts
+│   │       ├── use-schedules.ts
+│   │       └── use-system.ts      ← health, status, version
+│   │
+│   ├── components/
+│   │   ├── ui/                    ← shadcn/ui primitives (button, input, table, etc.)
+│   │   ├── layout/
+│   │   │   ├── sidebar.tsx
+│   │   │   ├── topbar.tsx
+│   │   │   └── root-layout.tsx
+│   │   ├── data-table/
+│   │   │   ├── data-table.tsx     ← Reusable TanStack Table wrapper
+│   │   │   ├── column-header.tsx
+│   │   │   ├── pagination.tsx
+│   │   │   └── toolbar.tsx
+│   │   ├── status-badge.tsx
+│   │   ├── stat-card.tsx
+│   │   └── command-palette.tsx
+│   │
+│   ├── routes/                    ← One file per route (TanStack Router)
+│   │   ├── __root.tsx
+│   │   ├── index.tsx              ← Dashboard
+│   │   ├── scans/
+│   │   │   ├── index.tsx          ← Scan list
+│   │   │   └── $scanId.tsx        ← Scan detail
+│   │   ├── hosts/
+│   │   │   ├── index.tsx
+│   │   │   └── $hostId.tsx
+│   │   ├── networks/
+│   │   │   ├── index.tsx
+│   │   │   └── $networkId.tsx
+│   │   ├── discovery/
+│   │   │   └── index.tsx
+│   │   ├── profiles/
+│   │   │   └── index.tsx
+│   │   ├── schedules/
+│   │   │   └── index.tsx
+│   │   └── admin/
+│   │       └── index.tsx
+│   │
+│   ├── lib/
+│   │   ├── utils.ts               ← cn() helper, formatters
+│   │   ├── constants.ts           ← Status colors, port labels, etc.
+│   │   └── ws.ts                  ← WebSocket connection manager
+│   │
+│   └── hooks/
+│       ├── use-theme.ts           ← Dark/light toggle
+│       └── use-debounce.ts
+│
+└── tests/
+    ├── setup.ts                   ← Vitest + Testing Library config
+    ├── msw/
+    │   ├── handlers.ts            ← MSW mock handlers for API
+    │   └── server.ts              ← MSW server setup
+    └── components/
+        └── ...                    ← Component tests
+```
+
+### Go embed integration (production)
+
+The Go server will embed the built frontend:
+
+```go
+//go:embed frontend/dist/*
+var frontendFS embed.FS
+
+// Serve at root, with SPA fallback to index.html for client-side routing
+```
+
+This is a later iteration — during development, Vite's dev server proxies API calls to the Go backend.
+
+---
+
+## 5. API Client Strategy
+
+### Type generation from OpenAPI spec
+
+```bash
+# Generate TypeScript types from the existing Swagger spec
+npx openapi-typescript ../docs/swagger/swagger.yaml -o src/api/types.ts
+```
+
+This gives us fully typed request/response interfaces derived directly from the backend's Swagger annotations. When the backend changes, we regenerate.
+
+### Type-safe fetch client
+
+```typescript
+// src/api/client.ts
+import createClient from 'openapi-fetch';
+import type { paths } from './types';
+
+export const api = createClient<paths>({
+  baseUrl: import.meta.env.VITE_API_BASE_URL ?? '/api/v1',
+});
+```
+
+Usage is fully typed — autocomplete on paths, params, and response shapes:
+
+```typescript
+const { data, error } = await api.GET('/hosts', {
+  params: { query: { page: 1, page_size: 20 } },
+});
+// data is typed as PaginatedHostsResponse
+```
+
+### TanStack Query wrappers
+
+Every API resource gets a hooks file that wraps the fetch client with TanStack Query for caching, polling, and mutations:
+
+```typescript
+// src/api/hooks/use-hosts.ts
+export function useHosts(params: HostListParams) {
+  return useQuery({
+    queryKey: ['hosts', params],
+    queryFn: () => api.GET('/hosts', { params: { query: params } }),
+    select: (res) => res.data,
+  });
+}
+
+export function useHost(id: string) {
+  return useQuery({
+    queryKey: ['hosts', id],
+    queryFn: () => api.GET('/hosts/{id}', { params: { path: { id } } }),
+    select: (res) => res.data,
+  });
+}
+```
+
+### Why this approach
+
+- **Single source of truth:** Backend Swagger annotations → generated types → typed client → typed hooks. No manual type duplication.
+- **Regeneration is cheap:** One command after backend changes. Compiler catches mismatches.
+- **No code generation runtime:** `openapi-fetch` is ~5 KB, uses native `fetch`, and the types are purely compile-time.
+
+---
+
+## 6. Local Development & Testing
+
+### Development environment setup
+
+```bash
+# Terminal 1: Start backend + database
+cd /path/to/scanorama
+make db-up                          # Postgres via Docker
+go run ./cmd/scanorama api \
+  --config config/environments/config.local.yaml
+
+# Terminal 2: Start frontend dev server
+cd frontend
+npm install
+npm run dev                         # Vite on port 5173, proxies /api → :8080
+```
+
+Vite config for API proxying:
+
+```typescript
+// vite.config.ts
+export default defineConfig({
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8080',
+      '/ws': { target: 'ws://localhost:8080', ws: true },
+    },
+  },
+});
+```
+
+### Testing strategy — three layers
+
+#### Layer 1: Component tests (Vitest + Testing Library)
+
+Fast, isolated, no backend needed. Mock API responses with MSW (Mock Service Worker).
+
+```bash
+npm run test              # Run all tests
+npm run test:watch        # Watch mode during development
+npm run test:coverage     # Coverage report
+```
+
+What we test:
+- Components render correctly with various data states (empty, loading, error, data)
+- User interactions (click buttons, fill forms, sort tables)
+- Conditional rendering (status badges show correct colors, disabled states)
+
+MSW intercepts `fetch` calls and returns canned responses — tests hit the same code paths as production but with deterministic data.
+
+```typescript
+// tests/msw/handlers.ts
+import { http, HttpResponse } from 'msw';
+
+export const handlers = [
+  http.get('/api/v1/hosts', () =>
+    HttpResponse.json({
+      data: [{ id: '...', ip_address: '192.168.1.1', status: 'up', ... }],
+      pagination: { page: 1, page_size: 20, total_items: 1, total_pages: 1 },
+    })
+  ),
+  // ... handlers for each endpoint
+];
+```
+
+#### Layer 2: Integration tests (Playwright)
+
+End-to-end browser tests against the real frontend + real (or mocked) backend.
+
+```bash
+npm run test:e2e          # Headless Chromium
+npm run test:e2e:ui       # Interactive Playwright UI
+```
+
+For local development, these run against Vite dev server + Go backend + test database. In CI, we can run against a Docker Compose stack or use MSW in the browser for hermetic tests.
+
+What we test:
+- Full user flows (navigate to hosts page → click host → see detail → go back)
+- Form submissions (create network → verify it appears in list)
+- Pagination and filtering work end-to-end
+- Error states display correctly when API returns errors
+
+#### Layer 3: Visual smoke tests (manual, supported by Playwright screenshots)
+
+Not automated initially, but Playwright can capture screenshots for manual review:
+
+```bash
+npm run test:e2e -- --update-snapshots
+```
+
+Useful when refactoring layout or theme without wanting to break visual appearance.
+
+### Testing conventions
+
+- **Filename pattern:** `*.test.tsx` for component tests, `*.spec.ts` for e2e
+- **One test file per component/route** — mirrors `src/` structure in `tests/`
+- **Minimum coverage target:** 60% for components, 80% for hooks/utils
+- **CI integration:** Component tests run on every PR (fast, no infra needed). E2e tests run on merge to main.
+
+### Seed data for local development
+
+The Go backend should have a `make seed` target (or we create one) that populates the dev database with realistic test data:
+
+- 3–5 networks (10.0.0.0/24, 192.168.1.0/24, 172.16.0.0/16, etc.)
+- 50–100 hosts with varied statuses, OS fingerprints, and port profiles
+- 10–20 completed scans with results
+- A few active schedules
+- Some discovery jobs in various states
+
+This makes local frontend development immediately useful — you see real-looking data, not empty states.
+
+---
+
+## 7. Iteration Plan
+
+Each iteration is a **shippable increment** — it adds visible, testable functionality. Iterations are scoped to roughly 2–4 days of work each.
+
+### Iteration 0: Scaffold & Prove the Stack
+
+**Goal:** Empty app that builds, runs, proxies to the backend, and proves every layer of the stack works.
+
+- [ ] `npm create vite@latest frontend -- --template react-ts`
+- [ ] Install Tailwind 4, configure with dark theme color system
+- [ ] Install and configure shadcn/ui (`npx shadcn@latest init`)
+- [ ] Set up Vite proxy to Go backend
+- [ ] Generate TypeScript types from Swagger spec (`openapi-typescript`)
+- [ ] Set up `openapi-fetch` client with one test call
+- [ ] Set up TanStack Query provider
+- [ ] Set up TanStack Router with root layout (sidebar placeholder + content area)
+- [ ] Add Vitest + Testing Library + MSW
+- [ ] One smoke test: root layout renders, health endpoint returns data
+- [ ] `npm run build` produces a `dist/` that can be served
+
+**Deliverable:** App shell with sidebar nav (links but placeholder pages), dark theme, hitting `/api/v1/health` and showing the result.
+
+---
+
+### Iteration 1: Dashboard
+
+**Goal:** Landing page with aggregate stats and at-a-glance system health.
+
+- [ ] `StatCard` component (icon, label, value, optional trend)
+- [ ] Fetch `/health`, `/status`, `/version` — display in top cards
+- [ ] Fetch `/networks/stats` — display network/host/exclusion counts
+- [ ] Fetch `/scans?page_size=5&sort=-created_at` — show recent scans table
+- [ ] Fetch `/hosts?status=up&page_size=1` — show active host count
+- [ ] Auto-refresh via TanStack Query `refetchInterval` (30s)
+- [ ] Loading skeletons for all cards
+- [ ] Tests for StatCard, dashboard data fetching
+
+**Deliverable:** A dashboard that immediately tells you "the system is healthy, there are N hosts across M networks, and here are the last 5 scans."
+
+---
+
+### Iteration 2: Hosts — The Primary View
+
+**Goal:** The most-used page. Browse, search, sort, and inspect hosts.
+
+- [ ] Reusable `DataTable` component (wrapping TanStack Table)
+  - [ ] Column sorting (click headers)
+  - [ ] Pagination controls (page size selector, prev/next/jump)
+  - [ ] Column visibility toggle
+  - [ ] Loading state with skeletons
+- [ ] Hosts list page using `DataTable`
+  - [ ] Columns: IP, hostname, status, OS, MAC, open ports count, last seen, first seen
+  - [ ] `StatusBadge` component (up = green, down = red, unknown = gray)
+  - [ ] Search/filter by IP, hostname, status
+  - [ ] Click row → navigate to host detail
+- [ ] Host detail page
+  - [ ] Header with IP, hostname, status, OS info
+  - [ ] Port/service table (from scan results)
+  - [ ] Scan history for this host
+  - [ ] Host metadata (vendor, MAC, response time, discovery count)
+- [ ] Tests for DataTable, StatusBadge, host list, host detail
+
+**Deliverable:** You can browse all hosts, search for one, click into it, and see its ports and scan history.
+
+---
+
+### Iteration 3: Scans — CRUD & Real-Time Progress
+
+**Goal:** View scans, create new ones, and monitor running scans.
+
+- [ ] Scan list page (DataTable with status, targets, progress, timestamps)
+- [ ] Create scan form
+  - [ ] Target input (multi-value: IPs, CIDRs, hostnames)
+  - [ ] Profile selector (dropdown populated from `/profiles`)
+  - [ ] Name and description fields
+  - [ ] Zod validation
+- [ ] Scan detail page
+  - [ ] Status + progress bar (for running scans)
+  - [ ] Results table (hosts found, ports scanned)
+  - [ ] Start/stop action buttons
+  - [ ] Error display for failed scans
+- [ ] Polling for running scans (`refetchInterval: 2000` when status === 'running')
+- [ ] Toast notifications for scan state changes
+- [ ] Tests for scan form validation, scan list, progress display
+
+**Deliverable:** Full scan lifecycle — create, monitor, view results, start/stop.
+
+---
+
+### Iteration 4: Networks & Exclusions
+
+**Goal:** Manage networks and their exclusion ranges.
+
+- [ ] Networks list page (CIDR, host count, active hosts, last discovery, status)
+- [ ] Create network form (name, CIDR, discovery method, description)
+- [ ] Network detail page
+  - [ ] Network info card
+  - [ ] Hosts in this network (filtered host table)
+  - [ ] Exclusions sub-table
+  - [ ] Enable/disable toggle
+  - [ ] Rename action
+- [ ] Exclusion management
+  - [ ] Add exclusion form (CIDR, reason)
+  - [ ] Delete exclusion (with confirmation dialog)
+  - [ ] Global exclusions page at `/exclusions`
+- [ ] Tests for network CRUD, exclusion management
+
+**Deliverable:** Complete network management — add networks, define exclusions, see which hosts belong to which network.
+
+---
+
+### Iteration 5: Discovery, Profiles & Schedules
+
+**Goal:** Fill in the remaining CRUD resources.
+
+- [ ] Discovery jobs page (list, create, start/stop, view results)
+- [ ] Profiles page (list, create, edit, delete)
+  - [ ] Profile form with scan type, timing, ports, scripts, OS targeting
+- [ ] Schedules page (list, create, edit, delete, enable/disable)
+  - [ ] Cron expression input with human-readable preview
+  - [ ] Next-run display
+  - [ ] Link to associated profile and targets
+- [ ] Tests for each resource page
+
+**Deliverable:** All seven resource domains are accessible and manageable from the frontend.
+
+---
+
+### Iteration 6: Polish & Power Features
+
+**Goal:** Quality-of-life features that make the tool feel professional.
+
+- [ ] Command palette (Cmd+K) — fuzzy search across all resources
+- [ ] Global search in top bar
+- [ ] Light/dark theme toggle (persist in localStorage)
+- [ ] Keyboard shortcuts (n = new, / = search, etc.)
+- [ ] Responsive sidebar (collapse to icons on narrow screens)
+- [ ] Empty states with illustrations and CTAs
+- [ ] Breadcrumbs on detail pages
+- [ ] Relative timestamps ("3 minutes ago") with absolute on hover
+- [ ] Monospace formatting for IPs, CIDRs, ports, MACs everywhere
+
+**Deliverable:** A polished, professional tool that feels good to use daily.
+
+---
+
+### Iteration 7: Real-Time & Admin
+
+**Goal:** WebSocket integration and admin panel.
+
+- [ ] WebSocket connection manager (`src/lib/ws.ts`)
+  - [ ] Auto-reconnect with exponential backoff
+  - [ ] Connection status indicator in top bar
+- [ ] Live scan progress via WebSocket (replace polling)
+- [ ] Admin panel
+  - [ ] Worker status (active/idle, queue depth, processed jobs)
+  - [ ] System config viewer
+  - [ ] Log viewer (streaming or paginated)
+- [ ] Tests for WebSocket reconnection logic, admin panel rendering
+
+**Deliverable:** Real-time updates and full admin visibility.
+
+---
+
+### Iteration 8: Production Integration
+
+**Goal:** Embed in Go binary, optimize, and ship.
+
+- [ ] Go `embed.FS` integration for `frontend/dist/`
+- [ ] SPA fallback handler (serve `index.html` for unknown routes)
+- [ ] Production build optimization (code splitting, chunk hashing, compression)
+- [ ] Content-Security-Policy headers for embedded frontend
+- [ ] Update Dockerfile to include frontend build step
+- [ ] Update Makefile with `make frontend` and `make build-all` targets
+- [ ] Playwright e2e tests running in CI against Docker Compose stack
+- [ ] Performance audit (Lighthouse, bundle size analysis)
+
+**Deliverable:** `go build` produces a single binary that serves both the API and the frontend. Ready for release.
+
+---
+
+## 8. Open Questions
+
+These need decisions before or during early iterations:
+
+| # | Question | Options | Leaning |
+|---|----------|---------|---------|
+| 1 | **Router choice:** TanStack Router vs React Router v7? | TanStack has type-safe routes and better DX. React Router is more established. | TanStack Router — type safety from route params through to components is worth it for a dashboard with many `:id` routes |
+| 2 | **Swagger 2.0 vs OpenAPI 3.x?** The backend currently generates Swagger 2.0. `openapi-typescript` works with both but OpenAPI 3.x is better supported everywhere. | Convert spec to 3.x during frontend setup, or update `swag` config to emit 3.x. | Convert to OpenAPI 3.x — one-time effort, better tooling support going forward |
+| 3 | **Where does the frontend live?** `frontend/` subdir (monorepo) or separate repo? | Monorepo (same repo as backend) — simpler for Go embed, single PR for full-stack changes, easier to keep spec in sync. | Monorepo in `frontend/` |
+| 4 | **State management for WebSocket data?** TanStack Query can't naturally handle push data. | Option A: WS messages invalidate query cache (trigger refetch). Option B: WS messages directly update query cache via `queryClient.setQueryData`. | Start with A (simpler), move to B if latency matters |
+| 5 | **Should we add a `make seed` command?** Need realistic data for frontend dev. | Yes — Go command or SQL script that populates dev database with sample data. | Yes, do this in Iteration 0 or 1 |
+| 6 | **Sidebar persistence.** Should collapsed/expanded state persist? | localStorage | Yes, localStorage |
+| 7 | **Table preferences.** Should column visibility, sort order, and page size persist per-table? | URL params (shareable) vs localStorage (sticky). | URL params for sort/filter/page (shareable links), localStorage for column visibility |
+
+---
+
+## Summary
+
+The plan is **8 iterations from empty scaffold to production-embedded release**, with each iteration producing a testable, demoable increment. The stack is React 19 + Vite 6 + TypeScript + Tailwind + shadcn/ui + TanStack (Query + Router + Table), with types generated directly from the backend's OpenAPI spec.
+
+The design direction is a **dark-first, information-dense operator dashboard** — professional and functional, built for people who stare at IP addresses all day and need clarity over aesthetics.
+
+Every iteration includes tests. Local development requires only `npm run dev` + a running Go backend (which is already one command). No heavyweight infrastructure needed to start building.

--- a/cmd/cli/api.go
+++ b/cmd/cli/api.go
@@ -215,6 +215,9 @@ func runAPIServer(_ *cobra.Command, _ []string) error {
 		}
 	}()
 
+	// Pass build info through to the API server so handlers can report it correctly.
+	api.SetBuildInfo(version, commit, buildTime)
+
 	// Create API server
 	apiServer, err := api.New(cfg, database)
 	if err != nil {

--- a/cmd/cli/server.go
+++ b/cmd/cli/server.go
@@ -461,6 +461,9 @@ func createAndStartServer(cfg *config.Config, database *db.DB, logger *logging.L
 		"build_time", buildTime,
 		"address", cfg.GetAPIAddress())
 
+	// Pass build info through to the API server so handlers can report it correctly.
+	api.SetBuildInfo(version, commit, buildTime)
+
 	apiServer, err := api.New(cfg, database)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create API server: %w", err)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.7.0",
+        "@vitest/coverage-v8": "^4.1.0",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
@@ -406,6 +407,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -2974,6 +2985,37 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.0.tgz",
+      "integrity": "sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.0",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.0",
+        "vitest": "4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
@@ -3199,6 +3241,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -4281,6 +4342,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4450,6 +4518,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -4937,6 +5044,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mdn-data": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.7.0",
+    "@vitest/coverage-v8": "^4.1.0",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1135,6 +1135,10 @@ export interface components {
       timestamp?: string;
       /** @example 0.7.0 */
       version?: string;
+      /** @example abc1234 */
+      commit?: string;
+      /** @example 2024-01-01T00:00:00Z */
+      build_time?: string;
     };
   };
   responses: never;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,4 +1,5 @@
 export { Button } from "./button";
+export { SystemInfoCard } from "./system-info-card";
 export { StatusBadge } from "./status-badge";
 export { StatCard } from "./stat-card";
 export { PlaceholderPage } from "./placeholder-page";

--- a/frontend/src/components/recent-scans-table.test.tsx
+++ b/frontend/src/components/recent-scans-table.test.tsx
@@ -24,34 +24,36 @@ const mockScans = [
 
 describe("RecentScansTable", () => {
   // 1. Loading skeletons
-  it("shows loading skeletons when loading is true", () => {
-    const { container } = renderWithRouter(<RecentScansTable loading={true} />);
+  it("shows loading skeletons when loading is true", async () => {
+    const { container } = await renderWithRouter(
+      <RecentScansTable loading={true} />,
+    );
     const skeletons = container.querySelectorAll(".animate-pulse");
     // 4 skeleton divs per row × 5 rows = 20
     expect(skeletons).toHaveLength(20);
   });
 
-  it("does not show the table or empty message when loading", () => {
-    renderWithRouter(<RecentScansTable loading={true} />);
+  it("does not show the table or empty message when loading", async () => {
+    await renderWithRouter(<RecentScansTable loading={true} />);
     expect(screen.queryByText("No scans found.")).not.toBeInTheDocument();
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
 
   // 2. No scans found — undefined
-  it("shows 'No scans found.' when scans is undefined", () => {
-    renderWithRouter(<RecentScansTable />);
+  it("shows 'No scans found.' when scans is undefined", async () => {
+    await renderWithRouter(<RecentScansTable />);
     expect(screen.getByText("No scans found.")).toBeInTheDocument();
   });
 
   // 3. No scans found — empty array
-  it("shows 'No scans found.' when scans is an empty array", () => {
-    renderWithRouter(<RecentScansTable scans={[]} />);
+  it("shows 'No scans found.' when scans is an empty array", async () => {
+    await renderWithRouter(<RecentScansTable scans={[]} />);
     expect(screen.getByText("No scans found.")).toBeInTheDocument();
   });
 
   // 4. Table headers
-  it("renders all table column headers when scans are provided", () => {
-    renderWithRouter(<RecentScansTable scans={mockScans} />);
+  it("renders all table column headers when scans are provided", async () => {
+    await renderWithRouter(<RecentScansTable scans={mockScans} />);
     expect(
       screen.getByRole("columnheader", { name: "Status" }),
     ).toBeInTheDocument();
@@ -70,15 +72,15 @@ describe("RecentScansTable", () => {
   });
 
   // 5. Scan data in rows
-  it("renders a row for each scan", () => {
-    renderWithRouter(<RecentScansTable scans={mockScans} />);
+  it("renders a row for each scan", async () => {
+    await renderWithRouter(<RecentScansTable scans={mockScans} />);
     const rows = screen.getAllByRole("row");
     // 1 header row + 2 data rows
     expect(rows).toHaveLength(3);
   });
 
-  it("renders numeric hosts_discovered and ports_scanned values", () => {
-    renderWithRouter(<RecentScansTable scans={mockScans} />);
+  it("renders numeric hosts_discovered and ports_scanned values", async () => {
+    await renderWithRouter(<RecentScansTable scans={mockScans} />);
     expect(screen.getByText("25")).toBeInTheDocument();
     expect(screen.getByText("2500")).toBeInTheDocument();
     expect(screen.getByText("10")).toBeInTheDocument();
@@ -86,27 +88,27 @@ describe("RecentScansTable", () => {
   });
 
   // 6. StatusBadge renders status text
-  it("displays the status text for each scan via StatusBadge", () => {
-    renderWithRouter(<RecentScansTable scans={mockScans} />);
+  it("displays the status text for each scan via StatusBadge", async () => {
+    await renderWithRouter(<RecentScansTable scans={mockScans} />);
     expect(screen.getByText("completed")).toBeInTheDocument();
     expect(screen.getByText("running")).toBeInTheDocument();
   });
 
   // 7. Multiple targets joined with comma
-  it("joins multiple targets with a comma separator", () => {
-    renderWithRouter(<RecentScansTable scans={mockScans} />);
+  it("joins multiple targets with a comma separator", async () => {
+    await renderWithRouter(<RecentScansTable scans={mockScans} />);
     expect(screen.getByText("10.0.0.0/8, 172.16.0.0/12")).toBeInTheDocument();
   });
 
-  it("renders a single target without a trailing comma", () => {
-    renderWithRouter(<RecentScansTable scans={mockScans} />);
+  it("renders a single target without a trailing comma", async () => {
+    await renderWithRouter(<RecentScansTable scans={mockScans} />);
     expect(screen.getByText("192.168.1.0/24")).toBeInTheDocument();
   });
 
   // 8. Em-dash for missing optional fields
-  it("shows em-dash for missing targets", () => {
+  it("shows em-dash for missing targets", async () => {
     const scans = [{ id: "scan-x", status: "completed" }];
-    renderWithRouter(<RecentScansTable scans={scans} />);
+    await renderWithRouter(<RecentScansTable scans={scans} />);
     const rows = screen.getAllByRole("row");
     const dataRow = rows[1];
     const cells = within(dataRow).getAllByRole("cell");
@@ -114,11 +116,11 @@ describe("RecentScansTable", () => {
     expect(cells[1]).toHaveTextContent("—");
   });
 
-  it("shows em-dash for missing hosts_discovered", () => {
+  it("shows em-dash for missing hosts_discovered", async () => {
     const scans = [
       { id: "scan-x", status: "completed", targets: ["10.0.0.1"] },
     ];
-    renderWithRouter(<RecentScansTable scans={scans} />);
+    await renderWithRouter(<RecentScansTable scans={scans} />);
     const rows = screen.getAllByRole("row");
     const dataRow = rows[1];
     const cells = within(dataRow).getAllByRole("cell");
@@ -126,11 +128,11 @@ describe("RecentScansTable", () => {
     expect(cells[2]).toHaveTextContent("—");
   });
 
-  it("shows em-dash for missing ports_scanned", () => {
+  it("shows em-dash for missing ports_scanned", async () => {
     const scans = [
       { id: "scan-x", status: "completed", targets: ["10.0.0.1"] },
     ];
-    renderWithRouter(<RecentScansTable scans={scans} />);
+    await renderWithRouter(<RecentScansTable scans={scans} />);
     const rows = screen.getAllByRole("row");
     const dataRow = rows[1];
     const cells = within(dataRow).getAllByRole("cell");
@@ -138,11 +140,11 @@ describe("RecentScansTable", () => {
     expect(cells[3]).toHaveTextContent("—");
   });
 
-  it("shows em-dash for missing created_at", () => {
+  it("shows em-dash for missing created_at", async () => {
     const scans = [
       { id: "scan-x", status: "completed", targets: ["10.0.0.1"] },
     ];
-    renderWithRouter(<RecentScansTable scans={scans} />);
+    await renderWithRouter(<RecentScansTable scans={scans} />);
     const rows = screen.getAllByRole("row");
     const dataRow = rows[1];
     const cells = within(dataRow).getAllByRole("cell");
@@ -151,22 +153,22 @@ describe("RecentScansTable", () => {
   });
 
   // 9. "Recent Scans" heading always present
-  it("shows the 'Recent Scans' heading when loading", () => {
-    renderWithRouter(<RecentScansTable loading={true} />);
+  it("shows the 'Recent Scans' heading when loading", async () => {
+    await renderWithRouter(<RecentScansTable loading={true} />);
     expect(
       screen.getByRole("heading", { name: "Recent Scans" }),
     ).toBeInTheDocument();
   });
 
-  it("shows the 'Recent Scans' heading when scans is undefined", () => {
-    renderWithRouter(<RecentScansTable />);
+  it("shows the 'Recent Scans' heading when scans is undefined", async () => {
+    await renderWithRouter(<RecentScansTable />);
     expect(
       screen.getByRole("heading", { name: "Recent Scans" }),
     ).toBeInTheDocument();
   });
 
-  it("shows the 'Recent Scans' heading when scans are provided", () => {
-    renderWithRouter(<RecentScansTable scans={mockScans} />);
+  it("shows the 'Recent Scans' heading when scans are provided", async () => {
+    await renderWithRouter(<RecentScansTable scans={mockScans} />);
     expect(
       screen.getByRole("heading", { name: "Recent Scans" }),
     ).toBeInTheDocument();

--- a/frontend/src/components/system-info-card.tsx
+++ b/frontend/src/components/system-info-card.tsx
@@ -1,0 +1,129 @@
+import { GitCommit, Clock, Package } from "lucide-react";
+import { cn } from "../lib/utils";
+import type { components } from "../api/types";
+
+type VersionResponse = components["schemas"]["docs.VersionResponse"];
+
+interface SystemInfoCardProps {
+  version?: VersionResponse;
+  loading?: boolean;
+}
+
+function formatBuildTime(buildTime?: string): string {
+  if (!buildTime || buildTime === "unknown") return "—";
+  try {
+    return new Date(buildTime).toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZoneName: "short",
+    });
+  } catch {
+    return buildTime;
+  }
+}
+
+export function SystemInfoCard({
+  version,
+  loading = false,
+}: SystemInfoCardProps) {
+  const isDev = !version?.version || version.version === "dev";
+
+  if (loading) {
+    return (
+      <div className="bg-surface rounded-lg border border-border p-4">
+        <div className="animate-pulse space-y-3">
+          <div className="h-3 w-16 rounded bg-surface-raised" />
+          <div className="h-px bg-surface-raised" />
+          <div className="grid grid-cols-3 gap-4">
+            <div className="space-y-1.5">
+              <div className="h-2.5 w-12 rounded bg-surface-raised" />
+              <div className="h-3 w-20 rounded bg-surface-raised" />
+            </div>
+            <div className="space-y-1.5">
+              <div className="h-2.5 w-12 rounded bg-surface-raised" />
+              <div className="h-3 w-16 rounded bg-surface-raised" />
+            </div>
+            <div className="space-y-1.5">
+              <div className="h-2.5 w-12 rounded bg-surface-raised" />
+              <div className="h-3 w-28 rounded bg-surface-raised" />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-surface rounded-lg border border-border p-4">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-xs uppercase tracking-wide text-text-muted">
+          Build info
+        </span>
+        {isDev && (
+          <span className="text-xs px-1.5 py-0.5 rounded-full font-medium bg-warning/10 text-warning">
+            dev build
+          </span>
+        )}
+      </div>
+
+      {/* Divider */}
+      <div className="h-px bg-border mb-3" />
+
+      {/* Build info grid */}
+      <div className="grid grid-cols-3 gap-x-4 gap-y-3">
+        {/* Version */}
+        <div className="flex flex-col gap-1 min-w-0">
+          <div className="flex items-center gap-1 text-text-muted">
+            <Package className="h-3 w-3 shrink-0" />
+            <span className="text-xs uppercase tracking-wide">Version</span>
+          </div>
+          <span className="text-sm font-mono text-text-primary truncate">
+            {version?.version ?? "—"}
+          </span>
+        </div>
+
+        {/* Commit */}
+        <div className="flex flex-col gap-1 min-w-0">
+          <div className="flex items-center gap-1 text-text-muted">
+            <GitCommit className="h-3 w-3 shrink-0" />
+            <span className="text-xs uppercase tracking-wide">Commit</span>
+          </div>
+          <span
+            className={cn(
+              "text-sm font-mono truncate",
+              version?.commit && version.commit !== "none"
+                ? "text-text-primary"
+                : "text-text-muted",
+            )}
+          >
+            {version?.commit && version.commit !== "none"
+              ? version.commit
+              : "—"}
+          </span>
+        </div>
+
+        {/* Built */}
+        <div className="flex flex-col gap-1 min-w-0">
+          <div className="flex items-center gap-1 text-text-muted">
+            <Clock className="h-3 w-3 shrink-0" />
+            <span className="text-xs uppercase tracking-wide">Built</span>
+          </div>
+          <span
+            className={cn(
+              "text-sm truncate",
+              version?.build_time && version.build_time !== "unknown"
+                ? "text-text-secondary"
+                : "text-text-muted",
+            )}
+          >
+            {formatBuildTime(version?.build_time)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/dashboard.test.tsx
+++ b/frontend/src/routes/dashboard.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { renderWithRouter } from "../test/utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DashboardPage } from "./dashboard";
@@ -39,7 +39,12 @@ function setupDefaultMocks() {
   } as unknown as ReturnType<typeof useHealth>);
 
   mockUseVersion.mockReturnValue({
-    data: { version: "0.7.0", service: "scanorama" },
+    data: {
+      version: "v0.15.0",
+      service: "scanorama",
+      commit: "abc1234",
+      build_time: "2025-01-01T12:00:00Z",
+    },
     isLoading: false,
   } as unknown as ReturnType<typeof useVersion>);
 
@@ -81,76 +86,128 @@ beforeEach(() => {
 });
 
 describe("DashboardPage", () => {
-  it("renders the System heading", () => {
-    renderWithRouter(<DashboardPage />);
-    expect(screen.getByText("System")).toBeInTheDocument();
+  // ── Build info card ────────────────────────────────────────────────────────
+
+  it("shows the version number", async () => {
+    await renderWithRouter(<DashboardPage />);
+    expect(screen.getByText("v0.15.0")).toBeInTheDocument();
   });
 
-  it("shows healthy status badge", () => {
-    renderWithRouter(<DashboardPage />);
-    expect(screen.getByText("healthy")).toBeInTheDocument();
+  it("shows the commit hash", async () => {
+    await renderWithRouter(<DashboardPage />);
+    expect(screen.getByText("abc1234")).toBeInTheDocument();
   });
 
-  it("shows version number", () => {
-    renderWithRouter(<DashboardPage />);
-    expect(screen.getByText("0.7.0")).toBeInTheDocument();
+  it("shows the Build info label", async () => {
+    await renderWithRouter(<DashboardPage />);
+    expect(screen.getByText("Build info")).toBeInTheDocument();
   });
 
-  it("shows network count in stat card", () => {
-    renderWithRouter(<DashboardPage />);
+  it("shows the Version label", async () => {
+    await renderWithRouter(<DashboardPage />);
+    expect(screen.getByText("Version")).toBeInTheDocument();
+  });
+
+  it("shows the Commit label", async () => {
+    await renderWithRouter(<DashboardPage />);
+    expect(screen.getByText("Commit")).toBeInTheDocument();
+  });
+
+  it("shows the Built label", async () => {
+    await renderWithRouter(<DashboardPage />);
+    expect(screen.getByText("Built")).toBeInTheDocument();
+  });
+
+  it("shows dev build badge when version is dev", async () => {
+    mockUseVersion.mockReturnValue({
+      data: {
+        version: "dev",
+        service: "scanorama",
+        commit: "none",
+        build_time: "unknown",
+      },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useVersion>);
+    await renderWithRouter(<DashboardPage />);
+    expect(screen.getByText("dev build")).toBeInTheDocument();
+  });
+
+  it("does not show dev build badge for a release version", async () => {
+    await renderWithRouter(<DashboardPage />);
+    expect(screen.queryByText("dev build")).not.toBeInTheDocument();
+  });
+
+  it("shows em-dash for commit when commit is none", async () => {
+    mockUseVersion.mockReturnValue({
+      data: {
+        version: "dev",
+        service: "scanorama",
+        commit: "none",
+        build_time: "unknown",
+      },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useVersion>);
+    await renderWithRouter(<DashboardPage />);
+    // em-dashes appear for both commit and build_time fields
+    const emDashes = screen.getAllByText("—");
+    expect(emDashes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("shows loading skeleton for build info while version is loading", async () => {
+    mockUseVersion.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useVersion>);
+    const { container } = await renderWithRouter(<DashboardPage />);
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  // ── Stat cards ─────────────────────────────────────────────────────────────
+
+  it("renders all four stat card labels", async () => {
+    await renderWithRouter(<DashboardPage />);
+    expect(screen.getByText("Networks")).toBeInTheDocument();
+    expect(screen.getAllByText("Hosts").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Active Hosts")).toBeInTheDocument();
+    expect(screen.getByText("Exclusions")).toBeInTheDocument();
+  });
+
+  it("shows network count in stat card", async () => {
+    await renderWithRouter(<DashboardPage />);
     expect(screen.getByText("Networks")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument();
   });
 
-  it("shows host count in stat card", () => {
-    renderWithRouter(<DashboardPage />);
-    // "Hosts" appears in both the stat card label and the scans table header
+  it("shows host count in stat card", async () => {
+    await renderWithRouter(<DashboardPage />);
     expect(screen.getAllByText("Hosts").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("42")).toBeInTheDocument();
   });
 
-  it("shows active host count from dedicated hook", () => {
-    renderWithRouter(<DashboardPage />);
+  it("shows active host count from dedicated hook", async () => {
+    await renderWithRouter(<DashboardPage />);
     expect(screen.getByText("Active Hosts")).toBeInTheDocument();
     expect(screen.getByText("30")).toBeInTheDocument();
   });
 
-  it("shows exclusion count in stat card", () => {
-    renderWithRouter(<DashboardPage />);
+  it("shows exclusion count in stat card", async () => {
+    await renderWithRouter(<DashboardPage />);
     expect(screen.getByText("Exclusions")).toBeInTheDocument();
     expect(screen.getByText("3")).toBeInTheDocument();
   });
 
-  it("shows recent scans table heading", () => {
-    renderWithRouter(<DashboardPage />);
-    expect(screen.getByText("Recent Scans")).toBeInTheDocument();
-  });
-
-  it("shows scan status and target in recent scans table", () => {
-    renderWithRouter(<DashboardPage />);
-    expect(screen.getByText("completed")).toBeInTheDocument();
-    expect(screen.getByText("192.168.1.0/24")).toBeInTheDocument();
-  });
-
-  it("shows error badge when health check fails", () => {
-    mockUseHealth.mockReturnValue({
-      data: null,
-      isLoading: false,
-    } as unknown as ReturnType<typeof useHealth>);
-    renderWithRouter(<DashboardPage />);
-    expect(screen.getByText("error")).toBeInTheDocument();
-  });
-
-  it("shows Checking... while health is loading", () => {
-    mockUseHealth.mockReturnValue({
+  it("shows em-dash when stat data is unavailable", async () => {
+    mockUseNetworkStats.mockReturnValue({
       data: undefined,
-      isLoading: true,
-    } as unknown as ReturnType<typeof useHealth>);
-    renderWithRouter(<DashboardPage />);
-    expect(screen.getByText("Checking...")).toBeInTheDocument();
+      isLoading: false,
+    } as unknown as ReturnType<typeof useNetworkStats>);
+    await renderWithRouter(<DashboardPage />);
+    const emDashes = screen.getAllByText("—");
+    expect(emDashes.length).toBeGreaterThanOrEqual(3);
   });
 
-  it("shows loading skeletons for stat cards while stats are loading", () => {
+  it("shows loading skeletons for stat cards while stats are loading", async () => {
     mockUseNetworkStats.mockReturnValue({
       data: undefined,
       isLoading: true,
@@ -159,43 +216,25 @@ describe("DashboardPage", () => {
       data: undefined,
       isLoading: true,
     } as unknown as ReturnType<typeof useActiveHostCount>);
-    const { container } = renderWithRouter(<DashboardPage />);
-    // Loading skeleton uses animate-pulse; there should be at least one
+    const { container } = await renderWithRouter(<DashboardPage />);
     const skeletons = container.querySelectorAll(".animate-pulse");
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  it("shows loading skeleton for recent scans while scans are loading", () => {
-    mockUseRecentScans.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-    } as unknown as ReturnType<typeof useRecentScans>);
-    renderWithRouter(<DashboardPage />);
-    const skeletons = document.querySelectorAll(".animate-pulse");
-    expect(skeletons.length).toBeGreaterThan(0);
+  // ── Recent scans ───────────────────────────────────────────────────────────
+
+  it("shows recent scans table heading", async () => {
+    await renderWithRouter(<DashboardPage />);
+    expect(screen.getByText("Recent Scans")).toBeInTheDocument();
   });
 
-  it("does not show version when version data is absent", () => {
-    mockUseVersion.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-    } as unknown as ReturnType<typeof useVersion>);
-    renderWithRouter(<DashboardPage />);
-    expect(screen.queryByText("0.7.0")).not.toBeInTheDocument();
+  it("shows scan status and target in recent scans table", async () => {
+    await renderWithRouter(<DashboardPage />);
+    expect(screen.getByText("completed")).toBeInTheDocument();
+    expect(screen.getByText("192.168.1.0/24")).toBeInTheDocument();
   });
 
-  it("shows em-dash when stat data is unavailable", () => {
-    mockUseNetworkStats.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-    } as unknown as ReturnType<typeof useNetworkStats>);
-    renderWithRouter(<DashboardPage />);
-    // All four stat cards should show the em-dash fallback
-    const emDashes = screen.getAllByText("—");
-    expect(emDashes.length).toBeGreaterThanOrEqual(3);
-  });
-
-  it("shows No scans found when scan list is empty", () => {
+  it("shows No scans found when scan list is empty", async () => {
     mockUseRecentScans.mockReturnValue({
       data: {
         data: [],
@@ -203,50 +242,17 @@ describe("DashboardPage", () => {
       },
       isLoading: false,
     } as unknown as ReturnType<typeof useRecentScans>);
-    renderWithRouter(<DashboardPage />);
+    await renderWithRouter(<DashboardPage />);
     expect(screen.getByText("No scans found.")).toBeInTheDocument();
   });
 
-  it("renders all four stat card labels", () => {
-    renderWithRouter(<DashboardPage />);
-    expect(screen.getByText("Networks")).toBeInTheDocument();
-    // "Hosts" appears in both the stat card label and the scans table header
-    expect(screen.getAllByText("Hosts").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("Active Hosts")).toBeInTheDocument();
-    expect(screen.getByText("Exclusions")).toBeInTheDocument();
-  });
-
-  it("waitFor still works with async state transitions", async () => {
-    // Start in loading state then update to resolved
-    mockUseHealth.mockReturnValue({
+  it("shows loading skeleton for recent scans while scans are loading", async () => {
+    mockUseRecentScans.mockReturnValue({
       data: undefined,
       isLoading: true,
-    } as unknown as ReturnType<typeof useHealth>);
-
-    renderWithRouter(<DashboardPage />);
-
-    expect(screen.getByText("Checking...")).toBeInTheDocument();
-
-    // Update the mock — on the next render cycle the component will re-read it
-    mockUseHealth.mockReturnValue({
-      data: { status: "healthy" },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useHealth>);
-
-    // Re-render by triggering a state change via a sibling mock update
-    mockUseNetworkStats.mockReturnValue({
-      data: {
-        networks: { total: 5 },
-        hosts: { total: 42, active: 30 },
-        exclusions: { total: 3 },
-      },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useNetworkStats>);
-
-    renderWithRouter(<DashboardPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText("healthy")).toBeInTheDocument();
-    });
+    } as unknown as ReturnType<typeof useRecentScans>);
+    const { container } = await renderWithRouter(<DashboardPage />);
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/routes/dashboard.tsx
+++ b/frontend/src/routes/dashboard.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import { useHealth, useVersion } from "../api/hooks/use-system";
+import { useVersion } from "../api/hooks/use-system";
 import { useNetworkStats } from "../api/hooks/use-networks";
 import { useRecentScans } from "../api/hooks/use-scans";
 import { useActiveHostCount } from "../api/hooks/use-hosts";
-import { StatusBadge } from "../components/status-badge";
 import { StatCard } from "../components/stat-card";
+import { SystemInfoCard } from "../components/system-info-card";
 import { RecentScansTable } from "../components/recent-scans-table";
 import { ScanDetailPanel } from "./scans";
 import { Network, Server, MonitorCheck, ShieldOff } from "lucide-react";
@@ -13,8 +13,7 @@ import type { components } from "../api/types";
 type ScanResponse = components["schemas"]["docs.ScanResponse"];
 
 export function DashboardPage() {
-  const { data: health, isLoading: healthLoading } = useHealth();
-  const { data: version } = useVersion();
+  const { data: version, isLoading: versionLoading } = useVersion();
   const { data: stats, isLoading: statsLoading } = useNetworkStats();
   const { data: recentScans, isLoading: scansLoading } = useRecentScans();
   const { data: activeHostCount, isLoading: activeHostsLoading } =
@@ -26,20 +25,8 @@ export function DashboardPage() {
     <>
       {/* System status */}
       <div className="mb-6">
-        <div className="flex items-center gap-3 mb-4">
-          <h2 className="text-lg font-medium text-text-primary">System</h2>
-          {healthLoading ? (
-            <span className="text-xs text-text-muted">Checking...</span>
-          ) : health ? (
-            <StatusBadge status={health.status ?? "unknown"} />
-          ) : (
-            <StatusBadge status="error" />
-          )}
-          {version && (
-            <span className="text-xs font-mono text-text-muted">
-              {version.version}
-            </span>
-          )}
+        <div className="mb-3">
+          <SystemInfoCard version={version} loading={versionLoading} />
         </div>
 
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">

--- a/frontend/src/routes/hosts.tsx
+++ b/frontend/src/routes/hosts.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
-import { Search, ScanLine } from "lucide-react";
+import { Search, ScanLine, X } from "lucide-react";
 import { Button } from "../components/button";
-import { useHosts } from "../api/hooks/use-hosts";
+import { useHosts, useHost } from "../api/hooks/use-hosts";
 import {
   StatusBadge,
   Skeleton,
@@ -10,8 +10,197 @@ import {
 } from "../components";
 import { formatRelativeTime } from "../lib/utils";
 import { cn } from "../lib/utils";
+import type { components } from "../api/types";
+
+type HostResponse = components["schemas"]["docs.HostResponse"];
 
 const PAGE_SIZE = 25;
+
+// ──────────────────────────────────────────────
+// Host detail panel
+// ──────────────────────────────────────────────
+
+function MetaRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex gap-2 text-xs">
+      <span className="text-text-muted w-28 shrink-0">{label}</span>
+      <span className="text-text-secondary break-all">{value ?? "—"}</span>
+    </div>
+  );
+}
+
+function HostDetailPanel({
+  host,
+  onClose,
+  onScan,
+}: {
+  host: HostResponse;
+  onClose: () => void;
+  onScan: (ip: string) => void;
+}) {
+  const { data: full, isLoading } = useHost(host.id ?? "");
+  const h = full ?? host;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/40 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div
+        role="dialog"
+        aria-label="Host details"
+        className={cn(
+          "fixed top-0 right-0 bottom-0 z-50",
+          "w-full max-w-[420px]",
+          "bg-surface border-l border-border",
+          "flex flex-col overflow-hidden",
+          "shadow-xl",
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 px-5 py-4 border-b border-border shrink-0">
+          <div className="flex flex-col gap-1.5 min-w-0">
+            <p className="text-xs text-text-muted">Host</p>
+            <p className="text-sm font-mono text-text-primary truncate">
+              {h.ip_address ?? "—"}
+            </p>
+            <StatusBadge status={h.status ?? "unknown"} />
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close panel"
+            className="shrink-0 p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-6">
+          {/* Identity */}
+          <section>
+            <h3 className="text-xs font-medium text-text-primary mb-3">
+              Identity
+            </h3>
+            {isLoading ? (
+              <div className="space-y-2">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <div key={i} className="flex gap-2">
+                    <Skeleton className="h-3 w-28 shrink-0" />
+                    <Skeleton className="h-3 w-40" />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <MetaRow label="ID" value={h.id} />
+                <MetaRow
+                  label="IP Address"
+                  value={<span className="font-mono">{h.ip_address}</span>}
+                />
+                <MetaRow label="Hostname" value={h.hostname} />
+                <MetaRow
+                  label="MAC Address"
+                  value={
+                    h.mac_address ? (
+                      <span className="font-mono">{h.mac_address}</span>
+                    ) : undefined
+                  }
+                />
+                <MetaRow
+                  label="Status"
+                  value={<StatusBadge status={h.status ?? "unknown"} />}
+                />
+              </div>
+            )}
+          </section>
+
+          {/* Activity */}
+          <section>
+            <h3 className="text-xs font-medium text-text-primary mb-3">
+              Activity
+            </h3>
+            {isLoading ? (
+              <div className="space-y-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="flex gap-2">
+                    <Skeleton className="h-3 w-28 shrink-0" />
+                    <Skeleton className="h-3 w-32" />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <MetaRow
+                  label="First seen"
+                  value={
+                    h.first_seen ? formatRelativeTime(h.first_seen) : undefined
+                  }
+                />
+                <MetaRow
+                  label="Last seen"
+                  value={
+                    h.last_seen ? formatRelativeTime(h.last_seen) : undefined
+                  }
+                />
+                <MetaRow label="Scan count" value={h.scan_count} />
+              </div>
+            )}
+          </section>
+
+          {/* Open ports */}
+          <section>
+            <h3 className="text-xs font-medium text-text-primary mb-3">
+              {isLoading
+                ? "Open Ports"
+                : `Open Ports (${h.open_ports?.length ?? 0})`}
+            </h3>
+            {isLoading ? (
+              <div className="flex flex-wrap gap-1.5">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <Skeleton key={i} className="h-5 w-10 rounded" />
+                ))}
+              </div>
+            ) : !h.open_ports || h.open_ports.length === 0 ? (
+              <p className="text-xs text-text-muted">No open ports recorded.</p>
+            ) : (
+              <div className="flex flex-wrap gap-1.5">
+                {h.open_ports.map((port) => (
+                  <span
+                    key={port}
+                    className="inline-block px-2 py-0.5 rounded bg-surface-raised text-xs font-mono text-text-secondary border border-border"
+                  >
+                    {port}
+                  </span>
+                ))}
+              </div>
+            )}
+          </section>
+        </div>
+
+        {/* Footer */}
+        <div className="px-5 py-3 border-t border-border shrink-0">
+          <Button
+            icon={<ScanLine className="h-3.5 w-3.5" />}
+            onClick={() => {
+              onClose();
+              onScan(h.ip_address ?? "");
+            }}
+            className="w-full justify-center"
+          >
+            Scan this host
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}
 
 type HostStatus = "all" | "up" | "down" | "unknown";
 
@@ -80,6 +269,7 @@ export function HostsPage() {
   const [searchInput, setSearchInput] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [scanIP, setScanIP] = useState<string | null>(null);
+  const [selectedHost, setSelectedHost] = useState<HostResponse | null>(null);
 
   // Debounce search input ~300ms
   useEffect(() => {
@@ -203,7 +393,8 @@ export function HostsPage() {
                   hosts.map((host) => (
                     <tr
                       key={host.id}
-                      className="border-b border-border/50 last:border-0 hover:bg-surface-raised/50 transition-colors"
+                      onClick={() => setSelectedHost(host)}
+                      className="border-b border-border/50 last:border-0 hover:bg-surface-raised/50 transition-colors cursor-pointer"
                     >
                       <td className="py-3 px-4 pr-4 font-mono text-text-primary whitespace-nowrap">
                         {host.ip_address ?? "—"}
@@ -270,6 +461,14 @@ export function HostsPage() {
 
       {scanIP !== null && (
         <RunScanModal initialTarget={scanIP} onClose={() => setScanIP(null)} />
+      )}
+
+      {selectedHost && (
+        <HostDetailPanel
+          host={selectedHost}
+          onClose={() => setSelectedHost(null)}
+          onScan={(ip) => setScanIP(ip)}
+        />
       )}
     </>
   );

--- a/frontend/src/test/utils.tsx
+++ b/frontend/src/test/utils.tsx
@@ -1,4 +1,4 @@
-import { render, type RenderOptions } from "@testing-library/react";
+import { render, act, type RenderOptions } from "@testing-library/react";
 import {
   createMemoryHistory,
   createRootRoute,
@@ -13,8 +13,11 @@ import type { ReactNode } from "react";
  * Wraps the given UI in a minimal TanStack Router context so that any
  * component that calls useRouter / Link / etc. does not throw
  * "useRouter must be used inside a RouterProvider".
+ *
+ * Returns a promise so callers can await the fully-rendered output after
+ * the router's async initialisation (Transitioner) has completed.
  */
-export function renderWithRouter(
+export async function renderWithRouter(
   ui: ReactNode,
   options?: Omit<RenderOptions, "wrapper">,
 ) {
@@ -30,5 +33,11 @@ export function renderWithRouter(
     history: createMemoryHistory({ initialEntries: ["/"] }),
   });
 
-  return render(<RouterProvider router={router} />, options);
+  let result!: ReturnType<typeof render>;
+
+  await act(async () => {
+    result = render(<RouterProvider router={router} />, options);
+  });
+
+  return result;
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,4 +17,21 @@ export default defineConfig({
       },
     },
   },
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "./coverage",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "src/api/types.ts", // generated — openapi-typescript output
+        "src/test/**", // test utilities and setup
+        "src/**/*.test.{ts,tsx}",
+        "src/main.tsx", // entry point
+        "src/router.tsx", // route wiring only
+      ],
+    },
+  },
 });

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -9,6 +9,24 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+// Build information - set via SetBuildInfo, which should be called during server startup.
+var (
+	buildVersion   = "dev"
+	buildCommit    = "none"
+	buildTimestamp = "unknown"
+)
+
+// SetBuildInfo sets the build information for use in status and version handlers.
+func SetBuildInfo(version, commit, buildTime string) {
+	buildVersion = version
+	buildCommit = commit
+	buildTimestamp = buildTime
+}
+
+func getVersion() string {
+	return buildVersion
+}
+
 // System handler constants.
 const (
 	healthCheckTimeout = 5 * time.Second
@@ -90,8 +108,8 @@ func (s *Server) statusHandler(w http.ResponseWriter, r *http.Request) {
 	response := map[string]interface{}{
 		"service":   "scanorama-api",
 		"timestamp": time.Now().UTC(),
-		"uptime":    time.Since(time.Now()).String(), // Placeholder
-		"version":   "0.2.0",
+		"uptime":    time.Since(s.startTime).String(),
+		"version":   getVersion(),
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -108,9 +126,11 @@ func (s *Server) statusHandler(w http.ResponseWriter, r *http.Request) {
 // @Router /version [get]
 func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 	response := map[string]interface{}{
-		"version":   "0.2.0",
-		"timestamp": time.Now().UTC(),
-		"service":   "scanorama",
+		"version":    getVersion(),
+		"commit":     buildCommit,
+		"build_time": buildTimestamp,
+		"timestamp":  time.Now().UTC(),
+		"service":    "scanorama",
 	}
 
 	s.WriteJSON(w, r, http.StatusOK, response)


### PR DESCRIPTION
## Summary

### Backend
- **Root cause fixed**: `/version` and `/status` endpoints had `"0.2.0"` hardcoded. Added `SetBuildInfo` to the `api` package and call it from both `runAPIServer` (the `api` command used by `make dev`) and `createAndStartServer` (daemon command) so the git-tag-derived version flows through correctly
- Fixed `statusHandler` uptime which was using `time.Since(time.Now())` (always zero); now uses `s.startTime`
- `/version` response now also includes `commit` and `build_time`

### Frontend
- Replaced the inline health/version text on the dashboard with a **SystemInfoCard** showing version, commit, and build time in a clean card layout; displays a `dev build` badge for untagged builds
- Added a **HostDetailPanel** slide-over — clicking a host row now opens a panel with identity, activity, and open ports sections, plus a _Scan this host_ action
- Fixed `renderWithRouter` to `await` the TanStack Router async initialisation so all **140 tests pass** (previously 36 were failing)