### PR TITLE
fix(tests): type ok/fail mock helpers with ReturnType<typeof mockGet>

### DIFF
--- a/frontend/src/api/hooks/use-hosts.test.ts
+++ b/frontend/src/api/hooks/use-hosts.test.ts
@@ -13,15 +13,19 @@ vi.mock("../client", () => ({
 import { api } from "../client";
 const mockGet = vi.mocked(api.GET);
 
-const ok = (data: unknown) =>
-  Promise.resolve({ data, error: undefined, response: new Response() });
+const ok = (data: unknown): ReturnType<typeof mockGet> =>
+  Promise.resolve({
+    data,
+    error: undefined,
+    response: new Response(),
+  }) as ReturnType<typeof mockGet>;
 
-const fail = (message = "something went wrong") =>
+const fail = (message = "something went wrong"): ReturnType<typeof mockGet> =>
   Promise.resolve({
     data: undefined,
     error: { message },
     response: new Response(),
-  });
+  }) as ReturnType<typeof mockGet>;
 
 const mockHost = {
   id: "host-1",

--- a/frontend/src/api/hooks/use-networks.test.ts
+++ b/frontend/src/api/hooks/use-networks.test.ts
@@ -13,15 +13,19 @@ vi.mock("../client", () => ({
 import { api } from "../client";
 const mockGet = vi.mocked(api.GET);
 
-const ok = (data: unknown) =>
-  Promise.resolve({ data, error: undefined, response: new Response() });
+const ok = (data: unknown): ReturnType<typeof mockGet> =>
+  Promise.resolve({
+    data,
+    error: undefined,
+    response: new Response(),
+  }) as ReturnType<typeof mockGet>;
 
-const fail = (message = "something went wrong") =>
+const fail = (message = "something went wrong"): ReturnType<typeof mockGet> =>
   Promise.resolve({
     data: undefined,
     error: { message },
     response: new Response(),
-  });
+  }) as ReturnType<typeof mockGet>;
 
 const mockNetworks = [
   {

--- a/frontend/src/api/hooks/use-profiles.test.ts
+++ b/frontend/src/api/hooks/use-profiles.test.ts
@@ -13,15 +13,19 @@ vi.mock("../client", () => ({
 import { api } from "../client";
 const mockGet = vi.mocked(api.GET);
 
-const ok = (data: unknown) =>
-  Promise.resolve({ data, error: undefined, response: new Response() });
+const ok = (data: unknown): ReturnType<typeof mockGet> =>
+  Promise.resolve({
+    data,
+    error: undefined,
+    response: new Response(),
+  }) as ReturnType<typeof mockGet>;
 
-const fail = (message = "something went wrong") =>
+const fail = (message = "something went wrong"): ReturnType<typeof mockGet> =>
   Promise.resolve({
     data: undefined,
     error: { message },
     response: new Response(),
-  });
+  }) as ReturnType<typeof mockGet>;
 
 const mockProfile = {
   id: "p1",

--- a/frontend/src/api/hooks/use-scans.test.ts
+++ b/frontend/src/api/hooks/use-scans.test.ts
@@ -21,15 +21,19 @@ import { api } from "../client";
 const mockGet = vi.mocked(api.GET);
 const mockPost = vi.mocked(api.POST);
 
-const ok = (data: unknown) =>
-  Promise.resolve({ data, error: undefined, response: new Response() });
+const ok = (data: unknown): ReturnType<typeof mockGet> =>
+  Promise.resolve({
+    data,
+    error: undefined,
+    response: new Response(),
+  }) as ReturnType<typeof mockGet>;
 
-const fail = (message = "something went wrong") =>
+const fail = (message = "something went wrong"): ReturnType<typeof mockGet> =>
   Promise.resolve({
     data: undefined,
     error: { message },
     response: new Response(),
-  });
+  }) as ReturnType<typeof mockGet>;
 
 const mockPagination = {
   page: 1,

--- a/frontend/src/api/hooks/use-system.test.ts
+++ b/frontend/src/api/hooks/use-system.test.ts
@@ -13,15 +13,19 @@ vi.mock("../client", () => ({
 import { api } from "../client";
 const mockGet = vi.mocked(api.GET);
 
-const ok = (data: unknown) =>
-  Promise.resolve({ data, error: undefined, response: new Response() });
+const ok = (data: unknown): ReturnType<typeof mockGet> =>
+  Promise.resolve({
+    data,
+    error: undefined,
+    response: new Response(),
+  }) as ReturnType<typeof mockGet>;
 
-const fail = (message = "something went wrong") =>
+const fail = (message = "something went wrong"): ReturnType<typeof mockGet> =>
   Promise.resolve({
     data: undefined,
     error: { message },
     response: new Response(),
-  });
+  }) as ReturnType<typeof mockGet>;
 
 // ── useHealth ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Use `ReturnType<typeof mockGet>` instead of `unknown`/`any` to satisfy openapi-fetch's strict `FetchResponse` generic type in all hook test files.

## Changes
- `use-hosts.test.ts`
- `use-networks.test.ts`
- `use-profiles.test.ts`
- `use-scans.test.ts`
- `use-system.test.ts`