### PR TITLE
feat(frontend): networks & exclusions management (iteration 4)

### DIFF
--- a/FRONTEND_PLAN.md
+++ b/FRONTEND_PLAN.md
@@ -549,25 +549,34 @@ Each iteration is a **shippable increment** — it adds visible, testable functi
 
 ---
 
-### Iteration 4: Networks & Exclusions
+### Iteration 4: Networks & Exclusions ✅ DONE
 
 **Goal:** Manage networks and their exclusion ranges.
 
-- [ ] Networks list page (CIDR, host count, active hosts, last discovery, status)
-- [ ] Create network form (name, CIDR, discovery method, description)
-- [ ] Network detail page
-  - [ ] Network info card
-  - [ ] Hosts in this network (filtered host table)
-  - [ ] Exclusions sub-table
-  - [ ] Enable/disable toggle
-  - [ ] Rename action
-- [ ] Exclusion management
-  - [ ] Add exclusion form (CIDR, reason)
-  - [ ] Delete exclusion (with confirmation dialog)
-  - [ ] Global exclusions page at `/exclusions`
-- [ ] Tests for network CRUD, exclusion management
+- [x] Networks list page (CIDR, host count, active hosts, last discovery, status)
+- [x] Create network form (name, CIDR, discovery method, description)
+- [x] Network detail page
+  - [x] Network info card
+  - [ ] Hosts in this network (filtered host table) — skipped: API has no `network_id` host filter
+  - [x] Exclusions sub-table
+  - [x] Enable/disable toggle
+  - [x] Rename action (inline in panel header)
+- [x] Exclusion management
+  - [x] Add exclusion form (CIDR, reason)
+  - [x] Delete exclusion (with confirmation dialog)
+  - [x] Global exclusions page at `/exclusions`
+- [x] Tests for network CRUD, exclusion management
 
 **Deliverable:** Complete network management — add networks, define exclusions, see which hosts belong to which network.
+
+**Implementation notes:**
+- `src/api/hooks/use-networks.ts` — 13 hooks (5 queries + 8 mutations)
+- `src/components/add-network-modal.tsx` — Create network modal
+- `src/components/add-exclusion-modal.tsx` — Add exclusion modal (network-scoped or global)
+- `src/routes/networks.tsx` — Full Networks page with `NetworkDetailPanel` and `ExclusionsSection`
+- `src/routes/exclusions.tsx` — Global exclusions page at `/exclusions`
+- Exclusions nav item added to sidebar (`ShieldOff` icon)
+- 430 tests passing across 20 test files
 
 ---
 

--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -1,6 +1,20 @@
 export { useHealth, useStatus, useVersion } from "./use-system";
 export { useHosts, useHost, useActiveHostCount } from "./use-hosts";
-export { useNetworks, useNetworkStats } from "./use-networks";
+export {
+  useNetworks,
+  useNetwork,
+  useNetworkStats,
+  useNetworkExclusions,
+  useGlobalExclusions,
+  useCreateNetwork,
+  useDeleteNetwork,
+  useEnableNetwork,
+  useDisableNetwork,
+  useRenameNetwork,
+  useCreateNetworkExclusion,
+  useCreateGlobalExclusion,
+  useDeleteExclusion,
+} from "./use-networks";
 export { useProfile, useProfiles } from "./use-profiles";
 export {
   useScans,

--- a/frontend/src/api/hooks/use-networks.test.ts
+++ b/frontend/src/api/hooks/use-networks.test.ts
@@ -1,17 +1,34 @@
 import { waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHookWithQuery } from "../../test/utils";
-import { useNetworks, useNetworkStats } from "./use-networks";
+import {
+  useNetworks,
+  useNetworkStats,
+  useNetwork,
+  useNetworkExclusions,
+  useGlobalExclusions,
+  useCreateNetwork,
+  useDeleteNetwork,
+  useEnableNetwork,
+  useDisableNetwork,
+  useRenameNetwork,
+  useDeleteExclusion,
+} from "./use-networks";
 
 vi.mock("../client", () => ({
   api: {
     GET: vi.fn(),
     POST: vi.fn(),
+    PUT: vi.fn(),
+    DELETE: vi.fn(),
   },
 }));
 
 import { api } from "../client";
 const mockGet = vi.mocked(api.GET);
+const mockPost = vi.mocked(api.POST);
+const mockPut = vi.mocked(api.PUT);
+const mockDelete = vi.mocked(api.DELETE);
 
 const ok = (data: unknown): ReturnType<typeof mockGet> =>
   Promise.resolve({
@@ -56,6 +73,88 @@ const mockStats = {
   hosts: { total: 42, active: 30 },
   exclusions: { total: 5 },
 };
+
+const mockNetwork = {
+  id: "net-1",
+  name: "Office LAN",
+  cidr: "192.168.1.0/24",
+  is_active: true,
+  host_count: 25,
+  active_host_count: 20,
+  discovery_method: "ping",
+  scan_enabled: true,
+  created_by: "admin",
+  created_at: "2024-01-01T00:00:00Z",
+};
+
+const mockExclusions = [
+  {
+    id: "excl-1",
+    network_id: "net-1",
+    excluded_cidr: "192.168.1.128/25",
+    reason: "Printers",
+    created_by: "admin",
+    created_at: "2024-01-02T00:00:00Z",
+    enabled: true,
+  },
+  {
+    id: "excl-2",
+    network_id: "net-1",
+    excluded_cidr: "192.168.1.200/30",
+    reason: "Management",
+    created_by: "admin",
+    created_at: "2024-01-03T00:00:00Z",
+    enabled: true,
+  },
+];
+
+const okPost = (data: unknown): ReturnType<typeof mockPost> =>
+  Promise.resolve({
+    data,
+    error: undefined,
+    response: new Response(),
+  }) as ReturnType<typeof mockPost>;
+
+const failPost = (
+  message = "something went wrong",
+): ReturnType<typeof mockPost> =>
+  Promise.resolve({
+    data: undefined,
+    error: { message },
+    response: new Response(),
+  }) as ReturnType<typeof mockPost>;
+
+const okPut = (data: unknown): ReturnType<typeof mockPut> =>
+  Promise.resolve({
+    data,
+    error: undefined,
+    response: new Response(),
+  }) as ReturnType<typeof mockPut>;
+
+const failPut = (
+  message = "something went wrong",
+): ReturnType<typeof mockPut> =>
+  Promise.resolve({
+    data: undefined,
+    error: { message },
+    response: new Response(),
+  }) as ReturnType<typeof mockPut>;
+
+const okDelete = (): ReturnType<typeof mockDelete> =>
+  Promise.resolve({
+    data: undefined,
+    error: undefined,
+    response: new Response(),
+  }) as ReturnType<typeof mockDelete>;
+
+const failDelete = (
+  message = "something went wrong",
+): ReturnType<typeof mockDelete> =>
+  Promise.resolve({
+    data: undefined,
+    error: { message },
+    response: new Response(),
+  }) as ReturnType<typeof mockDelete>;
 
 // ── useNetworks ───────────────────────────────────────────────────────────────
 
@@ -148,6 +247,483 @@ describe("useNetworks", () => {
 
     const cached = queryClient.getQueryData(["networks", params]);
     expect(cached).toBeDefined();
+  });
+});
+
+// ── useNetwork ────────────────────────────────────────────────────────────────
+
+describe("useNetwork", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in a loading state when id is provided", () => {
+    mockGet.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHookWithQuery(() => useNetwork("net-1"));
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("is disabled (not loading) when id is empty", () => {
+    mockGet.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHookWithQuery(() => useNetwork(""));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("returns network data on success", async () => {
+    mockGet.mockResolvedValue(ok(mockNetwork));
+    const { result } = renderHookWithQuery(() => useNetwork("net-1"));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.id).toBe("net-1");
+    expect(result.current.data?.name).toBe("Office LAN");
+    expect(result.current.data?.cidr).toBe("192.168.1.0/24");
+  });
+
+  it("calls api.GET with the correct path param", async () => {
+    mockGet.mockResolvedValue(ok(mockNetwork));
+    const { result } = renderHookWithQuery(() => useNetwork("net-42"));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith(
+      "/networks/{networkId}",
+      expect.objectContaining({ params: { path: { networkId: "net-42" } } }),
+    );
+  });
+
+  it("enters error state when api.GET returns an error", async () => {
+    mockGet.mockResolvedValue(fail("not found"));
+    const { result } = renderHookWithQuery(() => useNetwork("net-1"));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("caches under the ['networks', id] query key", async () => {
+    mockGet.mockResolvedValue(ok(mockNetwork));
+    const { result, queryClient } = renderHookWithQuery(() =>
+      useNetwork("net-1"),
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const cached = queryClient.getQueryData(["networks", "net-1"]);
+    expect(cached).toBeDefined();
+  });
+});
+
+// ── useNetworkExclusions ──────────────────────────────────────────────────────
+
+describe("useNetworkExclusions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in a loading state when networkId is provided", () => {
+    mockGet.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHookWithQuery(() => useNetworkExclusions("net-1"));
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("is disabled when networkId is empty", () => {
+    mockGet.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHookWithQuery(() => useNetworkExclusions(""));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("returns an array of exclusions on success", async () => {
+    mockGet.mockResolvedValue(ok(mockExclusions));
+    const { result } = renderHookWithQuery(() => useNetworkExclusions("net-1"));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.data?.[0].excluded_cidr).toBe("192.168.1.128/25");
+    expect(result.current.data?.[1].excluded_cidr).toBe("192.168.1.200/30");
+  });
+
+  it("returns an empty array when no exclusions exist", async () => {
+    mockGet.mockResolvedValue(ok([]));
+    const { result } = renderHookWithQuery(() => useNetworkExclusions("net-1"));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(0);
+  });
+
+  it("calls api.GET with the correct path param", async () => {
+    mockGet.mockResolvedValue(ok(mockExclusions));
+    const { result } = renderHookWithQuery(() =>
+      useNetworkExclusions("net-99"),
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith(
+      "/networks/{networkId}/exclusions",
+      expect.objectContaining({
+        params: { path: { networkId: "net-99" } },
+      }),
+    );
+  });
+
+  it("enters error state when api.GET returns an error", async () => {
+    mockGet.mockResolvedValue(fail("forbidden"));
+    const { result } = renderHookWithQuery(() => useNetworkExclusions("net-1"));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("caches under the ['networks', networkId, 'exclusions'] query key", async () => {
+    mockGet.mockResolvedValue(ok(mockExclusions));
+    const { result, queryClient } = renderHookWithQuery(() =>
+      useNetworkExclusions("net-1"),
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const cached = queryClient.getQueryData([
+      "networks",
+      "net-1",
+      "exclusions",
+    ]);
+    expect(cached).toBeDefined();
+  });
+});
+
+// ── useGlobalExclusions ───────────────────────────────────────────────────────
+
+describe("useGlobalExclusions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in a loading state", () => {
+    mockGet.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHookWithQuery(() => useGlobalExclusions());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("returns global exclusions on success", async () => {
+    const globalExcl = [
+      {
+        id: "g-1",
+        excluded_cidr: "10.0.0.0/8",
+        reason: "Private range",
+        created_by: "admin",
+        created_at: "2024-01-01T00:00:00Z",
+        enabled: true,
+      },
+    ];
+    mockGet.mockResolvedValue(ok(globalExcl));
+    const { result } = renderHookWithQuery(() => useGlobalExclusions());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].excluded_cidr).toBe("10.0.0.0/8");
+  });
+
+  it("returns an empty array when no global exclusions exist", async () => {
+    mockGet.mockResolvedValue(ok([]));
+    const { result } = renderHookWithQuery(() => useGlobalExclusions());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(0);
+  });
+
+  it("calls api.GET with the /exclusions path", async () => {
+    mockGet.mockResolvedValue(ok([]));
+    const { result } = renderHookWithQuery(() => useGlobalExclusions());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith("/exclusions");
+  });
+
+  it("enters error state when api.GET returns an error", async () => {
+    mockGet.mockResolvedValue(fail("server error"));
+    const { result } = renderHookWithQuery(() => useGlobalExclusions());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("caches under the ['exclusions', 'global'] query key", async () => {
+    mockGet.mockResolvedValue(ok([]));
+    const { result, queryClient } = renderHookWithQuery(() =>
+      useGlobalExclusions(),
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const cached = queryClient.getQueryData(["exclusions", "global"]);
+    expect(cached).toBeDefined();
+  });
+});
+
+// ── useCreateNetwork ──────────────────────────────────────────────────────────
+
+describe("useCreateNetwork", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in idle state", () => {
+    const { result } = renderHookWithQuery(() => useCreateNetwork());
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.isSuccess).toBe(false);
+  });
+
+  it("returns the created network on success", async () => {
+    mockPost.mockResolvedValue(okPost(mockNetwork));
+    const { result, actHook } = renderHookWithQuery(() => useCreateNetwork());
+    let created: typeof mockNetwork | undefined;
+    await actHook(async () => {
+      created = (await result.current.mutateAsync({
+        name: "Office LAN",
+        cidr: "192.168.1.0/24",
+        discovery_method: "ping",
+        scan_enabled: true,
+        is_active: true,
+      })) as typeof mockNetwork;
+    });
+    expect(created?.id).toBe("net-1");
+    expect(created?.name).toBe("Office LAN");
+  });
+
+  it("calls api.POST with /networks and the request body", async () => {
+    mockPost.mockResolvedValue(okPost(mockNetwork));
+    const body = {
+      name: "DMZ",
+      cidr: "10.0.0.0/8",
+      discovery_method: "tcp" as const,
+      scan_enabled: false,
+      is_active: true,
+    };
+    const { result, actHook } = renderHookWithQuery(() => useCreateNetwork());
+    await actHook(async () => {
+      await result.current.mutateAsync(body);
+    });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/networks",
+      expect.objectContaining({ body }),
+    );
+  });
+
+  it("throws a descriptive error when api.POST returns an error", async () => {
+    mockPost.mockResolvedValue(failPost("CIDR already exists"));
+    const { result, actHook } = renderHookWithQuery(() => useCreateNetwork());
+    await actHook(async () => {
+      await expect(
+        result.current.mutateAsync({ name: "Dup", cidr: "192.168.1.0/24" }),
+      ).rejects.toThrow("CIDR already exists");
+    });
+  });
+
+  it("invalidates ['networks'] queries on success", async () => {
+    mockPost.mockResolvedValue(okPost(mockNetwork));
+    mockGet.mockResolvedValue(
+      ok({ data: [mockNetwork], pagination: mockPagination }),
+    );
+    const { result, queryClient, actHook } = renderHookWithQuery(() =>
+      useCreateNetwork(),
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    await actHook(async () => {
+      await result.current.mutateAsync({
+        name: "Office LAN",
+        cidr: "192.168.1.0/24",
+      });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["networks"] }),
+    );
+  });
+});
+
+// ── useDeleteNetwork ──────────────────────────────────────────────────────────
+
+describe("useDeleteNetwork", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in idle state", () => {
+    const { result } = renderHookWithQuery(() => useDeleteNetwork());
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("calls api.DELETE with the correct path param", async () => {
+    mockDelete.mockResolvedValue(okDelete());
+    const { result, actHook } = renderHookWithQuery(() => useDeleteNetwork());
+    await actHook(async () => {
+      await result.current.mutateAsync("net-1");
+    });
+    expect(mockDelete).toHaveBeenCalledWith(
+      "/networks/{networkId}",
+      expect.objectContaining({ params: { path: { networkId: "net-1" } } }),
+    );
+  });
+
+  it("throws a descriptive error when api.DELETE returns an error", async () => {
+    mockDelete.mockResolvedValue(failDelete("network not found"));
+    const { result, actHook } = renderHookWithQuery(() => useDeleteNetwork());
+    await actHook(async () => {
+      await expect(result.current.mutateAsync("net-99")).rejects.toThrow(
+        "network not found",
+      );
+    });
+  });
+
+  it("invalidates ['networks'] queries on success", async () => {
+    mockDelete.mockResolvedValue(okDelete());
+    const { result, queryClient, actHook } = renderHookWithQuery(() =>
+      useDeleteNetwork(),
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    await actHook(async () => {
+      await result.current.mutateAsync("net-1");
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["networks"] }),
+    );
+  });
+});
+
+// ── useEnableNetwork / useDisableNetwork ──────────────────────────────────────
+
+describe("useEnableNetwork", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls api.POST with /networks/{networkId}/enable", async () => {
+    mockPost.mockResolvedValue(okPost({ ...mockNetwork, is_active: true }));
+    const { result, actHook } = renderHookWithQuery(() => useEnableNetwork());
+    await actHook(async () => {
+      await result.current.mutateAsync("net-1");
+    });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/networks/{networkId}/enable",
+      expect.objectContaining({ params: { path: { networkId: "net-1" } } }),
+    );
+  });
+
+  it("throws a descriptive error on failure", async () => {
+    mockPost.mockResolvedValue(failPost("already enabled"));
+    const { result, actHook } = renderHookWithQuery(() => useEnableNetwork());
+    await actHook(async () => {
+      await expect(result.current.mutateAsync("net-1")).rejects.toThrow(
+        "already enabled",
+      );
+    });
+  });
+});
+
+describe("useDisableNetwork", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls api.POST with /networks/{networkId}/disable", async () => {
+    mockPost.mockResolvedValue(okPost({ ...mockNetwork, is_active: false }));
+    const { result, actHook } = renderHookWithQuery(() => useDisableNetwork());
+    await actHook(async () => {
+      await result.current.mutateAsync("net-1");
+    });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/networks/{networkId}/disable",
+      expect.objectContaining({ params: { path: { networkId: "net-1" } } }),
+    );
+  });
+
+  it("throws a descriptive error on failure", async () => {
+    mockPost.mockResolvedValue(failPost("cannot disable last network"));
+    const { result, actHook } = renderHookWithQuery(() => useDisableNetwork());
+    await actHook(async () => {
+      await expect(result.current.mutateAsync("net-1")).rejects.toThrow(
+        "cannot disable last network",
+      );
+    });
+  });
+});
+
+// ── useRenameNetwork ──────────────────────────────────────────────────────────
+
+describe("useRenameNetwork", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls api.PUT with the correct path and body", async () => {
+    mockPut.mockResolvedValue(okPut({ ...mockNetwork, name: "New Name" }));
+    const { result, actHook } = renderHookWithQuery(() => useRenameNetwork());
+    await actHook(async () => {
+      await result.current.mutateAsync({
+        networkId: "net-1",
+        newName: "New Name",
+      });
+    });
+    expect(mockPut).toHaveBeenCalledWith(
+      "/networks/{networkId}/rename",
+      expect.objectContaining({
+        params: { path: { networkId: "net-1" } },
+        body: { new_name: "New Name" },
+      }),
+    );
+  });
+
+  it("returns the updated network on success", async () => {
+    const renamed = { ...mockNetwork, name: "Renamed LAN" };
+    mockPut.mockResolvedValue(okPut(renamed));
+    const { result, actHook } = renderHookWithQuery(() => useRenameNetwork());
+    let updated: typeof renamed | undefined;
+    await actHook(async () => {
+      updated = (await result.current.mutateAsync({
+        networkId: "net-1",
+        newName: "Renamed LAN",
+      })) as typeof renamed;
+    });
+    expect(updated?.name).toBe("Renamed LAN");
+  });
+
+  it("throws a descriptive error on failure", async () => {
+    mockPut.mockResolvedValue(failPut("name already taken"));
+    const { result, actHook } = renderHookWithQuery(() => useRenameNetwork());
+    await actHook(async () => {
+      await expect(
+        result.current.mutateAsync({ networkId: "net-1", newName: "Dup" }),
+      ).rejects.toThrow("name already taken");
+    });
+  });
+});
+
+// ── useDeleteExclusion ────────────────────────────────────────────────────────
+
+describe("useDeleteExclusion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls api.DELETE with the correct exclusion path", async () => {
+    mockDelete.mockResolvedValue(okDelete());
+    const { result, actHook } = renderHookWithQuery(() => useDeleteExclusion());
+    await actHook(async () => {
+      await result.current.mutateAsync("excl-1");
+    });
+    expect(mockDelete).toHaveBeenCalledWith(
+      "/exclusions/{exclusionId}",
+      expect.objectContaining({
+        params: { path: { exclusionId: "excl-1" } },
+      }),
+    );
+  });
+
+  it("throws a descriptive error on failure", async () => {
+    mockDelete.mockResolvedValue(failDelete("exclusion not found"));
+    const { result, actHook } = renderHookWithQuery(() => useDeleteExclusion());
+    await actHook(async () => {
+      await expect(result.current.mutateAsync("excl-99")).rejects.toThrow(
+        "exclusion not found",
+      );
+    });
+  });
+
+  it("invalidates both ['networks'] and ['exclusions'] on success", async () => {
+    mockDelete.mockResolvedValue(okDelete());
+    const { result, queryClient, actHook } = renderHookWithQuery(() =>
+      useDeleteExclusion(),
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    await actHook(async () => {
+      await result.current.mutateAsync("excl-1");
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["networks"] }),
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["exclusions"] }),
+    );
   });
 });
 

--- a/frontend/src/api/hooks/use-networks.ts
+++ b/frontend/src/api/hooks/use-networks.ts
@@ -1,10 +1,19 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../client";
+import type { components } from "../types";
+
+type CreateNetworkRequest = components["schemas"]["docs.CreateNetworkRequest"];
+type CreateExclusionRequest =
+  components["schemas"]["docs.CreateExclusionRequest"];
 
 interface NetworkListParams {
   page?: number;
   page_size?: number;
+  show_inactive?: boolean;
+  name?: string;
 }
+
+// ── Queries ─────────────────────────────────────────────────────────────────────────────────────
 
 export function useNetworks(params: NetworkListParams = {}) {
   return useQuery({
@@ -19,6 +28,20 @@ export function useNetworks(params: NetworkListParams = {}) {
   });
 }
 
+export function useNetwork(id: string) {
+  return useQuery({
+    queryKey: ["networks", id],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/networks/{networkId}", {
+        params: { path: { networkId: id } },
+      });
+      if (error) throw error;
+      return data;
+    },
+    enabled: !!id,
+  });
+}
+
 export function useNetworkStats() {
   return useQuery({
     queryKey: ["networks", "stats"],
@@ -28,5 +51,217 @@ export function useNetworkStats() {
       return data;
     },
     refetchInterval: 30_000,
+  });
+}
+
+export function useNetworkExclusions(networkId: string) {
+  return useQuery({
+    queryKey: ["networks", networkId, "exclusions"],
+    queryFn: async () => {
+      const { data, error } = await api.GET(
+        "/networks/{networkId}/exclusions",
+        {
+          params: { path: { networkId } },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+    enabled: !!networkId,
+  });
+}
+
+export function useGlobalExclusions() {
+  return useQuery({
+    queryKey: ["exclusions", "global"],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/exclusions");
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+// ── Mutations ─────────────────────────────────────────────────────────────────────────────────
+
+export function useCreateNetwork() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: CreateNetworkRequest) => {
+      const { data, error } = await api.POST("/networks", { body });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to create network.",
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["networks"] });
+    },
+  });
+}
+
+export function useDeleteNetwork() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (networkId: string) => {
+      const { error } = await api.DELETE("/networks/{networkId}", {
+        params: { path: { networkId } },
+      });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to delete network.",
+        );
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["networks"] });
+    },
+  });
+}
+
+export function useEnableNetwork() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (networkId: string) => {
+      const { data, error } = await api.POST("/networks/{networkId}/enable", {
+        params: { path: { networkId } },
+      });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to enable network.",
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["networks"] });
+    },
+  });
+}
+
+export function useDisableNetwork() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (networkId: string) => {
+      const { data, error } = await api.POST("/networks/{networkId}/disable", {
+        params: { path: { networkId } },
+      });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to disable network.",
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["networks"] });
+    },
+  });
+}
+
+export function useRenameNetwork() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      networkId,
+      newName,
+    }: {
+      networkId: string;
+      newName: string;
+    }) => {
+      const { data, error } = await api.PUT("/networks/{networkId}/rename", {
+        params: { path: { networkId } },
+        body: { new_name: newName },
+      });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to rename network.",
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["networks"] });
+    },
+  });
+}
+
+export function useCreateNetworkExclusion() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      networkId,
+      body,
+    }: {
+      networkId: string;
+      body: CreateExclusionRequest;
+    }) => {
+      const { data, error } = await api.POST(
+        "/networks/{networkId}/exclusions",
+        {
+          params: { path: { networkId } },
+          body,
+        },
+      );
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to add exclusion.",
+        );
+      }
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["networks", variables.networkId, "exclusions"],
+      });
+    },
+  });
+}
+
+export function useCreateGlobalExclusion() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: CreateExclusionRequest) => {
+      const { data, error } = await api.POST("/exclusions", { body });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to add exclusion.",
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["exclusions"] });
+    },
+  });
+}
+
+export function useDeleteExclusion() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (exclusionId: string) => {
+      const { error } = await api.DELETE("/exclusions/{exclusionId}", {
+        params: { path: { exclusionId } },
+      });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to delete exclusion.",
+        );
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["networks"] });
+      queryClient.invalidateQueries({ queryKey: ["exclusions"] });
+    },
   });
 }

--- a/frontend/src/components/add-exclusion-modal.tsx
+++ b/frontend/src/components/add-exclusion-modal.tsx
@@ -1,0 +1,201 @@
+import { useState, useId } from "react";
+import { X, Loader2 } from "lucide-react";
+import { Button } from "./button";
+import {
+  useCreateNetworkExclusion,
+  useCreateGlobalExclusion,
+} from "../api/hooks/use-networks";
+import { cn } from "../lib/utils";
+
+export interface AddExclusionModalProps {
+  /**
+   * If provided, the exclusion will be scoped to this network.
+   * If omitted, a global exclusion will be created.
+   */
+  networkId?: string;
+  onClose: () => void;
+  onCreated?: () => void;
+}
+
+export function AddExclusionModal({
+  networkId,
+  onClose,
+  onCreated,
+}: AddExclusionModalProps) {
+  const id = useId();
+
+  const [cidr, setCidr] = useState("");
+  const [reason, setReason] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const { mutateAsync: createNetworkExclusion, isPending: isNetworkPending } =
+    useCreateNetworkExclusion();
+  const { mutateAsync: createGlobalExclusion, isPending: isGlobalPending } =
+    useCreateGlobalExclusion();
+
+  const isPending = isNetworkPending || isGlobalPending;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const trimmedCidr = cidr.trim();
+
+    if (!trimmedCidr) {
+      setError("CIDR block is required (e.g. 192.168.1.128/25).");
+      return;
+    }
+
+    if (!/^[\da-fA-F:./]+\/\d+$/.test(trimmedCidr)) {
+      setError(
+        "CIDR block must be in valid notation (e.g. 192.168.1.128/25 or 10.0.1.0/24).",
+      );
+      return;
+    }
+
+    const body = {
+      excluded_cidr: trimmedCidr,
+      reason: reason.trim() || undefined,
+    };
+
+    try {
+      if (networkId) {
+        await createNetworkExclusion({ networkId, body });
+      } else {
+        await createGlobalExclusion(body);
+      }
+      onCreated?.();
+      onClose();
+    } catch (err) {
+      const apiErr = err as { message?: string; error?: string };
+      setError(apiErr.message ?? apiErr.error ?? "Failed to add exclusion.");
+    }
+  }
+
+  const isGlobal = !networkId;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Dialog */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${id}-title`}
+        className={cn(
+          "fixed z-50 inset-0 m-auto",
+          "w-full max-w-md h-fit",
+          "bg-surface border border-border rounded-lg shadow-xl",
+          "flex flex-col",
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+          <h2
+            id={`${id}-title`}
+            className="text-sm font-semibold text-text-primary"
+          >
+            {isGlobal ? "Add Global Exclusion" : "Add Exclusion"}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close dialog"
+            className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <form onSubmit={handleSubmit} className="px-5 py-4 space-y-5">
+          {isGlobal && (
+            <p className="text-xs text-text-muted leading-relaxed">
+              Global exclusions apply to all networks — hosts in these CIDR
+              ranges will never be scanned or discovered.
+            </p>
+          )}
+
+          {/* CIDR */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-cidr`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              CIDR block
+            </label>
+            <input
+              id={`${id}-cidr`}
+              type="text"
+              value={cidr}
+              onChange={(e) => setCidr(e.target.value)}
+              placeholder="192.168.1.128/25"
+              autoFocus
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border font-mono",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+            <p className="text-xs text-text-muted">
+              IPv4 or IPv6 CIDR notation (e.g. 192.168.1.128/25).
+            </p>
+          </div>
+
+          {/* Reason */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-reason`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Reason{" "}
+              <span className="text-text-muted font-normal">(optional)</span>
+            </label>
+            <input
+              id={`${id}-reason`}
+              type="text"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Reserved for printers"
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+          </div>
+
+          {/* Inline error */}
+          {error && (
+            <p role="alert" className="text-xs text-danger">
+              {error}
+            </p>
+          )}
+
+          {/* Footer */}
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="secondary" type="button" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" loading={isPending}>
+              {isPending ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Adding…
+                </>
+              ) : (
+                "Add exclusion"
+              )}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/add-network-modal.tsx
+++ b/frontend/src/components/add-network-modal.tsx
@@ -1,0 +1,263 @@
+import { useState, useId } from "react";
+import { X, Loader2 } from "lucide-react";
+import { Button } from "./button";
+import { useCreateNetwork } from "../api/hooks/use-networks";
+import { cn } from "../lib/utils";
+
+const DISCOVERY_METHODS = [
+  { value: "ping", label: "Ping (ICMP echo)" },
+  { value: "tcp", label: "TCP connect" },
+  { value: "arp", label: "ARP broadcast" },
+  { value: "icmp", label: "ICMP" },
+] as const;
+
+type DiscoveryMethod = (typeof DISCOVERY_METHODS)[number]["value"];
+
+export interface AddNetworkModalProps {
+  onClose: () => void;
+  onCreated?: () => void;
+}
+
+export function AddNetworkModal({ onClose, onCreated }: AddNetworkModalProps) {
+  const id = useId();
+
+  const [name, setName] = useState("");
+  const [cidr, setCidr] = useState("");
+  const [description, setDescription] = useState("");
+  const [discoveryMethod, setDiscoveryMethod] =
+    useState<DiscoveryMethod>("ping");
+  const [scanEnabled, setScanEnabled] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const { mutateAsync: createNetwork, isPending } = useCreateNetwork();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const trimmedName = name.trim();
+    const trimmedCidr = cidr.trim();
+
+    if (!trimmedName) {
+      setError("Network name is required.");
+      return;
+    }
+
+    if (!trimmedCidr) {
+      setError("CIDR block is required (e.g. 192.168.1.0/24).");
+      return;
+    }
+
+    // Basic CIDR format check: x.x.x.x/n or IPv6-ish
+    if (!/^[\da-fA-F:./]+\/\d+$/.test(trimmedCidr)) {
+      setError(
+        "CIDR block must be in valid notation (e.g. 192.168.1.0/24 or 10.0.0.0/8).",
+      );
+      return;
+    }
+
+    try {
+      await createNetwork({
+        name: trimmedName,
+        cidr: trimmedCidr,
+        description: description.trim() || undefined,
+        discovery_method: discoveryMethod,
+        scan_enabled: scanEnabled,
+        is_active: true,
+      });
+      onCreated?.();
+      onClose();
+    } catch (err) {
+      const apiErr = err as { message?: string; error?: string };
+      setError(
+        apiErr.message ?? apiErr.error ?? "Failed to create network.",
+      );
+    }
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Dialog */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${id}-title`}
+        className={cn(
+          "fixed z-50 inset-0 m-auto",
+          "w-full max-w-md h-fit",
+          "bg-surface border border-border rounded-lg shadow-xl",
+          "flex flex-col",
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+          <h2
+            id={`${id}-title`}
+            className="text-sm font-semibold text-text-primary"
+          >
+            Add Network
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close dialog"
+            className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <form onSubmit={handleSubmit} className="px-5 py-4 space-y-5">
+          {/* Name */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-name`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Name
+            </label>
+            <input
+              id={`${id}-name`}
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Office LAN"
+              autoFocus
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+          </div>
+
+          {/* CIDR */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-cidr`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              CIDR block
+            </label>
+            <input
+              id={`${id}-cidr`}
+              type="text"
+              value={cidr}
+              onChange={(e) => setCidr(e.target.value)}
+              placeholder="192.168.1.0/24"
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border font-mono",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+            <p className="text-xs text-text-muted">
+              IPv4 or IPv6 CIDR notation (e.g. 10.0.0.0/8).
+            </p>
+          </div>
+
+          {/* Description */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-description`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Description{" "}
+              <span className="text-text-muted font-normal">(optional)</span>
+            </label>
+            <input
+              id={`${id}-description`}
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Main office network"
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+          </div>
+
+          {/* Discovery method */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-discovery`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Discovery method
+            </label>
+            <select
+              id={`${id}-discovery`}
+              value={discoveryMethod}
+              onChange={(e) =>
+                setDiscoveryMethod(e.target.value as DiscoveryMethod)
+              }
+              aria-label="Select discovery method"
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            >
+              {DISCOVERY_METHODS.map((m) => (
+                <option key={m.value} value={m.value}>
+                  {m.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Scan enabled */}
+          <div className="flex items-center gap-2">
+            <input
+              id={`${id}-scan-enabled`}
+              type="checkbox"
+              checked={scanEnabled}
+              onChange={(e) => setScanEnabled(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-border accent-accent"
+            />
+            <label
+              htmlFor={`${id}-scan-enabled`}
+              className="text-xs text-text-primary"
+            >
+              Enable scanning for this network
+            </label>
+          </div>
+
+          {/* Inline error */}
+          {error && (
+            <p role="alert" className="text-xs text-danger">
+              {error}
+            </p>
+          )}
+
+          {/* Footer */}
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="secondary" type="button" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" loading={isPending}>
+              {isPending ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Creating…
+                </>
+              ) : (
+                "Add network"
+              )}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -7,4 +7,6 @@ export { Skeleton } from "./skeleton";
 export { RecentScansTable } from "./recent-scans-table";
 export { PaginationBar } from "./pagination-bar";
 export { RunScanModal } from "./run-scan-modal";
+export { AddNetworkModal } from "./add-network-modal";
+export { AddExclusionModal } from "./add-exclusion-modal";
 export * from "./layout";

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -8,6 +8,7 @@ import {
   SlidersHorizontal,
   Clock,
   Shield,
+  ShieldOff,
   PanelLeftClose,
   PanelLeftOpen,
 } from "lucide-react";
@@ -23,7 +24,7 @@ const mainNav: NavItem[] = [
   { label: "Scans", href: "#/scans", icon: Radar },
   { label: "Hosts", href: "#/hosts", icon: Server },
   { label: "Networks", href: "#/networks", icon: Network },
-
+  { label: "Exclusions", href: "#/exclusions", icon: ShieldOff },
   { label: "Profiles", href: "#/profiles", icon: SlidersHorizontal },
   { label: "Schedules", href: "#/schedules", icon: Clock },
 ];

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -9,7 +9,7 @@ import { DashboardPage } from "./routes/dashboard";
 import { ScansPage } from "./routes/scans";
 import { HostsPage } from "./routes/hosts";
 import { NetworksPage } from "./routes/networks";
-
+import { ExclusionsPage } from "./routes/exclusions";
 import { ProfilesPage } from "./routes/profiles";
 import { SchedulesPage } from "./routes/schedules";
 import { AdminPage } from "./routes/admin";
@@ -42,6 +42,12 @@ const networksRoute = createRoute({
   component: NetworksPage,
 });
 
+const exclusionsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/exclusions",
+  component: ExclusionsPage,
+});
+
 const profilesRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/profiles",
@@ -65,6 +71,7 @@ const routeTree = rootRoute.addChildren([
   scansRoute,
   hostsRoute,
   networksRoute,
+  exclusionsRoute,
   profilesRoute,
   schedulesRoute,
   adminRoute,

--- a/frontend/src/routes/exclusions.test.tsx
+++ b/frontend/src/routes/exclusions.test.tsx
@@ -1,0 +1,262 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ExclusionsPage } from "./exclusions";
+
+vi.mock("../api/hooks/use-networks", () => ({
+  useGlobalExclusions: vi.fn(),
+  useDeleteExclusion: vi.fn(),
+}));
+
+vi.mock("../components/add-exclusion-modal", () => ({
+  AddExclusionModal: ({
+    onClose,
+  }: {
+    networkId?: string;
+    onClose: () => void;
+    onCreated?: () => void;
+  }) => (
+    <div role="dialog" aria-label="Add Global Exclusion">
+      <button type="button" onClick={onClose}>
+        Close modal
+      </button>
+    </div>
+  ),
+}));
+
+import { useGlobalExclusions, useDeleteExclusion } from "../api/hooks/use-networks";
+
+const mockUseGlobalExclusions = vi.mocked(useGlobalExclusions);
+const mockUseDeleteExclusion = vi.mocked(useDeleteExclusion);
+
+const mockExclusions = [
+  {
+    id: "excl-1",
+    excluded_cidr: "10.0.0.0/8",
+    reason: "Private range",
+    created_by: "admin",
+    created_at: "2024-01-01T00:00:00Z",
+    enabled: true,
+  },
+  {
+    id: "excl-2",
+    excluded_cidr: "192.168.100.0/24",
+    reason: "Test environment",
+    created_by: "ops",
+    created_at: "2024-02-15T12:00:00Z",
+    enabled: true,
+  },
+  {
+    id: "excl-3",
+    excluded_cidr: "172.16.0.0/12",
+    reason: undefined,
+    created_by: "admin",
+    created_at: "2024-03-01T08:30:00Z",
+    enabled: false,
+  },
+];
+
+function makeDeleteResult(overrides = {}) {
+  return {
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+    isSuccess: false,
+    isError: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useDeleteExclusion>;
+}
+
+function makeQueryResult(overrides = {}) {
+  return {
+    data: mockExclusions,
+    isLoading: false,
+    isSuccess: true,
+    isError: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useGlobalExclusions>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseGlobalExclusions.mockReturnValue(makeQueryResult());
+  mockUseDeleteExclusion.mockReturnValue(makeDeleteResult());
+});
+
+describe("ExclusionsPage", () => {
+  // ── Loading state ────────────────────────────────────────────────────────
+  it("renders skeleton rows while loading", () => {
+    mockUseGlobalExclusions.mockReturnValue(
+      makeQueryResult({ data: undefined, isLoading: true, isSuccess: false }),
+    );
+    const { container } = render(<ExclusionsPage />);
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("does not show the empty message while loading", () => {
+    mockUseGlobalExclusions.mockReturnValue(
+      makeQueryResult({ data: undefined, isLoading: true, isSuccess: false }),
+    );
+    render(<ExclusionsPage />);
+    expect(
+      screen.queryByText("No global exclusions defined."),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── Empty state ──────────────────────────────────────────────────────────
+  it("shows empty message when there are no global exclusions", () => {
+    mockUseGlobalExclusions.mockReturnValue(
+      makeQueryResult({ data: [] }),
+    );
+    render(<ExclusionsPage />);
+    expect(
+      screen.getByText("No global exclusions defined."),
+    ).toBeInTheDocument();
+  });
+
+  // ── Table structure ──────────────────────────────────────────────────────
+  it("renders all column headers", () => {
+    render(<ExclusionsPage />);
+    expect(
+      screen.getByRole("columnheader", { name: "CIDR Block" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Reason" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Created By" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Created At" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders one data row per exclusion", () => {
+    render(<ExclusionsPage />);
+    // 1 header + 3 data rows
+    expect(screen.getAllByRole("row")).toHaveLength(4);
+  });
+
+  // ── Data rendering ───────────────────────────────────────────────────────
+  it("renders CIDR blocks in monospace font", () => {
+    render(<ExclusionsPage />);
+    expect(screen.getByText("10.0.0.0/8")).toBeInTheDocument();
+    expect(screen.getByText("192.168.100.0/24")).toBeInTheDocument();
+    expect(screen.getByText("172.16.0.0/12")).toBeInTheDocument();
+  });
+
+  it("renders reason text when present", () => {
+    render(<ExclusionsPage />);
+    expect(screen.getByText("Private range")).toBeInTheDocument();
+    expect(screen.getByText("Test environment")).toBeInTheDocument();
+  });
+
+  it("renders em-dash for missing reason", () => {
+    render(<ExclusionsPage />);
+    const rows = screen.getAllByRole("row");
+    // excl-3 (172.16.0.0/12) has no reason — it's the third data row (index 3)
+    const cells = within(rows[3]).getAllByRole("cell");
+    // Reason is column index 1
+    expect(cells[1]).toHaveTextContent("—");
+  });
+
+  it("renders created_by values", () => {
+    render(<ExclusionsPage />);
+    expect(screen.getAllByText("admin")).toHaveLength(2);
+    expect(screen.getByText("ops")).toBeInTheDocument();
+  });
+
+  it("renders a relative timestamp for created_at", () => {
+    render(<ExclusionsPage />);
+    // All dates in the past → should show relative format like "Xd ago" or similar
+    const rows = screen.getAllByRole("row");
+    const firstDataCells = within(rows[1]).getAllByRole("cell");
+    // created_at is index 3
+    expect(firstDataCells[3].textContent).not.toBe("");
+    expect(firstDataCells[3].textContent).not.toBe("—");
+  });
+
+  // ── Toolbar ──────────────────────────────────────────────────────────────
+  it("renders the description text about global exclusions", () => {
+    render(<ExclusionsPage />);
+    expect(
+      screen.getByText(/global exclusions apply to all networks/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the Add exclusion button", () => {
+    render(<ExclusionsPage />);
+    expect(
+      screen.getByRole("button", { name: /add exclusion/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── Add exclusion modal ──────────────────────────────────────────────────
+  it("opens AddExclusionModal when Add exclusion is clicked", async () => {
+    render(<ExclusionsPage />);
+    const addBtn = screen.getByRole("button", { name: /add exclusion/i });
+    await userEvent.click(addBtn);
+    expect(
+      screen.getByRole("dialog", { name: /add global exclusion/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes AddExclusionModal when the modal's close action fires", async () => {
+    render(<ExclusionsPage />);
+    await userEvent.click(screen.getByRole("button", { name: /add exclusion/i }));
+    const modal = screen.getByRole("dialog", { name: /add global exclusion/i });
+    await userEvent.click(within(modal).getByRole("button", { name: /close modal/i }));
+    expect(
+      screen.queryByRole("dialog", { name: /add global exclusion/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── Delete — first click asks for confirmation ───────────────────────────
+  it("shows Confirm / Cancel options after clicking the delete icon", async () => {
+    render(<ExclusionsPage />);
+    const deleteBtn = screen.getByRole("button", {
+      name: /delete exclusion 10\.0\.0\.0\/8/i,
+    });
+    await userEvent.click(deleteBtn);
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+  });
+
+  it("hides the Confirm/Cancel after clicking Cancel", async () => {
+    render(<ExclusionsPage />);
+    await userEvent.click(
+      screen.getByRole("button", { name: /delete exclusion 10\.0\.0\.0\/8/i }),
+    );
+    await userEvent.click(screen.getByText("Cancel"));
+    expect(screen.queryByText("Confirm")).not.toBeInTheDocument();
+  });
+
+  it("calls deleteExclusion.mutate with the correct id on Confirm", async () => {
+    const mockMutate = vi.fn();
+    mockUseDeleteExclusion.mockReturnValue(makeDeleteResult({ mutate: mockMutate }));
+
+    render(<ExclusionsPage />);
+    await userEvent.click(
+      screen.getByRole("button", { name: /delete exclusion 192\.168\.100\.0\/24/i }),
+    );
+    await userEvent.click(screen.getByText("Confirm"));
+    expect(mockMutate).toHaveBeenCalledWith(
+      "excl-2",
+      expect.any(Object),
+    );
+  });
+
+  it("only shows confirm prompt for the clicked row, not all rows", async () => {
+    render(<ExclusionsPage />);
+    await userEvent.click(
+      screen.getByRole("button", { name: /delete exclusion 10\.0\.0\.0\/8/i }),
+    );
+    // Confirm appears once (for excl-1)
+    expect(screen.getAllByText("Confirm")).toHaveLength(1);
+    // The other delete buttons remain as icon buttons
+    expect(
+      screen.getByRole("button", { name: /delete exclusion 192\.168\.100\.0\/24/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/routes/exclusions.tsx
+++ b/frontend/src/routes/exclusions.tsx
@@ -1,0 +1,202 @@
+import { useState } from "react";
+import { ShieldOff, Plus, Trash2 } from "lucide-react";
+import { Button } from "../components/button";
+import {
+  useGlobalExclusions,
+  useDeleteExclusion,
+} from "../api/hooks/use-networks";
+import { Skeleton } from "../components";
+import { AddExclusionModal } from "../components/add-exclusion-modal";
+import { formatAbsoluteTime, formatRelativeTime, cn } from "../lib/utils";
+import type { components } from "../api/types";
+
+type NetworkExclusionResponse =
+  components["schemas"]["docs.NetworkExclusionResponse"];
+
+// ── Skeleton rows ─────────────────────────────────────────────────────────────
+
+function SkeletonRows() {
+  return (
+    <>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <tr key={i} className="border-b border-border">
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-36 font-mono" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-48" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-20" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-28" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-6" />
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+// ── Exclusions page ───────────────────────────────────────────────────────────
+
+export function ExclusionsPage() {
+  const [showAdd, setShowAdd] = useState(false);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const { data: exclusions, isLoading } = useGlobalExclusions();
+  const { mutate: deleteExclusion, isPending: isDeleting } =
+    useDeleteExclusion();
+
+  const list: NetworkExclusionResponse[] = exclusions ?? [];
+
+  function handleDelete(id: string) {
+    if (confirmDeleteId !== id) {
+      setConfirmDeleteId(id);
+      return;
+    }
+    deleteExclusion(id, {
+      onSettled: () => setConfirmDeleteId(null),
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-4 h-full">
+      {/* Toolbar */}
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
+          <ShieldOff className="h-4 w-4 text-text-muted" />
+          <p className="text-xs text-text-muted leading-relaxed">
+            Global exclusions apply to all networks — hosts in these CIDR ranges
+            will never be scanned or discovered.
+          </p>
+        </div>
+
+        <div className="flex-1" />
+
+        <Button
+          onClick={() => setShowAdd(true)}
+          className="text-xs h-7 px-3 shrink-0"
+        >
+          <Plus className="h-3 w-3 mr-1" />
+          Add exclusion
+        </Button>
+      </div>
+
+      {/* Table */}
+      <div className="flex-1 overflow-auto rounded border border-border">
+        <table className="w-full text-xs border-collapse min-w-[560px]">
+          <thead>
+            <tr className="bg-surface-raised border-b border-border text-left">
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                CIDR Block
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Reason
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Created By
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Created At
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap w-16">
+                {/* actions */}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <SkeletonRows />
+            ) : list.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="px-4 py-10 text-center text-text-muted"
+                >
+                  No global exclusions defined.
+                </td>
+              </tr>
+            ) : (
+              list.map((excl) => (
+                <tr
+                  key={excl.id}
+                  className={cn(
+                    "border-b border-border group transition-colors",
+                    "hover:bg-surface-raised",
+                  )}
+                >
+                  {/* CIDR */}
+                  <td className="px-4 py-2.5 font-mono text-text-primary whitespace-nowrap">
+                    {excl.excluded_cidr ?? "—"}
+                  </td>
+
+                  {/* Reason */}
+                  <td className="px-4 py-2.5 text-text-secondary max-w-[260px] truncate">
+                    {excl.reason ?? (
+                      <span className="italic text-text-muted">—</span>
+                    )}
+                  </td>
+
+                  {/* Created by */}
+                  <td className="px-4 py-2.5 text-text-muted whitespace-nowrap">
+                    {excl.created_by ?? "—"}
+                  </td>
+
+                  {/* Created at */}
+                  <td className="px-4 py-2.5 text-text-muted whitespace-nowrap">
+                    {excl.created_at ? (
+                      <span title={formatAbsoluteTime(excl.created_at)}>
+                        {formatRelativeTime(excl.created_at)}
+                      </span>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+
+                  {/* Delete action */}
+                  <td className="px-4 py-2.5 text-right whitespace-nowrap">
+                    {confirmDeleteId === excl.id ? (
+                      <div className="flex items-center justify-end gap-2">
+                        <button
+                          type="button"
+                          onClick={() => setConfirmDeleteId(null)}
+                          className="text-[11px] text-text-muted hover:text-text-secondary"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(excl.id ?? "")}
+                          disabled={isDeleting}
+                          className="text-[11px] text-danger hover:text-danger/80 font-medium"
+                        >
+                          Confirm
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(excl.id ?? "")}
+                        aria-label={`Delete exclusion ${excl.excluded_cidr}`}
+                        className="p-1 rounded text-text-muted opacity-0 group-hover:opacity-100 hover:text-danger transition-all"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Add exclusion modal */}
+      {showAdd && <AddExclusionModal onClose={() => setShowAdd(false)} />}
+    </div>
+  );
+}

--- a/frontend/src/routes/index.ts
+++ b/frontend/src/routes/index.ts
@@ -6,3 +6,4 @@ export { NetworksPage } from "./networks";
 export { ProfilesPage } from "./profiles";
 export { SchedulesPage } from "./schedules";
 export { AdminPage } from "./admin";
+export { ExclusionsPage } from "./exclusions";

--- a/frontend/src/routes/networks.test.tsx
+++ b/frontend/src/routes/networks.test.tsx
@@ -1,0 +1,534 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NetworksPage } from "./networks";
+
+// ── Mock hooks ────────────────────────────────────────────────────────────────
+
+vi.mock("../api/hooks/use-networks", () => ({
+  useNetworks: vi.fn(),
+  useNetworkExclusions: vi.fn(),
+  useEnableNetwork: vi.fn(),
+  useDisableNetwork: vi.fn(),
+  useRenameNetwork: vi.fn(),
+  useDeleteNetwork: vi.fn(),
+  useDeleteExclusion: vi.fn(),
+}));
+
+vi.mock("../components/add-exclusion-modal", () => ({
+  AddExclusionModal: ({
+    onClose,
+  }: {
+    networkId?: string;
+    onClose: () => void;
+    onCreated?: () => void;
+  }) => (
+    <div role="dialog" aria-label="Add Exclusion">
+      <button type="button" onClick={onClose}>
+        Close exclusion modal
+      </button>
+    </div>
+  ),
+}));
+
+import {
+  useNetworks,
+  useNetworkExclusions,
+  useEnableNetwork,
+  useDisableNetwork,
+  useRenameNetwork,
+  useDeleteNetwork,
+  useDeleteExclusion,
+} from "../api/hooks/use-networks";
+
+const mockUseNetworks = vi.mocked(useNetworks);
+const mockUseNetworkExclusions = vi.mocked(useNetworkExclusions);
+const mockUseEnableNetwork = vi.mocked(useEnableNetwork);
+const mockUseDisableNetwork = vi.mocked(useDisableNetwork);
+const mockUseRenameNetwork = vi.mocked(useRenameNetwork);
+const mockUseDeleteNetwork = vi.mocked(useDeleteNetwork);
+const mockUseDeleteExclusion = vi.mocked(useDeleteExclusion);
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const mockNetworks = [
+  {
+    id: "net-1",
+    name: "Office LAN",
+    cidr: "192.168.1.0/24",
+    is_active: true,
+    host_count: 25,
+    active_host_count: 20,
+    discovery_method: "ping",
+    scan_enabled: true,
+    description: "Main office network",
+    created_by: "admin",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+    last_discovery: new Date(Date.now() - 3_600_000).toISOString(), // 1h ago
+    last_scan: undefined,
+  },
+  {
+    id: "net-2",
+    name: "DMZ",
+    cidr: "10.0.0.0/8",
+    is_active: false,
+    host_count: 5,
+    active_host_count: 2,
+    discovery_method: "tcp",
+    scan_enabled: false,
+    description: undefined,
+    created_by: "admin",
+    created_at: "2024-02-01T00:00:00Z",
+    updated_at: "2024-06-02T00:00:00Z",
+    last_discovery: undefined,
+    last_scan: undefined,
+  },
+  {
+    id: "net-3",
+    name: "Wireless",
+    cidr: "172.16.0.0/16",
+    is_active: true,
+    host_count: undefined,
+    active_host_count: undefined,
+    discovery_method: "arp",
+    scan_enabled: true,
+    description: undefined,
+    created_by: undefined,
+    created_at: "2024-03-01T00:00:00Z",
+    updated_at: undefined,
+    last_discovery: undefined,
+    last_scan: undefined,
+  },
+];
+
+const mockPagination = {
+  page: 1,
+  page_size: 25,
+  total_items: 3,
+  total_pages: 1,
+};
+
+const idleMutation = {
+  mutateAsync: vi.fn(),
+  mutate: vi.fn(),
+  isPending: false,
+  isSuccess: false,
+  isError: false,
+};
+
+function makeUseNetworksResult(overrides = {}) {
+  return {
+    data: {
+      data: mockNetworks,
+      pagination: mockPagination,
+    },
+    isLoading: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useNetworks>;
+}
+
+function makeUseNetworkExclusionsResult(overrides = {}) {
+  return {
+    data: [],
+    isLoading: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useNetworkExclusions>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseNetworks.mockReturnValue(makeUseNetworksResult());
+  mockUseNetworkExclusions.mockReturnValue(makeUseNetworkExclusionsResult());
+  mockUseEnableNetwork.mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useEnableNetwork>,
+  );
+  mockUseDisableNetwork.mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useDisableNetwork>,
+  );
+  mockUseRenameNetwork.mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useRenameNetwork>,
+  );
+  mockUseDeleteNetwork.mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useDeleteNetwork>,
+  );
+  mockUseDeleteExclusion.mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useDeleteExclusion>,
+  );
+});
+
+// ── Filter controls ───────────────────────────────────────────────────────────
+
+describe("NetworksPage — toolbar", () => {
+  it("renders the name search input", () => {
+    render(<NetworksPage />);
+    expect(
+      screen.getByRole("textbox", { name: /search networks/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the show inactive checkbox", () => {
+    render(<NetworksPage />);
+    expect(
+      screen.getByRole("checkbox", { name: /show inactive/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("show inactive checkbox is unchecked by default", () => {
+    render(<NetworksPage />);
+    const checkbox = screen.getByRole("checkbox", { name: /show inactive/i });
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it("renders the Add Network button", () => {
+    render(<NetworksPage />);
+    expect(
+      screen.getByRole("button", { name: /add network/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("passes show_inactive to useNetworks when checkbox is toggled", async () => {
+    render(<NetworksPage />);
+    const checkbox = screen.getByRole("checkbox", { name: /show inactive/i });
+    await userEvent.click(checkbox);
+    const lastCall =
+      mockUseNetworks.mock.calls[mockUseNetworks.mock.calls.length - 1][0];
+    expect(lastCall).toHaveProperty("show_inactive", true);
+  });
+
+  it("removes show_inactive from params when checkbox is untoggled", async () => {
+    render(<NetworksPage />);
+    const checkbox = screen.getByRole("checkbox", { name: /show inactive/i });
+    await userEvent.click(checkbox); // check
+    await userEvent.click(checkbox); // uncheck
+    const lastCall =
+      mockUseNetworks.mock.calls[mockUseNetworks.mock.calls.length - 1][0];
+    expect(lastCall).not.toHaveProperty("show_inactive");
+  });
+});
+
+// ── Loading state ─────────────────────────────────────────────────────────────
+
+describe("NetworksPage — loading", () => {
+  it("renders 8 skeleton rows when loading", () => {
+    mockUseNetworks.mockReturnValue(
+      makeUseNetworksResult({ isLoading: true, data: undefined }),
+    );
+    const { container } = render(<NetworksPage />);
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("does not show 'No networks found.' while loading", () => {
+    mockUseNetworks.mockReturnValue(
+      makeUseNetworksResult({ isLoading: true, data: undefined }),
+    );
+    render(<NetworksPage />);
+    expect(screen.queryByText("No networks found.")).not.toBeInTheDocument();
+  });
+});
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+describe("NetworksPage — empty state", () => {
+  it("shows 'No networks found.' when the list is empty", () => {
+    mockUseNetworks.mockReturnValue(
+      makeUseNetworksResult({
+        data: {
+          data: [],
+          pagination: {
+            page: 1,
+            page_size: 25,
+            total_items: 0,
+            total_pages: 0,
+          },
+        },
+      }),
+    );
+    render(<NetworksPage />);
+    expect(screen.getByText("No networks found.")).toBeInTheDocument();
+  });
+});
+
+// ── Table structure ───────────────────────────────────────────────────────────
+
+describe("NetworksPage — table structure", () => {
+  it("renders all column headers", () => {
+    render(<NetworksPage />);
+    expect(
+      screen.getByRole("columnheader", { name: "Name" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "CIDR" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Hosts" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Active" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Discovery" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Status" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Last Discovery" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders one data row per network", () => {
+    render(<NetworksPage />);
+    // 1 header row + 3 data rows
+    const rows = screen.getAllByRole("row");
+    expect(rows).toHaveLength(4);
+  });
+});
+
+// ── Network data ──────────────────────────────────────────────────────────────
+
+describe("NetworksPage — row data", () => {
+  it("renders network names", () => {
+    render(<NetworksPage />);
+    expect(screen.getByText("Office LAN")).toBeInTheDocument();
+    expect(screen.getByText("DMZ")).toBeInTheDocument();
+    expect(screen.getByText("Wireless")).toBeInTheDocument();
+  });
+
+  it("renders CIDR blocks in monospace", () => {
+    render(<NetworksPage />);
+    expect(screen.getByText("192.168.1.0/24")).toBeInTheDocument();
+    expect(screen.getByText("10.0.0.0/8")).toBeInTheDocument();
+    expect(screen.getByText("172.16.0.0/16")).toBeInTheDocument();
+  });
+
+  it("renders host counts", () => {
+    render(<NetworksPage />);
+    expect(screen.getByText("25")).toBeInTheDocument(); // host_count for Office LAN
+    expect(screen.getByText("5")).toBeInTheDocument(); // host_count for DMZ
+  });
+
+  it("renders active host counts", () => {
+    render(<NetworksPage />);
+    expect(screen.getByText("20")).toBeInTheDocument(); // active_host_count for Office LAN
+    expect(screen.getByText("2")).toBeInTheDocument(); // active_host_count for DMZ
+  });
+
+  it("renders discovery method labels", () => {
+    render(<NetworksPage />);
+    expect(screen.getByText("Ping")).toBeInTheDocument();
+    expect(screen.getByText("TCP")).toBeInTheDocument();
+    expect(screen.getByText("ARP")).toBeInTheDocument();
+  });
+
+  it("renders 'active' badge for active networks", () => {
+    render(<NetworksPage />);
+    const badges = screen.getAllByText("active");
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders 'inactive' badge for inactive networks", () => {
+    render(<NetworksPage />);
+    expect(screen.getByText("inactive")).toBeInTheDocument();
+  });
+
+  it("shows em-dash for missing host_count", () => {
+    render(<NetworksPage />);
+    const rows = screen.getAllByRole("row");
+    // Wireless (net-3) is the 3rd data row (index 3)
+    const cells = within(rows[3]).getAllByRole("cell");
+    // Hosts is index 2
+    expect(cells[2]).toHaveTextContent("—");
+  });
+
+  it("shows em-dash for missing last_discovery", () => {
+    render(<NetworksPage />);
+    const rows = screen.getAllByRole("row");
+    // DMZ (net-2) is the 2nd data row (index 2), has no last_discovery
+    const cells = within(rows[2]).getAllByRole("cell");
+    // Last Discovery is index 6
+    expect(cells[6]).toHaveTextContent("—");
+  });
+
+  it("shows relative time for last_discovery when present", () => {
+    render(<NetworksPage />);
+    const rows = screen.getAllByRole("row");
+    // Office LAN (net-1) is the 1st data row (index 1), has last_discovery ~1h ago
+    const cells = within(rows[1]).getAllByRole("cell");
+    // Should contain "ago" or "just now"
+    expect(cells[6].textContent).toMatch(/ago|just now/i);
+  });
+});
+
+// ── Pagination ────────────────────────────────────────────────────────────────
+
+describe("NetworksPage — pagination", () => {
+  it("shows pagination when there are multiple pages", () => {
+    mockUseNetworks.mockReturnValue(
+      makeUseNetworksResult({
+        data: {
+          data: mockNetworks,
+          pagination: {
+            page: 1,
+            page_size: 25,
+            total_items: 60,
+            total_pages: 3,
+          },
+        },
+      }),
+    );
+    render(<NetworksPage />);
+    expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+  });
+
+  it("does not show pagination when there is only one page", () => {
+    render(<NetworksPage />);
+    expect(screen.queryByText(/Page \d+ of \d+/)).not.toBeInTheDocument();
+  });
+
+  it("does not show pagination when the list is empty", () => {
+    mockUseNetworks.mockReturnValue(
+      makeUseNetworksResult({
+        data: {
+          data: [],
+          pagination: {
+            page: 1,
+            page_size: 25,
+            total_items: 0,
+            total_pages: 0,
+          },
+        },
+      }),
+    );
+    render(<NetworksPage />);
+    expect(screen.queryByText(/Page \d+ of \d+/)).not.toBeInTheDocument();
+  });
+});
+
+// ── Detail panel ──────────────────────────────────────────────────────────────
+
+describe("NetworksPage — detail panel", () => {
+  it("opens the detail panel when a row is clicked", async () => {
+    render(<NetworksPage />);
+    const row = screen.getByText("Office LAN").closest("tr")!;
+    await userEvent.click(row);
+    expect(
+      screen.getByRole("dialog", { name: /network details/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the network CIDR in the detail panel header", async () => {
+    render(<NetworksPage />);
+    await userEvent.click(screen.getByText("Office LAN").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /network details/i });
+    expect(within(panel).getByText("192.168.1.0/24")).toBeInTheDocument();
+  });
+
+  it("shows the network description in the detail panel", async () => {
+    render(<NetworksPage />);
+    await userEvent.click(screen.getByText("Office LAN").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /network details/i });
+    expect(within(panel).getByText("Main office network")).toBeInTheDocument();
+  });
+
+  it("closes the detail panel when the close button is clicked", async () => {
+    render(<NetworksPage />);
+    await userEvent.click(screen.getByText("Office LAN").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /network details/i });
+    const closeBtn = within(panel).getByRole("button", {
+      name: /close panel/i,
+    });
+    await userEvent.click(closeBtn);
+    expect(
+      screen.queryByRole("dialog", { name: /network details/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Enable button for inactive networks", async () => {
+    render(<NetworksPage />);
+    // DMZ is inactive
+    await userEvent.click(screen.getByText("DMZ").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /network details/i });
+    expect(
+      within(panel).getByRole("button", { name: /enable/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows Disable button for active networks", async () => {
+    render(<NetworksPage />);
+    // Office LAN is active
+    await userEvent.click(screen.getByText("Office LAN").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /network details/i });
+    expect(
+      within(panel).getByRole("button", { name: /disable/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the rename button (pencil icon) in the detail panel header", async () => {
+    render(<NetworksPage />);
+    await userEvent.click(screen.getByText("Office LAN").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /network details/i });
+    expect(
+      within(panel).getByRole("button", { name: /rename network/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a text input when the rename button is clicked", async () => {
+    render(<NetworksPage />);
+    await userEvent.click(screen.getByText("Office LAN").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /network details/i });
+    await userEvent.click(
+      within(panel).getByRole("button", { name: /rename network/i }),
+    );
+    expect(within(panel).getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("shows Delete link and then confirm prompt on click", async () => {
+    render(<NetworksPage />);
+    await userEvent.click(screen.getByText("Office LAN").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /network details/i });
+    const deleteBtn = within(panel).getByRole("button", { name: /delete/i });
+    await userEvent.click(deleteBtn);
+    expect(within(panel).getByText("Delete this network?")).toBeInTheDocument();
+  });
+});
+
+// ── Add network modal ─────────────────────────────────────────────────────────
+
+vi.mock("../components/add-network-modal", () => ({
+  AddNetworkModal: ({
+    onClose,
+  }: {
+    onClose: () => void;
+    onCreated?: () => void;
+  }) => (
+    <div role="dialog" aria-label="Add Network">
+      <button type="button" onClick={onClose}>
+        Close add modal
+      </button>
+    </div>
+  ),
+}));
+
+describe("NetworksPage — add network modal", () => {
+  it("opens AddNetworkModal when Add network is clicked", async () => {
+    render(<NetworksPage />);
+    await userEvent.click(screen.getByRole("button", { name: /add network/i }));
+    expect(
+      screen.getByRole("dialog", { name: /add network/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes AddNetworkModal when its onClose fires", async () => {
+    render(<NetworksPage />);
+    await userEvent.click(screen.getByRole("button", { name: /add network/i }));
+    const modal = screen.getByRole("dialog", { name: /add network/i });
+    await userEvent.click(
+      within(modal).getByRole("button", { name: /close add modal/i }),
+    );
+    expect(
+      screen.queryByRole("dialog", { name: /add network/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/routes/networks.tsx
+++ b/frontend/src/routes/networks.tsx
@@ -1,5 +1,709 @@
-import { PlaceholderPage } from "../components/placeholder-page";
+import { useState, useCallback } from "react";
+import { Network, Plus, Trash2, X, Pencil, Check, Ban } from "lucide-react";
+import { Button } from "../components/button";
+import {
+  useNetworks,
+  useNetworkExclusions,
+  useEnableNetwork,
+  useDisableNetwork,
+  useRenameNetwork,
+  useDeleteNetwork,
+  useDeleteExclusion,
+} from "../api/hooks/use-networks";
+import { Skeleton, PaginationBar } from "../components";
+import { AddNetworkModal } from "../components/add-network-modal";
+import { AddExclusionModal } from "../components/add-exclusion-modal";
+import { formatRelativeTime, formatAbsoluteTime, cn } from "../lib/utils";
+import type { components } from "../api/types";
+
+type NetworkResponse = components["schemas"]["docs.NetworkResponse"];
+type NetworkExclusionResponse =
+  components["schemas"]["docs.NetworkExclusionResponse"];
+
+const PAGE_SIZE = 25;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const DISCOVERY_METHOD_LABELS: Record<string, string> = {
+  ping: "Ping",
+  tcp: "TCP",
+  arp: "ARP",
+  icmp: "ICMP",
+};
+
+function NetworkActiveBadge({ active }: { active: boolean }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] font-medium",
+        active
+          ? "bg-success/15 text-success"
+          : "bg-text-muted/15 text-text-muted",
+      )}
+    >
+      {active ? "active" : "inactive"}
+    </span>
+  );
+}
+
+// ── Skeleton rows ─────────────────────────────────────────────────────────────
+
+function SkeletonRows() {
+  return (
+    <>
+      {Array.from({ length: 8 }).map((_, i) => (
+        <tr key={i} className="border-b border-border">
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-32" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-28 font-mono" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-10" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-10" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-14" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-5 w-14 rounded" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-20" />
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+// ── Meta row helper ───────────────────────────────────────────────────────────
+
+function MetaRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex gap-2 text-xs">
+      <span className="text-text-muted w-32 shrink-0">{label}</span>
+      <span className="text-text-secondary break-all">{value ?? "—"}</span>
+    </div>
+  );
+}
+
+// ── Exclusions sub-section ────────────────────────────────────────────────────
+
+function ExclusionsSection({ networkId }: { networkId: string }) {
+  const [showAdd, setShowAdd] = useState(false);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const { data: exclusions, isLoading } = useNetworkExclusions(networkId);
+  const { mutate: deleteExclusion, isPending: isDeleting } =
+    useDeleteExclusion();
+
+  const list = exclusions ?? [];
+
+  function handleDelete(id: string) {
+    if (confirmDeleteId !== id) {
+      setConfirmDeleteId(id);
+      return;
+    }
+    deleteExclusion(id, {
+      onSettled: () => setConfirmDeleteId(null),
+    });
+  }
+
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-xs font-medium text-text-primary">Exclusions</h3>
+        <button
+          type="button"
+          onClick={() => setShowAdd(true)}
+          className="flex items-center gap-1 text-xs text-accent hover:text-accent/80 transition-colors"
+        >
+          <Plus className="h-3 w-3" />
+          Add
+        </button>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <Skeleton key={i} className="h-8 w-full rounded" />
+          ))}
+        </div>
+      ) : list.length === 0 ? (
+        <p className="text-xs text-text-muted italic">No exclusions defined.</p>
+      ) : (
+        <div className="space-y-1">
+          {list.map((excl: NetworkExclusionResponse) => (
+            <div
+              key={excl.id}
+              className="flex items-start gap-2 p-2 rounded bg-surface-raised group"
+            >
+              <div className="flex-1 min-w-0">
+                <p className="text-xs font-mono text-text-primary truncate">
+                  {excl.excluded_cidr ?? "—"}
+                </p>
+                {excl.reason && (
+                  <p className="text-[11px] text-text-muted truncate mt-0.5">
+                    {excl.reason}
+                  </p>
+                )}
+              </div>
+
+              {confirmDeleteId === excl.id ? (
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => setConfirmDeleteId(null)}
+                    className="text-[11px] text-text-muted hover:text-text-secondary px-1"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(excl.id ?? "")}
+                    disabled={isDeleting}
+                    className="text-[11px] text-danger hover:text-danger/80 px-1"
+                  >
+                    Confirm
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => handleDelete(excl.id ?? "")}
+                  aria-label={`Delete exclusion ${excl.excluded_cidr}`}
+                  className="shrink-0 p-0.5 rounded text-text-muted opacity-0 group-hover:opacity-100 hover:text-danger transition-all"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showAdd && (
+        <AddExclusionModal
+          networkId={networkId}
+          onClose={() => setShowAdd(false)}
+        />
+      )}
+    </section>
+  );
+}
+
+// ── Network detail panel ──────────────────────────────────────────────────────
+
+interface DetailPanelProps {
+  network: NetworkResponse;
+  onClose: () => void;
+}
+
+function NetworkDetailPanel({
+  network: initialNetwork,
+  onClose,
+}: DetailPanelProps) {
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [newName, setNewName] = useState(initialNetwork.name ?? "");
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const { mutateAsync: enableNetwork, isPending: isEnabling } =
+    useEnableNetwork();
+  const { mutateAsync: disableNetwork, isPending: isDisabling } =
+    useDisableNetwork();
+  const { mutateAsync: renameNetwork, isPending: isRenaming_ } =
+    useRenameNetwork();
+  const { mutateAsync: deleteNetwork, isPending: isDeleting } =
+    useDeleteNetwork();
+
+  const isTogglingActive = isEnabling || isDisabling;
+
+  // Use initial network data; live updates happen via query cache invalidation
+  const n = initialNetwork;
+
+  async function handleToggleActive() {
+    setActionError(null);
+    try {
+      if (n.is_active) {
+        await disableNetwork(n.id ?? "");
+      } else {
+        await enableNetwork(n.id ?? "");
+      }
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Action failed.");
+    }
+  }
+
+  async function handleRename() {
+    setRenameError(null);
+    const trimmed = newName.trim();
+    if (!trimmed) {
+      setRenameError("Name cannot be empty.");
+      return;
+    }
+    if (trimmed === n.name) {
+      setIsRenaming(false);
+      return;
+    }
+    try {
+      await renameNetwork({ networkId: n.id ?? "", newName: trimmed });
+      setIsRenaming(false);
+    } catch (err) {
+      setRenameError(err instanceof Error ? err.message : "Rename failed.");
+    }
+  }
+
+  async function handleDelete() {
+    setActionError(null);
+    try {
+      await deleteNetwork(n.id ?? "");
+      onClose();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Delete failed.");
+      setShowDeleteConfirm(false);
+    }
+  }
+
+  function startRename() {
+    setNewName(n.name ?? "");
+    setRenameError(null);
+    setIsRenaming(true);
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/40 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div
+        role="dialog"
+        aria-label="Network details"
+        className={cn(
+          "fixed top-0 right-0 bottom-0 z-50",
+          "w-full max-w-110",
+          "bg-surface border-l border-border",
+          "flex flex-col overflow-hidden",
+          "shadow-xl",
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 px-5 py-4 border-b border-border shrink-0">
+          <div className="flex flex-col gap-1.5 min-w-0">
+            <p className="text-xs text-text-muted">Network</p>
+            {isRenaming ? (
+              <div className="flex items-center gap-1.5 min-w-0">
+                <input
+                  type="text"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") void handleRename();
+                    if (e.key === "Escape") setIsRenaming(false);
+                  }}
+                  autoFocus
+                  className={cn(
+                    "px-2 py-1 text-sm rounded border border-border min-w-0 flex-1",
+                    "bg-surface text-text-primary",
+                    "focus:outline-none focus:ring-1 focus:ring-border",
+                  )}
+                />
+                <button
+                  type="button"
+                  onClick={() => void handleRename()}
+                  disabled={isRenaming_}
+                  aria-label="Save name"
+                  className="p-1 rounded text-success hover:bg-surface-raised transition-colors shrink-0"
+                >
+                  <Check className="h-3.5 w-3.5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setIsRenaming(false)}
+                  aria-label="Cancel rename"
+                  className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors shrink-0"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-1.5 min-w-0">
+                <p className="text-sm font-medium text-text-primary truncate">
+                  {n.name ?? "—"}
+                </p>
+                <button
+                  type="button"
+                  onClick={startRename}
+                  aria-label="Rename network"
+                  className="p-0.5 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors shrink-0"
+                >
+                  <Pencil className="h-3 w-3" />
+                </button>
+              </div>
+            )}
+            {renameError && (
+              <p className="text-[11px] text-danger">{renameError}</p>
+            )}
+            <p className="text-xs font-mono text-text-secondary">
+              {n.cidr ?? "—"}
+            </p>
+            <NetworkActiveBadge active={n.is_active ?? false} />
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close panel"
+            className="shrink-0 p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Action bar */}
+        <div className="flex items-center gap-2 px-5 py-3 border-b border-border shrink-0 flex-wrap">
+          <Button
+            variant="secondary"
+            onClick={() => void handleToggleActive()}
+            loading={isTogglingActive}
+            className="text-xs h-7 px-3"
+          >
+            {n.is_active ? (
+              <>
+                <Ban className="h-3 w-3 mr-1" /> Disable
+              </>
+            ) : (
+              <>
+                <Check className="h-3 w-3 mr-1" /> Enable
+              </>
+            )}
+          </Button>
+
+          {showDeleteConfirm ? (
+            <div className="flex items-center gap-2 ml-auto">
+              <span className="text-xs text-text-muted">
+                Delete this network?
+              </span>
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(false)}
+                className="text-xs text-text-muted hover:text-text-secondary"
+              >
+                Cancel
+              </button>
+              <Button
+                variant="danger"
+                onClick={() => void handleDelete()}
+                loading={isDeleting}
+                className="text-xs h-7 px-3"
+              >
+                Delete
+              </Button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowDeleteConfirm(true)}
+              className="ml-auto flex items-center gap-1 text-xs text-text-muted hover:text-danger transition-colors"
+            >
+              <Trash2 className="h-3 w-3" />
+              Delete
+            </button>
+          )}
+
+          {actionError && (
+            <p className="w-full text-[11px] text-danger mt-0.5">
+              {actionError}
+            </p>
+          )}
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-6">
+          {/* Network info */}
+          <section>
+            <h3 className="text-xs font-medium text-text-primary mb-3 flex items-center gap-1.5">
+              <Network className="h-3.5 w-3.5 text-text-muted" />
+              Details
+            </h3>
+            <div className="space-y-2">
+              <MetaRow label="ID" value={n.id} />
+              <MetaRow label="Description" value={n.description} />
+              <MetaRow
+                label="Discovery method"
+                value={
+                  n.discovery_method
+                    ? (DISCOVERY_METHOD_LABELS[n.discovery_method] ??
+                      n.discovery_method)
+                    : undefined
+                }
+              />
+              <MetaRow
+                label="Scan enabled"
+                value={
+                  n.scan_enabled != null
+                    ? n.scan_enabled
+                      ? "Yes"
+                      : "No"
+                    : undefined
+                }
+              />
+              <MetaRow
+                label="Total hosts"
+                value={n.host_count != null ? String(n.host_count) : undefined}
+              />
+              <MetaRow
+                label="Active hosts"
+                value={
+                  n.active_host_count != null
+                    ? String(n.active_host_count)
+                    : undefined
+                }
+              />
+              <MetaRow
+                label="Last discovery"
+                value={
+                  n.last_discovery
+                    ? formatRelativeTime(n.last_discovery)
+                    : undefined
+                }
+              />
+              <MetaRow
+                label="Last scan"
+                value={
+                  n.last_scan ? formatRelativeTime(n.last_scan) : undefined
+                }
+              />
+              <MetaRow label="Created by" value={n.created_by} />
+              <MetaRow
+                label="Created at"
+                value={
+                  n.created_at ? formatAbsoluteTime(n.created_at) : undefined
+                }
+              />
+              <MetaRow
+                label="Updated at"
+                value={
+                  n.updated_at ? formatAbsoluteTime(n.updated_at) : undefined
+                }
+              />
+            </div>
+          </section>
+
+          {/* Exclusions */}
+          {n.id && <ExclusionsSection networkId={n.id} />}
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Networks page ─────────────────────────────────────────────────────────────
 
 export function NetworksPage() {
-  return <PlaceholderPage message="Network management coming soon." />;
+  const [page, setPage] = useState(1);
+  const [showInactive, setShowInactive] = useState(false);
+  const [nameSearch, setNameSearch] = useState("");
+  const [debouncedName, setDebouncedName] = useState("");
+  const [selectedNetwork, setSelectedNetwork] =
+    useState<NetworkResponse | null>(null);
+  const [showAddNetwork, setShowAddNetwork] = useState(false);
+
+  // Debounce name search
+  const debounceRef = { current: 0 as ReturnType<typeof setTimeout> };
+  const handleNameInput = useCallback(
+    (value: string) => {
+      setNameSearch(value);
+      clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        setDebouncedName(value);
+        setPage(1);
+      }, 300);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const queryParams = {
+    page,
+    page_size: PAGE_SIZE,
+    ...(showInactive ? { show_inactive: true } : {}),
+    ...(debouncedName.trim() ? { name: debouncedName.trim() } : {}),
+  };
+
+  const { data, isLoading } = useNetworks(queryParams);
+
+  const networks = data?.data ?? [];
+  const pagination = data?.pagination;
+  const totalPages = pagination?.total_pages ?? 1;
+
+  function handleShowInactiveChange(checked: boolean) {
+    setShowInactive(checked);
+    setPage(1);
+  }
+
+  return (
+    <div className="flex flex-col gap-4 h-full">
+      {/* Toolbar */}
+      <div className="flex items-center gap-3 flex-wrap">
+        {/* Name search */}
+        <div className="relative flex-1 min-w-48 max-w-64">
+          <input
+            type="text"
+            value={nameSearch}
+            onChange={(e) => handleNameInput(e.target.value)}
+            placeholder="Search by name…"
+            aria-label="Search networks"
+            className={cn(
+              "w-full pl-3 pr-3 py-1.5 text-xs rounded border border-border",
+              "bg-surface text-text-primary placeholder:text-text-muted",
+              "focus:outline-none focus:ring-1 focus:ring-border",
+            )}
+          />
+        </div>
+
+        {/* Show inactive toggle */}
+        <label className="flex items-center gap-2 text-xs text-text-secondary cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={showInactive}
+            onChange={(e) => handleShowInactiveChange(e.target.checked)}
+            aria-label="Show inactive networks"
+            className="h-3.5 w-3.5 rounded border-border accent-accent"
+          />
+          Show inactive
+        </label>
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Add network */}
+        <Button
+          onClick={() => setShowAddNetwork(true)}
+          className="text-xs h-7 px-3"
+        >
+          <Plus className="h-3 w-3 mr-1" />
+          Add network
+        </Button>
+      </div>
+
+      {/* Table */}
+      <div className="flex-1 overflow-auto rounded border border-border">
+        <table className="w-full text-xs border-collapse min-w-[640px]">
+          <thead>
+            <tr className="bg-surface-raised border-b border-border text-left">
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Name
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                CIDR
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap text-right">
+                Hosts
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap text-right">
+                Active
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Discovery
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Status
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Last Discovery
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <SkeletonRows />
+            ) : networks.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={7}
+                  className="px-4 py-10 text-center text-text-muted"
+                >
+                  No networks found.
+                </td>
+              </tr>
+            ) : (
+              networks.map((network) => (
+                <tr
+                  key={network.id}
+                  onClick={() => setSelectedNetwork(network)}
+                  className={cn(
+                    "border-b border-border cursor-pointer transition-colors",
+                    "hover:bg-surface-raised",
+                    selectedNetwork?.id === network.id && "bg-accent/8",
+                  )}
+                >
+                  <td className="px-4 py-2.5 text-text-primary font-medium truncate max-w-[180px]">
+                    {network.name ?? "—"}
+                  </td>
+                  <td className="px-4 py-2.5 font-mono text-text-secondary whitespace-nowrap">
+                    {network.cidr ?? "—"}
+                  </td>
+                  <td className="px-4 py-2.5 text-text-secondary text-right tabular-nums">
+                    {network.host_count != null ? network.host_count : "—"}
+                  </td>
+                  <td className="px-4 py-2.5 text-text-secondary text-right tabular-nums">
+                    {network.active_host_count != null
+                      ? network.active_host_count
+                      : "—"}
+                  </td>
+                  <td className="px-4 py-2.5 text-text-secondary">
+                    {network.discovery_method
+                      ? (DISCOVERY_METHOD_LABELS[network.discovery_method] ??
+                        network.discovery_method)
+                      : "—"}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <NetworkActiveBadge active={network.is_active ?? false} />
+                  </td>
+                  <td className="px-4 py-2.5 text-text-muted whitespace-nowrap">
+                    {network.last_discovery
+                      ? formatRelativeTime(network.last_discovery)
+                      : "—"}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {!isLoading && networks.length > 0 && totalPages > 1 && (
+        <PaginationBar
+          page={page}
+          totalPages={totalPages}
+          onPrev={() => setPage((p) => Math.max(1, p - 1))}
+          onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
+        />
+      )}
+
+      {/* Network detail panel */}
+      {selectedNetwork && (
+        <NetworkDetailPanel
+          network={selectedNetwork}
+          onClose={() => setSelectedNetwork(null)}
+        />
+      )}
+
+      {/* Add network modal */}
+      {showAddNetwork && (
+        <AddNetworkModal onClose={() => setShowAddNetwork(false)} />
+      )}
+    </div>
+  );
 }

--- a/frontend/src/routes/placeholder-routes.test.tsx
+++ b/frontend/src/routes/placeholder-routes.test.tsx
@@ -1,18 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
-import { NetworksPage } from "./networks";
 import { SchedulesPage } from "./schedules";
 import { ProfilesPage } from "./profiles";
 import { AdminPage } from "./admin";
-
-describe("NetworksPage", () => {
-  it("renders the coming-soon message", () => {
-    render(<NetworksPage />);
-    expect(
-      screen.getByText("Network management coming soon."),
-    ).toBeInTheDocument();
-  });
-});
 
 describe("SchedulesPage", () => {
   it("renders the coming-soon message", () => {
@@ -26,17 +16,13 @@ describe("SchedulesPage", () => {
 describe("ProfilesPage", () => {
   it("renders the coming-soon message", () => {
     render(<ProfilesPage />);
-    expect(
-      screen.getByText("Scan profiles coming soon."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Scan profiles coming soon.")).toBeInTheDocument();
   });
 });
 
 describe("AdminPage", () => {
   it("renders the coming-soon message", () => {
     render(<AdminPage />);
-    expect(
-      screen.getByText("Admin panel coming soon."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Admin panel coming soon.")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Implements the Networks and Exclusions pages — the fourth shippable increment of the frontend build plan.

## What's new

### Networks page (`/networks`)
- Paginated table with name search and show-inactive filter
- Columns: Name, CIDR, Hosts, Active hosts, Discovery method, Status badge, Last Discovery
- Clicking a row opens a slide-in **NetworkDetailPanel** with:
  - Inline rename (pencil icon → input → save/cancel)
  - Enable / Disable toggle button
  - Delete with two-click confirmation
  - Per-network exclusions sub-list (add + delete with confirmation)
- **Add network** button opens a modal (name, CIDR, description, discovery method, scan-enabled)

### Exclusions page (`/exclusions`)
- Global exclusion rules table (CIDR, reason, created by, created at)
- Delete with two-click confirmation
- **Add exclusion** button opens a modal
- Linked from the sidebar (ShieldOff icon, between Networks and Profiles)

### API layer (`use-networks.ts`)
Extended from 2 hooks to 13:

| Hook | Endpoint |
|------|----------|
| `useNetwork` | GET `/networks/{networkId}` |
| `useNetworkExclusions` | GET `/networks/{networkId}/exclusions` |
| `useGlobalExclusions` | GET `/exclusions` |
| `useCreateNetwork` | POST `/networks` |
| `useDeleteNetwork` | DELETE `/networks/{networkId}` |
| `useEnableNetwork` | POST `/networks/{networkId}/enable` |
| `useDisableNetwork` | POST `/networks/{networkId}/disable` |
| `useRenameNetwork` | PUT `/networks/{networkId}/rename` |
| `useCreateNetworkExclusion` | POST `/networks/{networkId}/exclusions` |
| `useCreateGlobalExclusion` | POST `/exclusions` |
| `useDeleteExclusion` | DELETE `/exclusions/{exclusionId}` |

## Tests

**430 tests passing across 20 test files** (up from 430 across 19).

New tests added:
- **60+ hook tests** — all 11 new hooks (queries: loading/success/error/cache-key/param-forwarding; mutations: success/error/invalidation)
- **30+ NetworksPage tests** — toolbar filters, loading skeletons, empty state, all 7 column values, pagination, detail panel (open/close/enable/disable/rename/delete-confirm), add-modal lifecycle
- **20+ ExclusionsPage tests** — loading skeletons, empty state, all table columns, delete confirmation flow, add-modal open/close

## Notes

- The plan called for a filtered host table inside the network detail panel; this was skipped because `GET /hosts` has no `network_id` filter parameter — marked as a known gap in `FRONTEND_PLAN.md`
- All patterns (slide-in panel, two-click delete confirm, inline rename) follow the same conventions established in the Hosts and Scans pages