### PR TITLE
chore: set default dev build version to v0.15-dev

### DIFF
--- a/cmd/scanorama/main.go
+++ b/cmd/scanorama/main.go
@@ -7,7 +7,7 @@ import (
 
 // Build information - these will be set by ldflags during build.
 var (
-	version   = "dev"
+	version   = "v0.15-dev"
 	commit    = "none"
 	buildTime = "unknown"
 )

--- a/cmd/scanorama/main_test.go
+++ b/cmd/scanorama/main_test.go
@@ -15,7 +15,7 @@ func TestMain(m *testing.M) {
 
 func TestBuildVariables(t *testing.T) {
 	t.Run("build variables have default values", func(t *testing.T) {
-		assert.Equal(t, "dev", version)
+		assert.Equal(t, "v0.15-dev", version)
 		assert.Equal(t, "none", commit)
 		assert.Equal(t, "unknown", buildTime)
 	})


### PR DESCRIPTION
## Why

`git describe --tags --always HEAD` on this branch reports `v0.15.0-44-g...` — HEAD is 44 commits ahead of the `v0.15.0` tag. The `v0.16.0` tag lives on a different branch.

The generic `"dev"` fallback gives no indication of which release line a dev build belongs to. Changing it to `v0.15-dev` makes untagged local/CI builds immediately identifiable as pre-release work based on v0.15.

## What

- `cmd/scanorama/main.go`: `version = "v0.15-dev"`
- `cmd/scanorama/main_test.go`: update `TestBuildVariables` assertion to match

`make build` and release CI are unaffected — ldflags always override the default.