### PR TITLE
fix(ci): wait for both coverage uploads before evaluating patch status

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,12 +18,14 @@ coverage:
         target: auto # Compare to base branch coverage
         threshold: 2% # Allow 2% decrease without failing
         if_ci_failed: error # Fail if CI tests fail
+        after_n_builds: 2 # Wait for both unit and integration uploads
 
     patch:
       default:
         target: 40% # Fixed threshold for new/changed code
         threshold: 0% # No additional slack on top of target
         if_ci_failed: error
+        after_n_builds: 2 # Wait for both unit and integration uploads
 
 # Ignore patterns - exclude test files and non-production code from coverage
 # This is the key section that excludes test files from coverage statistics

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -291,10 +291,6 @@ jobs:
           flags: integration
           fail_ci_if_error: true
           verbose: true
-          # Carry forward coverage from the previous upload for any flags not
-          # present in this run (e.g. unit flag when only integration runs).
-          # This prevents the badge dropping to "unknown" on non-Go commits.
-          carryforward: unit
 
       - name: Run database migration tests
         run: |

--- a/frontend/src/routes/hosts.tsx
+++ b/frontend/src/routes/hosts.tsx
@@ -56,7 +56,7 @@ function HostDetailPanel({
         aria-label="Host details"
         className={cn(
           "fixed top-0 right-0 bottom-0 z-50",
-          "w-full max-w-[420px]",
+          "w-full max-w-105",
           "bg-surface border-l border-border",
           "flex flex-col overflow-hidden",
           "shadow-xl",

--- a/frontend/src/routes/scans.tsx
+++ b/frontend/src/routes/scans.tsx
@@ -152,7 +152,7 @@ export function ScanDetailPanel({ scan, onClose }: DetailPanelProps) {
         aria-label="Scan details"
         className={cn(
           "fixed top-0 right-0 bottom-0 z-50",
-          "w-full max-w-[480px]",
+          "w-full max-w-120",
           "bg-surface border-l border-border",
           "flex flex-col overflow-hidden",
           "shadow-xl",
@@ -463,7 +463,7 @@ export function ScansPage() {
                         "hover:bg-surface-raised/50 transition-colors cursor-pointer",
                       )}
                     >
-                      <td className="py-3 px-4 pr-4 font-mono text-text-secondary max-w-[200px] truncate">
+                      <td className="py-3 px-4 pr-4 font-mono text-text-secondary max-w-50 truncate">
                         {scan.targets?.join(", ") ?? "—"}
                       </td>
                       <td className="py-3 pr-4">


### PR DESCRIPTION
## Problem

Codecov was evaluating the patch status check immediately after the unit upload arrived. In the unit job, all `connectTestDB`-backed tests are skipped via `-short`, so patch coverage landed at 21% — below the 40% threshold — even though the integration job would later upload full coverage.

## Changes

**`.codecov.yml`**
- Add `after_n_builds: 2` to both `project` and `patch` status checks so Codecov holds evaluation until both the unit and integration uploads are present for a commit.

**`main.yml`**
- Remove the invalid `carryforward: unit` parameter from the `codecov/codecov-action` step — this is a `.codecov.yml` flag-level setting, not an action input, so it was a no-op.

**`scans.tsx` / `hosts.tsx`**
- Replace Tailwind arbitrary values with shorthand equivalents (`max-w-[480px]` → `max-w-120`, etc.) to clear linter warnings.