### PR TITLE
fix(scanning): correct nmap timing template and simplify host lookup

### DIFF
--- a/internal/scanning/scan.go
+++ b/internal/scanning/scan.go
@@ -5,6 +5,7 @@ package scanning
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"net"
 	"os"
@@ -17,7 +18,6 @@ import (
 	"github.com/anstrom/scanorama/internal/logging"
 	"github.com/anstrom/scanorama/internal/metrics"
 	"github.com/google/uuid"
-	"github.com/jmoiron/sqlx"
 )
 
 // Constants for scan configuration validation.
@@ -29,6 +29,7 @@ const (
 	defaultTargetCapacity = 10
 	nullMethodValue       = "NULL"
 	scanTypeConnect       = "connect"
+	scanTypeAggressive    = "aggressive"
 )
 
 const (
@@ -174,7 +175,7 @@ func buildScanOptions(config *ScanConfig) []nmap.Option {
 		options = append(options, nmap.WithACKScan())
 	case "udp":
 		options = append(options, nmap.WithUDPScan())
-	case "aggressive":
+	case scanTypeAggressive:
 		options = append(options,
 			nmap.WithSYNScan(),
 			nmap.WithServiceInfo(),
@@ -194,20 +195,22 @@ func buildScanOptions(config *ScanConfig) []nmap.Option {
 		options = append(options, nmap.WithOSDetection())
 	}
 
-	// Add timing template based on configuration
-	if config.TimeoutSec > 0 {
-		if config.TimeoutSec <= minTimeoutSeconds {
-			options = append(options, nmap.WithTimingTemplate(nmap.TimingAggressive))
-		} else if config.TimeoutSec <= mediumTimeoutSeconds {
-			options = append(options, nmap.WithTimingTemplate(nmap.TimingNormal))
-		} else {
-			options = append(options, nmap.WithTimingTemplate(nmap.TimingPolite))
-		}
-	}
-
-	// Add performance optimizations
-	if config.Concurrency > 0 {
-		// nmap library doesn't directly expose parallelism, but we can use timing
+	// Add nmap timing template. The Timing field (set from the scan profile) takes
+	// precedence. If not set, fall back to a concurrency-based heuristic.
+	switch config.Timing {
+	case "paranoid":
+		options = append(options, nmap.WithTimingTemplate(nmap.TimingSlowest))
+	case "polite":
+		options = append(options, nmap.WithTimingTemplate(nmap.TimingSneaky))
+	case "normal":
+		options = append(options, nmap.WithTimingTemplate(nmap.TimingNormal))
+	case scanTypeAggressive:
+		options = append(options, nmap.WithTimingTemplate(nmap.TimingAggressive))
+	case "insane":
+		options = append(options, nmap.WithTimingTemplate(nmap.TimingFastest))
+	default:
+		// No explicit timing — apply T4 when high concurrency is requested,
+		// otherwise leave nmap to use its own default (T3).
 		if config.Concurrency > maxConcurrency {
 			options = append(options, nmap.WithTimingTemplate(nmap.TimingAggressive))
 		}
@@ -226,9 +229,9 @@ func buildScanOptions(config *ScanConfig) []nmap.Option {
 // requested type requires raw-socket / root privileges and the process is not root.
 func resolveScanType(requested string) string {
 	rootRequired := map[string]bool{
-		"syn":           true,
-		"aggressive":    true,
-		"comprehensive": true,
+		"syn":              true,
+		scanTypeAggressive: true,
+		"comprehensive":    true,
 	}
 	if rootRequired[requested] && os.Getuid() != 0 {
 		logging.Warn("scan type requires root privileges, falling back to connect scan",
@@ -466,7 +469,7 @@ func createAdhocScanTarget(ctx context.Context, targetRepo *db.ScanTargetReposit
 	// Map scan types to database-compatible values
 	dbScanType := config.ScanType
 	switch config.ScanType {
-	case "comprehensive", "aggressive":
+	case "comprehensive", scanTypeAggressive:
 		dbScanType = "version" // Map complex scan types to version detection
 	case "stealth":
 		dbScanType = scanTypeConnect // Map stealth to basic connect scan
@@ -503,26 +506,6 @@ func debugHostLookup(ctx context.Context, database *db.DB, hostAddress string, i
 	}
 }
 
-// debugListExistingHosts lists current hosts in database for debugging.
-func debugListExistingHosts(ctx context.Context, database *db.DB) {
-	var debugHosts []struct {
-		IP     string  `db:"ip_address"`
-		Method *string `db:"discovery_method"`
-		ID     string  `db:"id"`
-	}
-	debugQuery := `SELECT ip_address::text, discovery_method, id::text FROM hosts LIMIT 5`
-	if err := database.SelectContext(ctx, &debugHosts, debugQuery); err == nil {
-		logging.Debug("Current hosts in database", "count", len(debugHosts))
-		for _, h := range debugHosts {
-			method := nullValue
-			if h.Method != nil {
-				method = *h.Method
-			}
-			logging.Debug("Database host", "ip", h.IP, "method", method, "id", h.ID)
-		}
-	}
-}
-
 // processHostForScan processes a single host for scanning, preserving discovery data.
 // Uses transaction-safe approach to handle race conditions between discovery and scan.
 func processHostForScan(ctx context.Context, database *db.DB, hostRepo *db.HostRepository,
@@ -530,7 +513,6 @@ func processHostForScan(ctx context.Context, database *db.DB, hostRepo *db.HostR
 	ipAddr := db.IPAddr{IP: net.ParseIP(host.Address)}
 	debugHostLookup(ctx, database, host.Address, ipAddr)
 
-	// Use transaction-safe host lookup with retries for CI consistency
 	dbHost, err := getOrCreateHostSafely(ctx, database, hostRepo, ipAddr, host)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get or create host %s: %w", host.Address, err)
@@ -545,11 +527,6 @@ func processHostForScan(ctx context.Context, database *db.DB, hostRepo *db.HostR
 			}
 			return nullValue
 		}())
-
-	// Final verification that host exists before creating port scans
-	if err := verifyHostExists(ctx, database, dbHost.ID); err != nil {
-		return nil, fmt.Errorf("host verification failed for %s: %w", host.Address, err)
-	}
 
 	// Create port scan records
 	portScans := make([]*db.PortScan, 0, len(host.Ports))
@@ -579,127 +556,61 @@ func processHostForScan(ctx context.Context, database *db.DB, hostRepo *db.HostR
 	return portScans, nil
 }
 
-// getOrCreateHostSafely performs transaction-safe host lookup with retries
-// to handle race conditions between discovery and scan operations.
-func getOrCreateHostSafely(ctx context.Context, database *db.DB, hostRepo *db.HostRepository,
+// getOrCreateHostSafely looks up a host by IP address and creates it if it does
+// not yet exist. It uses the repository's GetByIP (sqlx tag-based scanning) so
+// there is no dependency on physical column order in the hosts table.
+func getOrCreateHostSafely(ctx context.Context, _ *db.DB, hostRepo *db.HostRepository,
 	ipAddr db.IPAddr, host Host) (*db.Host, error) {
-	const maxRetries = 3
-	const retryDelay = 100 * time.Millisecond
+	logging.Debug("Looking up host by IP", "ip", ipAddr.String())
 
-	for attempt := 1; attempt <= maxRetries; attempt++ {
-		logging.Debug("Attempting host lookup", "ip", ipAddr.String(), "attempt", attempt, "max_retries", maxRetries)
-
-		// Use explicit transaction for consistent reads
-		tx, err := database.BeginTx(ctx)
-		if err != nil {
-			logging.Error("Failed to begin transaction", "ip", ipAddr.String(), "error", err)
-			if attempt == maxRetries {
-				return nil, fmt.Errorf("failed to begin transaction after %d attempts: %w", maxRetries, err)
-			}
-			time.Sleep(retryDelay)
-			continue
-		}
-
-		// Try to find existing host within transaction
-		var existingHost db.Host
-		query := `SELECT * FROM hosts WHERE ip_address = $1`
-		err = tx.QueryRowContext(ctx, query, ipAddr).Scan(
-			&existingHost.ID, &existingHost.IPAddress, &existingHost.Hostname,
-			&existingHost.MACAddress, &existingHost.Vendor, &existingHost.OSFamily,
-			&existingHost.OSName, &existingHost.OSVersion, &existingHost.OSConfidence,
-			&existingHost.OSDetectedAt, &existingHost.OSMethod, &existingHost.OSDetails,
-			&existingHost.DiscoveryMethod, &existingHost.ResponseTimeMS,
-			&existingHost.DiscoveryCount, &existingHost.IgnoreScanning,
-			&existingHost.FirstSeen, &existingHost.LastSeen, &existingHost.Status)
-
-		if err == nil {
-			// Found existing host - handle commit and return
-			result, commitErr := handleHostCommit(tx, &existingHost, host, ipAddr)
-			if commitErr != nil {
-				if attempt == maxRetries {
-					return nil, commitErr
+	existing, err := hostRepo.GetByIP(ctx, ipAddr)
+	if err == nil {
+		// Host already exists — update status but preserve all discovery data.
+		existing.Status = host.Status
+		logging.Debug("Found existing host",
+			"ip", ipAddr.String(),
+			"id", existing.ID.String(),
+			"discovery_method", func() string {
+				if existing.DiscoveryMethod != nil {
+					return *existing.DiscoveryMethod
 				}
-				time.Sleep(retryDelay)
-				continue
-			}
-			return result, nil
-		}
-
-		// Host not found - rollback read transaction
-		if rollbackErr := tx.Rollback(); rollbackErr != nil {
-			logging.Error("Failed to rollback read transaction", "ip", ipAddr.String(), "error", rollbackErr)
-		}
-
-		if attempt == maxRetries {
-			// Create new host if all retries exhausted
-			logging.Debug("Creating new host after lookup attempts", "ip", ipAddr.String(), "attempts", maxRetries)
-			debugListExistingHosts(ctx, database)
-
-			newHost := &db.Host{
-				ID:        uuid.New(),
-				IPAddress: ipAddr,
-				Status:    host.Status,
-				// Note: discovery_method will be NULL for hosts created during scan
-			}
-
-			// Create the new host with CreateOrUpdate to handle potential race condition
-			if createErr := hostRepo.CreateOrUpdate(ctx, newHost); createErr != nil {
-				return nil, fmt.Errorf("failed to create new host: %w", createErr)
-			}
-
-			logging.Debug("Successfully created new host", "ip", ipAddr.String())
-			return newHost, nil
-		}
-
-		logging.Debug("Host lookup attempt failed, retrying", "attempt", attempt, "ip", ipAddr.String())
-		time.Sleep(retryDelay)
+				return nullValue
+			}())
+		return existing, nil
 	}
 
-	return nil, fmt.Errorf("failed to get or create host after %d attempts", maxRetries)
+	// Any error other than not-found is unexpected.
+	if !isNotFoundError(err) {
+		return nil, fmt.Errorf("failed to look up host %s: %w", ipAddr, err)
+	}
+
+	// Host does not exist yet — create it.
+	logging.Debug("Creating new host", "ip", ipAddr.String())
+	newHost := &db.Host{
+		ID:        uuid.New(),
+		IPAddress: ipAddr,
+		Status:    host.Status,
+	}
+	if createErr := hostRepo.CreateOrUpdate(ctx, newHost); createErr != nil {
+		return nil, fmt.Errorf("failed to create new host %s: %w", ipAddr, createErr)
+	}
+
+	logging.Debug("Successfully created new host", "ip", ipAddr.String())
+	return newHost, nil
 }
 
-// verifyHostExists ensures the host record exists before creating port scans
-// to prevent foreign key constraint violations.
-func verifyHostExists(ctx context.Context, database *db.DB, hostID uuid.UUID) error {
-	var exists bool
-	query := `SELECT EXISTS(SELECT 1 FROM hosts WHERE id = $1)`
-
-	err := database.QueryRowContext(ctx, query, hostID).Scan(&exists)
-	if err != nil {
-		return fmt.Errorf("failed to verify host existence: %w", err)
+// isNotFoundError reports whether err represents a "not found" condition
+// returned by the db layer (wraps sql.ErrNoRows or our own CodeNotFound error).
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
 	}
-
-	if !exists {
-		return fmt.Errorf("host with ID %s does not exist", hostID.String())
+	// Our sanitizeDBError wraps sql.ErrNoRows as errors.DatabaseError with CodeNotFound.
+	var dbErr *errors.DatabaseError
+	if stderrors.As(err, &dbErr) {
+		return dbErr.Code == errors.CodeNotFound
 	}
-
-	logging.Debug("Verified host exists in database", "host_id", hostID.String())
-	return nil
-}
-
-// handleHostCommit handles the transaction commit for found hosts.
-func handleHostCommit(tx *sqlx.Tx, existingHost *db.Host, host Host, ipAddr db.IPAddr) (*db.Host, error) {
-	if commitErr := tx.Commit(); commitErr != nil {
-		logging.Error("Failed to commit read transaction", "ip", ipAddr.String(), "error", commitErr)
-		if rollbackErr := tx.Rollback(); rollbackErr != nil {
-			logging.Error("Failed to rollback after commit error", "ip", ipAddr.String(), "error", rollbackErr)
-		}
-		return nil, fmt.Errorf("failed to commit read transaction: %w", commitErr)
-	}
-
-	logging.Debug("Found existing host",
-		"ip", ipAddr.String(),
-		"id", existingHost.ID.String(),
-		"discovery_method", func() string {
-			if existingHost.DiscoveryMethod != nil {
-				return *existingHost.DiscoveryMethod
-			}
-			return nullValue
-		}())
-
-	// Update status but preserve discovery data
-	existingHost.Status = host.Status
-	return existingHost, nil
+	return false
 }
 
 // storeHostResults stores host and port scan results in the database.

--- a/internal/scanning/scan_unit_test.go
+++ b/internal/scanning/scan_unit_test.go
@@ -118,82 +118,112 @@ func TestBuildScanOptions_OSDetectionOff(t *testing.T) {
 	assert.False(t, hasArg(args, "-O"), "OSDetection=false must not add -O; args=%v", args)
 }
 
-// ─── buildScanOptions — timing template driven by TimeoutSec ─────────────────
+// ─── buildScanOptions — timing template driven by Timing field ───────────────
 
-func TestBuildScanOptions_TimeoutZero_NoTimingFlag(t *testing.T) {
-	// TimeoutSec == 0 → timeout branch is skipped; no -T flag from it.
+func TestBuildScanOptions_TimingParanoid(t *testing.T) {
+	// "paranoid" → nmap T0 (-T0)
 	cfg := &ScanConfig{
-		Targets:    []string{"127.0.0.1"},
-		Ports:      "80",
-		ScanType:   scanTypeConnect,
-		TimeoutSec: 0,
+		Targets:  []string{"127.0.0.1"},
+		Ports:    "80",
+		ScanType: scanTypeConnect,
+		Timing:   "paranoid",
 	}
 	args := scanArgs(t, buildScanOptions(cfg))
-	for _, f := range []string{"-T2", "-T3", "-T4"} {
+	assert.True(t, hasArg(args, "-T0"), "paranoid timing should produce -T0; args=%v", args)
+}
+
+func TestBuildScanOptions_TimingPolite(t *testing.T) {
+	// "polite" → nmap T1 (-T1)
+	cfg := &ScanConfig{
+		Targets:  []string{"127.0.0.1"},
+		Ports:    "80",
+		ScanType: scanTypeConnect,
+		Timing:   "polite",
+	}
+	args := scanArgs(t, buildScanOptions(cfg))
+	assert.True(t, hasArg(args, "-T1"), "polite timing should produce -T1; args=%v", args)
+}
+
+func TestBuildScanOptions_TimingNormal(t *testing.T) {
+	// "normal" → nmap T3 (-T3)
+	cfg := &ScanConfig{
+		Targets:  []string{"127.0.0.1"},
+		Ports:    "80",
+		ScanType: scanTypeConnect,
+		Timing:   "normal",
+	}
+	args := scanArgs(t, buildScanOptions(cfg))
+	assert.True(t, hasArg(args, "-T3"), "normal timing should produce -T3; args=%v", args)
+}
+
+func TestBuildScanOptions_TimingAggressive(t *testing.T) {
+	// "aggressive" → nmap T4 (-T4)
+	cfg := &ScanConfig{
+		Targets:  []string{"127.0.0.1"},
+		Ports:    "80",
+		ScanType: scanTypeConnect,
+		Timing:   "aggressive",
+	}
+	args := scanArgs(t, buildScanOptions(cfg))
+	assert.True(t, hasArg(args, "-T4"), "aggressive timing should produce -T4; args=%v", args)
+}
+
+func TestBuildScanOptions_TimingInsane(t *testing.T) {
+	// "insane" → nmap T5 (-T5)
+	cfg := &ScanConfig{
+		Targets:  []string{"127.0.0.1"},
+		Ports:    "80",
+		ScanType: scanTypeConnect,
+		Timing:   "insane",
+	}
+	args := scanArgs(t, buildScanOptions(cfg))
+	assert.True(t, hasArg(args, "-T5"), "insane timing should produce -T5; args=%v", args)
+}
+
+func TestBuildScanOptions_TimingEmpty_NoTimingFlag(t *testing.T) {
+	// Empty Timing and no high concurrency → no -T flag added.
+	cfg := &ScanConfig{
+		Targets:     []string{"127.0.0.1"},
+		Ports:       "80",
+		ScanType:    scanTypeConnect,
+		Timing:      "",
+		Concurrency: 0,
+	}
+	args := scanArgs(t, buildScanOptions(cfg))
+	for _, f := range []string{"-T0", "-T1", "-T2", "-T3", "-T4", "-T5"} {
 		assert.False(t, hasArg(args, f),
-			"TimeoutSec=0 should not add %s; args=%v", f, args)
+			"empty Timing with no concurrency should not add %s; args=%v", f, args)
 	}
 }
 
-func TestBuildScanOptions_TimeoutAtMin_AggressiveTiming(t *testing.T) {
-	// TimeoutSec <= minTimeoutSeconds (5) → TimingAggressive == -T4
+func TestBuildScanOptions_TimingUnknown_NoTimingFlag(t *testing.T) {
+	// Unrecognized Timing string → falls through to default, no -T flag.
 	cfg := &ScanConfig{
-		Targets:    []string{"127.0.0.1"},
-		Ports:      "80",
-		ScanType:   scanTypeConnect,
-		TimeoutSec: minTimeoutSeconds,
+		Targets:     []string{"127.0.0.1"},
+		Ports:       "80",
+		ScanType:    scanTypeConnect,
+		Timing:      "unknown-value",
+		Concurrency: 0,
 	}
 	args := scanArgs(t, buildScanOptions(cfg))
-	assert.True(t, hasArg(args, "-T4"), "short timeout should produce -T4; args=%v", args)
+	for _, f := range []string{"-T0", "-T1", "-T2", "-T3", "-T4", "-T5"} {
+		assert.False(t, hasArg(args, f),
+			"unknown Timing should not add %s; args=%v", f, args)
+	}
 }
 
-func TestBuildScanOptions_TimeoutBelowMin_AggressiveTiming(t *testing.T) {
-	// TimeoutSec = 1 (< minTimeoutSeconds) → TimingAggressive == -T4
+func TestBuildScanOptions_TimingTakesPrecedenceOverConcurrency(t *testing.T) {
+	// Explicit Timing field wins even when Concurrency > maxConcurrency.
 	cfg := &ScanConfig{
-		Targets:    []string{"127.0.0.1"},
-		Ports:      "80",
-		ScanType:   scanTypeConnect,
-		TimeoutSec: 1,
+		Targets:     []string{"127.0.0.1"},
+		Ports:       "80",
+		ScanType:    scanTypeConnect,
+		Timing:      "polite",
+		Concurrency: maxConcurrency + 1,
 	}
 	args := scanArgs(t, buildScanOptions(cfg))
-	assert.True(t, hasArg(args, "-T4"), "very short timeout should produce -T4; args=%v", args)
-}
-
-func TestBuildScanOptions_TimeoutAtMedium_NormalTiming(t *testing.T) {
-	// TimeoutSec == mediumTimeoutSeconds (15) → TimingNormal == -T3
-	cfg := &ScanConfig{
-		Targets:    []string{"127.0.0.1"},
-		Ports:      "80",
-		ScanType:   scanTypeConnect,
-		TimeoutSec: mediumTimeoutSeconds,
-	}
-	args := scanArgs(t, buildScanOptions(cfg))
-	assert.True(t, hasArg(args, "-T3"), "medium timeout should produce -T3; args=%v", args)
-}
-
-func TestBuildScanOptions_TimeoutBetweenMinAndMedium_NormalTiming(t *testing.T) {
-	// minTimeoutSeconds < TimeoutSec < mediumTimeoutSeconds → -T3
-	cfg := &ScanConfig{
-		Targets:    []string{"127.0.0.1"},
-		Ports:      "80",
-		ScanType:   scanTypeConnect,
-		TimeoutSec: minTimeoutSeconds + 1,
-	}
-	args := scanArgs(t, buildScanOptions(cfg))
-	assert.True(t, hasArg(args, "-T3"),
-		"timeout between min and medium should produce -T3; args=%v", args)
-}
-
-func TestBuildScanOptions_TimeoutAboveMedium_PoliteTiming(t *testing.T) {
-	// TimeoutSec > mediumTimeoutSeconds → TimingPolite == -T2
-	cfg := &ScanConfig{
-		Targets:    []string{"127.0.0.1"},
-		Ports:      "80",
-		ScanType:   scanTypeConnect,
-		TimeoutSec: mediumTimeoutSeconds + 1,
-	}
-	args := scanArgs(t, buildScanOptions(cfg))
-	assert.True(t, hasArg(args, "-T2"), "long timeout should produce -T2; args=%v", args)
+	assert.True(t, hasArg(args, "-T1"), "explicit Timing=polite should produce -T1; args=%v", args)
+	assert.False(t, hasArg(args, "-T4"), "explicit Timing should prevent concurrency fallback to -T4; args=%v", args)
 }
 
 // ─── buildScanOptions — concurrency ──────────────────────────────────────────

--- a/internal/scanning/types.go
+++ b/internal/scanning/types.go
@@ -42,6 +42,9 @@ type ScanConfig struct {
 	Ports string
 	// ScanType determines the type of scan: "connect", "syn", "ack", "udp", "aggressive", or "comprehensive"
 	ScanType string
+	// Timing sets the nmap timing template explicitly: "paranoid", "polite", "normal", "aggressive", "insane".
+	// When set, this takes precedence over any timing derived from TimeoutSec.
+	Timing string
 	// OSDetection enables nmap OS fingerprinting (-O)
 	OSDetection bool
 	// TimeoutSec specifies scan timeout in seconds (0 = default timeout)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -580,7 +580,7 @@ hostLoop:
 		}
 
 		wg.Add(1)
-		go func(h *db.Host, pID string, ports, scanType string, timeoutSec int) {
+		go func(h *db.Host, pID string, ports, scanType, timing string, timeoutSec int) {
 			defer func() {
 				<-sem // release semaphore slot
 				wg.Done()
@@ -598,6 +598,7 @@ hostLoop:
 				Targets:     []string{h.IPAddress.String()},
 				Ports:       ports,
 				ScanType:    scanType,
+				Timing:      timing,
 				TimeoutSec:  timeoutSec,
 				Concurrency: 1,
 			}
@@ -613,7 +614,7 @@ hostLoop:
 
 			log.Printf("Completed scan of host %s: %d hosts responded, %d up",
 				h.IPAddress, result.Stats.Total, result.Stats.Up)
-		}(host, profileID, profile.Ports, profile.ScanType, timingToScanTimeout(profile.Timing))
+		}(host, profileID, profile.Ports, profile.ScanType, profile.Timing, timingToScanTimeout(profile.Timing))
 	}
 
 	// Wait for all in-flight scans to finish before returning.
@@ -650,6 +651,7 @@ func (s *Scheduler) processHostsViaQueue(ctx context.Context, hosts []*db.Host, 
 			Targets:     []string{host.IPAddress.String()},
 			Ports:       profile.Ports,
 			ScanType:    profile.ScanType,
+			Timing:      profile.Timing,
 			TimeoutSec:  timingToScanTimeout(profile.Timing),
 			Concurrency: 1,
 		}


### PR DESCRIPTION
## What was wrong

### Bug 1 — Every scheduled scan ran at nmap `-T1` (polite/sneaky)

`buildScanOptions` was deriving the nmap `-T` flag from `TimeoutSec` using this logic:

- `≤ 5s` → `-T4`
- `≤ 15s` → `-T3`
- `> 15s` → `-T2` ← **all scheduled scans fell here**

The scheduler sets `TimeoutSec` to 300–3600s depending on the profile timing. Every single one is `> 15s`, so every scan got `-T2` (polite), regardless of whether the profile said `aggressive` or `insane`. A scan that should run at `-T5` was running at `-T1` — roughly 10× slower.

### Bug 2 — `SELECT *` with positional `Scan()` in host lookup

`getOrCreateHostSafely` used `SELECT * FROM hosts` and then manually scanned columns in a hard-coded order. Any migration adding or reordering a column would silently scan data into the wrong struct fields, or panic at runtime. The rest of the codebase uses explicit column lists everywhere.

The same function also opened a full `BEGIN`/`COMMIT` read transaction for every single host lookup (unnecessary overhead), retried up to 3 times with 100ms sleeps even when the host simply didn't exist (~200ms wasted delay per new host on first scan), and finished with a redundant `verifyHostExists` round-trip.

## What was fixed

**Timing:** Added a `Timing string` field to `ScanConfig`. The scheduler now passes `profile.Timing` through, and `buildScanOptions` maps it directly to the correct nmap constant:

| Profile timing | nmap flag |
|---|---|
| `paranoid` | `-T0` |
| `polite` | `-T1` |
| `normal` | `-T3` |
| `aggressive` | `-T4` |
| `insane` | `-T5` |

`TimeoutSec` still controls `context.WithTimeout` only, as intended. The concurrency-based `-T4` fallback is preserved for cases where no explicit timing is set.

**Host lookup:** Replaced the entire `getOrCreateHostSafely` with a call to the existing `hostRepo.GetByIP` (sqlx struct-tag scanning, no column-order dependency). Not-found is handled immediately without retries. Removed `verifyHostExists`, `handleHostCommit`, and `debugListExistingHosts` (all now dead code).

## Files changed

- `internal/scanning/types.go` — add `Timing` field to `ScanConfig`
- `internal/scanning/scan.go` — fix `buildScanOptions`, rewrite `getOrCreateHostSafely`, remove dead helpers, add `scanTypeAggressive` constant
- `internal/scheduler/scheduler.go` — pass `profile.Timing` into `ScanConfig` in both the direct goroutine and queue paths
- `internal/scanning/scan_unit_test.go` — replace timeout-driven timing tests with correct Timing-field tests