### PR TITLE
feat(frontend): discovery, profiles & schedules (iteration 5)

### DIFF
--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -15,7 +15,29 @@ export {
   useCreateGlobalExclusion,
   useDeleteExclusion,
 } from "./use-networks";
-export { useProfile, useProfiles } from "./use-profiles";
+export {
+  useProfile,
+  useProfiles,
+  useCreateProfile,
+  useUpdateProfile,
+  useDeleteProfile,
+} from "./use-profiles";
+export {
+  useSchedules,
+  useSchedule,
+  useCreateSchedule,
+  useUpdateSchedule,
+  useDeleteSchedule,
+  useEnableSchedule,
+  useDisableSchedule,
+} from "./use-schedules";
+export {
+  useDiscoveryJobs,
+  useDiscoveryJob,
+  useCreateDiscoveryJob,
+  useStartDiscovery,
+  useStopDiscovery,
+} from "./use-discovery";
 export {
   useScans,
   useScan,

--- a/frontend/src/api/hooks/use-discovery.test.ts
+++ b/frontend/src/api/hooks/use-discovery.test.ts
@@ -1,0 +1,545 @@
+import { waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHookWithQuery } from "../../test/utils";
+import {
+  useDiscoveryJobs,
+  useDiscoveryJob,
+  useCreateDiscoveryJob,
+  useStartDiscovery,
+  useStopDiscovery,
+} from "./use-discovery";
+
+vi.mock("../client", () => ({
+  api: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+  },
+}));
+
+import { api } from "../client";
+const mockGet = vi.mocked(api.GET);
+const mockPost = vi.mocked(api.POST);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const ok = (data: unknown): ReturnType<typeof mockGet> =>
+  Promise.resolve({
+    data,
+    error: undefined,
+    response: new Response(),
+  }) as ReturnType<typeof mockGet>;
+
+const fail = (message = "something went wrong"): ReturnType<typeof mockGet> =>
+  Promise.resolve({
+    data: undefined,
+    error: { message },
+    response: new Response(),
+  }) as ReturnType<typeof mockGet>;
+
+const okPost = (data: unknown): ReturnType<typeof mockPost> =>
+  Promise.resolve({
+    data,
+    error: undefined,
+    response: new Response(),
+  }) as ReturnType<typeof mockPost>;
+
+const failPost = (
+  message = "something went wrong",
+): ReturnType<typeof mockPost> =>
+  Promise.resolve({
+    data: undefined,
+    error: { message },
+    response: new Response(),
+  }) as ReturnType<typeof mockPost>;
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const mockPagination = {
+  page: 1,
+  page_size: 20,
+  total_items: 2,
+  total_pages: 1,
+};
+
+const mockJobs = [
+  {
+    id: "job-1",
+    name: "Office LAN Discovery",
+    network: "192.168.1.0/24",
+    method: "tcp" as const,
+    status: "completed" as const,
+    progress: 100,
+    started_at: "2024-01-01T10:00:00Z",
+    created_at: "2024-01-01T09:00:00Z",
+  },
+  {
+    id: "job-2",
+    name: "DMZ Discovery",
+    network: "10.0.0.0/8",
+    method: "icmp" as const,
+    status: "running" as const,
+    progress: 45,
+    started_at: "2024-01-02T10:00:00Z",
+    created_at: "2024-01-02T09:00:00Z",
+  },
+];
+
+const mockJob = mockJobs[0];
+
+// ── useDiscoveryJobs ──────────────────────────────────────────────────────────
+
+describe("useDiscoveryJobs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in a loading state", () => {
+    mockGet.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHookWithQuery(() => useDiscoveryJobs());
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("returns job list and pagination on success", async () => {
+    mockGet.mockResolvedValue(
+      ok({ data: mockJobs, pagination: mockPagination }),
+    );
+
+    const { result } = renderHookWithQuery(() => useDiscoveryJobs());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.data).toHaveLength(2);
+    expect(result.current.data?.data?.[0].name).toBe("Office LAN Discovery");
+    expect(result.current.data?.data?.[1].name).toBe("DMZ Discovery");
+    expect(result.current.data?.pagination?.total_items).toBe(2);
+    expect(result.current.data?.pagination?.total_pages).toBe(1);
+  });
+
+  it("enters error state when api.GET returns an error", async () => {
+    mockGet.mockResolvedValue(fail("internal error"));
+
+    const { result } = renderHookWithQuery(() => useDiscoveryJobs());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("calls api.GET with the /discovery path", async () => {
+    mockGet.mockResolvedValue(
+      ok({ data: mockJobs, pagination: mockPagination }),
+    );
+
+    const { result } = renderHookWithQuery(() => useDiscoveryJobs());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/discovery",
+      expect.objectContaining({ params: { query: {} } }),
+    );
+  });
+
+  it("forwards page and page_size as query params", async () => {
+    mockGet.mockResolvedValue(
+      ok({ data: [], pagination: mockPagination }),
+    );
+
+    const { result } = renderHookWithQuery(() =>
+      useDiscoveryJobs({ page: 2, page_size: 10 }),
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/discovery",
+      expect.objectContaining({
+        params: { query: { page: 2, page_size: 10 } },
+      }),
+    );
+  });
+
+  it("returns an empty list when the API returns no jobs", async () => {
+    mockGet.mockResolvedValue(
+      ok({ data: [], pagination: { ...mockPagination, total_items: 0 } }),
+    );
+
+    const { result } = renderHookWithQuery(() => useDiscoveryJobs());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.data).toHaveLength(0);
+  });
+
+  it("caches the result under the ['discovery', params] query key", async () => {
+    const params = { page: 1, page_size: 20 };
+    mockGet.mockResolvedValue(
+      ok({ data: mockJobs, pagination: mockPagination }),
+    );
+
+    const { result, queryClient } = renderHookWithQuery(() =>
+      useDiscoveryJobs(params),
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = queryClient.getQueryData(["discovery", params]);
+    expect(cached).toBeDefined();
+  });
+});
+
+// ── useDiscoveryJob ───────────────────────────────────────────────────────────
+
+describe("useDiscoveryJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in a loading state when id is provided", () => {
+    mockGet.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHookWithQuery(() => useDiscoveryJob("job-1"));
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("is disabled (not loading) when id is empty", () => {
+    mockGet.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHookWithQuery(() => useDiscoveryJob(""));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("returns job data on success", async () => {
+    mockGet.mockResolvedValue(ok(mockJob));
+
+    const { result } = renderHookWithQuery(() => useDiscoveryJob("job-1"));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.id).toBe("job-1");
+    expect(result.current.data?.name).toBe("Office LAN Discovery");
+    expect(result.current.data?.network).toBe("192.168.1.0/24");
+  });
+
+  it("enters error state when api.GET returns an error", async () => {
+    mockGet.mockResolvedValue(fail("not found"));
+
+    const { result } = renderHookWithQuery(() => useDiscoveryJob("job-999"));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("calls api.GET with the correct path param", async () => {
+    mockGet.mockResolvedValue(ok(mockJob));
+
+    const { result } = renderHookWithQuery(() => useDiscoveryJob("job-1"));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/discovery/{discoveryId}",
+      expect.objectContaining({
+        params: { path: { discoveryId: "job-1" } },
+      }),
+    );
+  });
+
+  it("caches the result under the ['discovery', id] query key", async () => {
+    mockGet.mockResolvedValue(ok(mockJob));
+
+    const { result, queryClient } = renderHookWithQuery(() =>
+      useDiscoveryJob("job-1"),
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = queryClient.getQueryData(["discovery", "job-1"]);
+    expect(cached).toBeDefined();
+  });
+});
+
+// ── useCreateDiscoveryJob ─────────────────────────────────────────────────────
+
+describe("useCreateDiscoveryJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in idle state", () => {
+    const { result } = renderHookWithQuery(() => useCreateDiscoveryJob());
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.isSuccess).toBe(false);
+  });
+
+  it("returns the created job on success", async () => {
+    mockPost.mockResolvedValue(okPost(mockJob));
+
+    const { result, actHook } = renderHookWithQuery(() =>
+      useCreateDiscoveryJob(),
+    );
+    let created: typeof mockJob | undefined;
+    await actHook(async () => {
+      created = (await result.current.mutateAsync({
+        name: "Office LAN Discovery",
+        network: "192.168.1.0/24",
+        method: "tcp",
+      })) as typeof mockJob;
+    });
+
+    expect(created?.id).toBe("job-1");
+    expect(created?.name).toBe("Office LAN Discovery");
+  });
+
+  it("calls api.POST with /discovery and the request body", async () => {
+    mockPost.mockResolvedValue(okPost(mockJob));
+
+    const body = {
+      name: "DMZ Scan",
+      network: "10.0.0.0/8",
+      method: "icmp" as const,
+    };
+    const { result, actHook } = renderHookWithQuery(() =>
+      useCreateDiscoveryJob(),
+    );
+    await actHook(async () => {
+      await result.current.mutateAsync(body);
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/discovery",
+      expect.objectContaining({ body }),
+    );
+  });
+
+  it("throws a descriptive error when api.POST returns an error", async () => {
+    mockPost.mockResolvedValue(failPost("network already exists"));
+
+    const { result, actHook } = renderHookWithQuery(() =>
+      useCreateDiscoveryJob(),
+    );
+    await actHook(async () => {
+      await expect(
+        result.current.mutateAsync({ network: "192.168.1.0/24" }),
+      ).rejects.toThrow("network already exists");
+    });
+  });
+
+  it("throws a fallback error when the error has no message", async () => {
+    mockPost.mockResolvedValue(
+      Promise.resolve({
+        data: undefined,
+        error: {},
+        response: new Response(),
+      }) as ReturnType<typeof mockPost>,
+    );
+
+    const { result, actHook } = renderHookWithQuery(() =>
+      useCreateDiscoveryJob(),
+    );
+    await actHook(async () => {
+      await expect(
+        result.current.mutateAsync({ network: "192.168.1.0/24" }),
+      ).rejects.toThrow("Failed to create discovery job.");
+    });
+  });
+
+  it("invalidates ['discovery'] queries on success", async () => {
+    mockPost.mockResolvedValue(okPost(mockJob));
+    mockGet.mockResolvedValue(
+      ok({ data: [mockJob], pagination: mockPagination }),
+    );
+
+    const { result, queryClient, actHook } = renderHookWithQuery(() =>
+      useCreateDiscoveryJob(),
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    await actHook(async () => {
+      await result.current.mutateAsync({
+        name: "Office LAN Discovery",
+        network: "192.168.1.0/24",
+        method: "tcp",
+      });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["discovery"] }),
+    );
+  });
+});
+
+// ── useStartDiscovery ─────────────────────────────────────────────────────────
+
+describe("useStartDiscovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in idle state", () => {
+    const { result } = renderHookWithQuery(() => useStartDiscovery());
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("returns the updated job on success", async () => {
+    const started = { ...mockJob, status: "running" as const };
+    mockPost.mockResolvedValue(okPost(started));
+
+    const { result, actHook } = renderHookWithQuery(() => useStartDiscovery());
+    let data: typeof started | undefined;
+    await actHook(async () => {
+      data = (await result.current.mutateAsync("job-1")) as typeof started;
+    });
+
+    expect(data?.id).toBe("job-1");
+    expect(data?.status).toBe("running");
+  });
+
+  it("calls api.POST with /discovery/{discoveryId}/start", async () => {
+    const started = { ...mockJob, status: "running" as const };
+    mockPost.mockResolvedValue(okPost(started));
+
+    const { result, actHook } = renderHookWithQuery(() => useStartDiscovery());
+    await actHook(async () => {
+      await result.current.mutateAsync("job-1");
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/discovery/{discoveryId}/start",
+      expect.objectContaining({
+        params: { path: { discoveryId: "job-1" } },
+      }),
+    );
+  });
+
+  it("forwards a different discovery id as the path param", async () => {
+    const started = { ...mockJobs[1], status: "running" as const };
+    mockPost.mockResolvedValue(okPost(started));
+
+    const { result, actHook } = renderHookWithQuery(() => useStartDiscovery());
+    await actHook(async () => {
+      await result.current.mutateAsync("job-2");
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/discovery/{discoveryId}/start",
+      expect.objectContaining({
+        params: { path: { discoveryId: "job-2" } },
+      }),
+    );
+  });
+
+  it("throws a descriptive error when api.POST returns an error", async () => {
+    mockPost.mockResolvedValue(failPost("job already running"));
+
+    const { result, actHook } = renderHookWithQuery(() => useStartDiscovery());
+    await actHook(async () => {
+      await expect(result.current.mutateAsync("job-1")).rejects.toThrow(
+        "job already running",
+      );
+    });
+  });
+
+  it("invalidates ['discovery'] queries on success", async () => {
+    const started = { ...mockJob, status: "running" as const };
+    mockPost.mockResolvedValue(okPost(started));
+    mockGet.mockResolvedValue(
+      ok({ data: [started], pagination: mockPagination }),
+    );
+
+    const { result, queryClient, actHook } = renderHookWithQuery(() =>
+      useStartDiscovery(),
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    await actHook(async () => {
+      await result.current.mutateAsync("job-1");
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["discovery"] }),
+    );
+  });
+});
+
+// ── useStopDiscovery ──────────────────────────────────────────────────────────
+
+describe("useStopDiscovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in idle state", () => {
+    const { result } = renderHookWithQuery(() => useStopDiscovery());
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("returns the updated job on success", async () => {
+    const stopped = { ...mockJobs[1], status: "failed" as const };
+    mockPost.mockResolvedValue(okPost(stopped));
+
+    const { result, actHook } = renderHookWithQuery(() => useStopDiscovery());
+    let data: typeof stopped | undefined;
+    await actHook(async () => {
+      data = (await result.current.mutateAsync("job-2")) as typeof stopped;
+    });
+
+    expect(data?.id).toBe("job-2");
+  });
+
+  it("calls api.POST with /discovery/{discoveryId}/stop", async () => {
+    const stopped = { ...mockJobs[1], status: "failed" as const };
+    mockPost.mockResolvedValue(okPost(stopped));
+
+    const { result, actHook } = renderHookWithQuery(() => useStopDiscovery());
+    await actHook(async () => {
+      await result.current.mutateAsync("job-2");
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/discovery/{discoveryId}/stop",
+      expect.objectContaining({
+        params: { path: { discoveryId: "job-2" } },
+      }),
+    );
+  });
+
+  it("forwards a different discovery id as the path param", async () => {
+    const stopped = { ...mockJob, status: "failed" as const };
+    mockPost.mockResolvedValue(okPost(stopped));
+
+    const { result, actHook } = renderHookWithQuery(() => useStopDiscovery());
+    await actHook(async () => {
+      await result.current.mutateAsync("job-1");
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/discovery/{discoveryId}/stop",
+      expect.objectContaining({
+        params: { path: { discoveryId: "job-1" } },
+      }),
+    );
+  });
+
+  it("throws a descriptive error when api.POST returns an error", async () => {
+    mockPost.mockResolvedValue(failPost("job not running"));
+
+    const { result, actHook } = renderHookWithQuery(() => useStopDiscovery());
+    await actHook(async () => {
+      await expect(result.current.mutateAsync("job-2")).rejects.toThrow(
+        "job not running",
+      );
+    });
+  });
+
+  it("invalidates ['discovery'] queries on success", async () => {
+    const stopped = { ...mockJobs[1], status: "failed" as const };
+    mockPost.mockResolvedValue(okPost(stopped));
+    mockGet.mockResolvedValue(
+      ok({ data: [stopped], pagination: mockPagination }),
+    );
+
+    const { result, queryClient, actHook } = renderHookWithQuery(() =>
+      useStopDiscovery(),
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    await actHook(async () => {
+      await result.current.mutateAsync("job-2");
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["discovery"] }),
+    );
+  });
+});

--- a/frontend/src/api/hooks/use-discovery.ts
+++ b/frontend/src/api/hooks/use-discovery.ts
@@ -1,0 +1,114 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../client";
+import type { components } from "../types";
+
+type CreateDiscoveryJobRequest =
+  components["schemas"]["docs.CreateDiscoveryJobRequest"];
+
+interface DiscoveryListParams {
+  page?: number;
+  page_size?: number;
+}
+
+// ── Queries ──────────────────────────────────────────────────────────────────
+
+export function useDiscoveryJobs(params: DiscoveryListParams = {}) {
+  return useQuery({
+    queryKey: ["discovery", params],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/discovery", {
+        params: { query: params },
+      });
+      if (error) throw error;
+      return data;
+    },
+    refetchInterval: (query) => {
+      const jobs = query.state.data?.data ?? [];
+      const hasActive = jobs.some(
+        (j) => j.status === "pending" || j.status === "running",
+      );
+      return hasActive ? 3_000 : false;
+    },
+  });
+}
+
+export function useDiscoveryJob(id: string) {
+  return useQuery({
+    queryKey: ["discovery", id],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/discovery/{discoveryId}", {
+        params: { path: { discoveryId: id } },
+      });
+      if (error) throw error;
+      return data;
+    },
+    enabled: !!id,
+  });
+}
+
+// ── Mutations ─────────────────────────────────────────────────────────────────
+
+export function useCreateDiscoveryJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: CreateDiscoveryJobRequest) => {
+      const { data, error } = await api.POST("/discovery", { body });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ??
+            apiError.error ??
+            "Failed to create discovery job.",
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["discovery"] });
+    },
+  });
+}
+
+export function useStartDiscovery() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (discoveryId: string) => {
+      const { data, error } = await api.POST("/discovery/{discoveryId}/start", {
+        params: { path: { discoveryId } },
+      });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ??
+            apiError.error ??
+            "Failed to start discovery job.",
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["discovery"] });
+    },
+  });
+}
+
+export function useStopDiscovery() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (discoveryId: string) => {
+      const { data, error } = await api.POST("/discovery/{discoveryId}/stop", {
+        params: { path: { discoveryId } },
+      });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to stop discovery job.",
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["discovery"] });
+    },
+  });
+}

--- a/frontend/src/api/hooks/use-profiles.ts
+++ b/frontend/src/api/hooks/use-profiles.ts
@@ -1,5 +1,8 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../client";
+import type { components } from "../types";
+
+type CreateProfileRequest = components["schemas"]["docs.CreateProfileRequest"];
 
 export function useProfile(id: string | undefined) {
   return useQuery({
@@ -15,7 +18,9 @@ export function useProfile(id: string | undefined) {
   });
 }
 
-export function useProfiles(params: { page?: number; page_size?: number } = {}) {
+export function useProfiles(
+  params: { page?: number; page_size?: number } = {},
+) {
   return useQuery({
     queryKey: ["profiles", params],
     queryFn: async () => {
@@ -24,6 +29,73 @@ export function useProfiles(params: { page?: number; page_size?: number } = {}) 
       });
       if (error) throw error;
       return data;
+    },
+  });
+}
+
+export function useCreateProfile() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: CreateProfileRequest) => {
+      const { data, error } = await api.POST("/profiles", { body });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to create profile.",
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["profiles"] });
+    },
+  });
+}
+
+export function useUpdateProfile() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      body,
+    }: {
+      id: string;
+      body: CreateProfileRequest;
+    }) => {
+      const { data, error } = await api.PUT("/profiles/{profileId}", {
+        params: { path: { profileId: id } },
+        body,
+      });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to update profile.",
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["profiles"] });
+    },
+  });
+}
+
+export function useDeleteProfile() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (profileId: string) => {
+      const { error } = await api.DELETE("/profiles/{profileId}", {
+        params: { path: { profileId } },
+      });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to delete profile.",
+        );
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["profiles"] });
     },
   });
 }

--- a/frontend/src/api/hooks/use-schedules.test.ts
+++ b/frontend/src/api/hooks/use-schedules.test.ts
@@ -1,0 +1,499 @@
+import { waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHookWithQuery } from "../../test/utils";
+import {
+  useSchedules,
+  useSchedule,
+  useCreateSchedule,
+  useUpdateSchedule,
+  useDeleteSchedule,
+  useEnableSchedule,
+  useDisableSchedule,
+} from "./use-schedules";
+
+vi.mock("../client", () => ({
+  api: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PUT: vi.fn(),
+    DELETE: vi.fn(),
+  },
+}));
+
+import { api } from "../client";
+const mockGet = vi.mocked(api.GET);
+const mockPost = vi.mocked(api.POST);
+const mockPut = vi.mocked(api.PUT);
+const mockDelete = vi.mocked(api.DELETE);
+
+const ok = (data: unknown): ReturnType<typeof mockGet> =>
+  Promise.resolve({
+    data,
+    error: undefined,
+    response: new Response(),
+  }) as ReturnType<typeof mockGet>;
+
+const fail = (message = "something went wrong"): ReturnType<typeof mockGet> =>
+  Promise.resolve({
+    data: undefined,
+    error: { message },
+    response: new Response(),
+  }) as ReturnType<typeof mockGet>;
+
+const okPost = (data: unknown): ReturnType<typeof mockPost> =>
+  Promise.resolve({
+    data,
+    error: undefined,
+    response: new Response(),
+  }) as ReturnType<typeof mockPost>;
+
+const failPost = (
+  message = "something went wrong",
+): ReturnType<typeof mockPost> =>
+  Promise.resolve({
+    data: undefined,
+    error: { message },
+    response: new Response(),
+  }) as ReturnType<typeof mockPost>;
+
+const okPut = (data: unknown): ReturnType<typeof mockPut> =>
+  Promise.resolve({
+    data,
+    error: undefined,
+    response: new Response(),
+  }) as ReturnType<typeof mockPut>;
+
+const failPut = (
+  message = "something went wrong",
+): ReturnType<typeof mockPut> =>
+  Promise.resolve({
+    data: undefined,
+    error: { message },
+    response: new Response(),
+  }) as ReturnType<typeof mockPut>;
+
+const okDelete = (): ReturnType<typeof mockDelete> =>
+  Promise.resolve({
+    data: undefined,
+    error: undefined,
+    response: new Response(),
+  }) as ReturnType<typeof mockDelete>;
+
+const failDelete = (
+  message = "something went wrong",
+): ReturnType<typeof mockDelete> =>
+  Promise.resolve({
+    data: undefined,
+    error: { message },
+    response: new Response(),
+  }) as ReturnType<typeof mockDelete>;
+
+const mockSchedules = [
+  {
+    id: "sched-1",
+    name: "Daily Security Scan",
+    cron_expression: "0 2 * * *",
+    enabled: true,
+    targets: ["192.168.1.0/24"],
+    next_run: "2024-06-02T02:00:00Z",
+    last_run: "2024-06-01T02:00:00Z",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+    profile_id: "profile-1",
+  },
+  {
+    id: "sched-2",
+    name: "Weekly Recon",
+    cron_expression: "0 0 * * 1",
+    enabled: false,
+    targets: ["10.0.0.0/8"],
+    next_run: undefined,
+    last_run: undefined,
+    created_at: "2024-02-01T00:00:00Z",
+    updated_at: "2024-06-02T00:00:00Z",
+  },
+];
+
+const mockPagination = {
+  page: 1,
+  page_size: 25,
+  total_items: 2,
+  total_pages: 1,
+};
+
+const mockSchedule = mockSchedules[0];
+
+// ── useSchedules ──────────────────────────────────────────────────────────────
+
+describe("useSchedules", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in a loading state", () => {
+    mockGet.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHookWithQuery(() => useSchedules());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("returns paginated schedule list on success", async () => {
+    mockGet.mockResolvedValue(
+      ok({ data: mockSchedules, pagination: mockPagination }),
+    );
+    const { result } = renderHookWithQuery(() => useSchedules());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.data).toHaveLength(2);
+    expect(result.current.data?.data?.[0].id).toBe("sched-1");
+    expect(result.current.data?.pagination?.total_items).toBe(2);
+  });
+
+  it("enters error state when api.GET returns an error", async () => {
+    mockGet.mockResolvedValue(fail("internal server error"));
+    const { result } = renderHookWithQuery(() => useSchedules());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("forwards page, page_size, and enabled as query params", async () => {
+    mockGet.mockResolvedValue(
+      ok({ data: [], pagination: { ...mockPagination, total_items: 0 } }),
+    );
+    const params = { page: 2, page_size: 10, enabled: true };
+    const { result } = renderHookWithQuery(() => useSchedules(params));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/schedules",
+      expect.objectContaining({
+        params: { query: params },
+      }),
+    );
+  });
+
+  it("caches the result under the ['schedules', params] query key", async () => {
+    const params = { page: 1, page_size: 25 };
+    mockGet.mockResolvedValue(
+      ok({ data: mockSchedules, pagination: mockPagination }),
+    );
+    const { result, queryClient } = renderHookWithQuery(() =>
+      useSchedules(params),
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = queryClient.getQueryData(["schedules", params]);
+    expect(cached).toBeDefined();
+  });
+
+  it("returns empty list when API returns no schedules", async () => {
+    mockGet.mockResolvedValue(
+      ok({ data: [], pagination: { ...mockPagination, total_items: 0 } }),
+    );
+    const { result } = renderHookWithQuery(() => useSchedules());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.data).toHaveLength(0);
+  });
+});
+
+// ── useSchedule ───────────────────────────────────────────────────────────────
+
+describe("useSchedule", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in a loading state when id is provided", () => {
+    mockGet.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHookWithQuery(() => useSchedule("sched-1"));
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("is disabled (idle) when id is empty", () => {
+    const { result } = renderHookWithQuery(() => useSchedule(""));
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("returns schedule data on success", async () => {
+    mockGet.mockResolvedValue(ok(mockSchedule));
+    const { result } = renderHookWithQuery(() => useSchedule("sched-1"));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.id).toBe("sched-1");
+    expect(result.current.data?.name).toBe("Daily Security Scan");
+  });
+
+  it("enters error state when api.GET returns an error", async () => {
+    mockGet.mockResolvedValue(fail("not found"));
+    const { result } = renderHookWithQuery(() => useSchedule("nonexistent"));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("calls api.GET with the correct path param", async () => {
+    mockGet.mockResolvedValue(ok(mockSchedule));
+    const { result } = renderHookWithQuery(() => useSchedule("sched-1"));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith(
+      "/schedules/{scheduleId}",
+      expect.objectContaining({
+        params: { path: { scheduleId: "sched-1" } },
+      }),
+    );
+  });
+
+  it("caches under the ['schedules', id] query key", async () => {
+    mockGet.mockResolvedValue(ok(mockSchedule));
+    const { result, queryClient } = renderHookWithQuery(() =>
+      useSchedule("sched-1"),
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const cached = queryClient.getQueryData(["schedules", "sched-1"]);
+    expect(cached).toBeDefined();
+  });
+});
+
+// ── useCreateSchedule ─────────────────────────────────────────────────────────
+
+describe("useCreateSchedule", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in idle state", () => {
+    const { result } = renderHookWithQuery(() => useCreateSchedule());
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.isIdle).toBe(true);
+  });
+
+  it("calls POST /schedules with the request body", async () => {
+    mockPost.mockResolvedValue(okPost(mockSchedule));
+    const { result, actHook } = renderHookWithQuery(() => useCreateSchedule());
+    await actHook(async () => {
+      await result.current.mutateAsync({
+        name: "Daily Security Scan",
+        cron_expression: "0 2 * * *",
+        targets: ["192.168.1.0/24"],
+        enabled: true,
+      });
+    });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/schedules",
+      expect.objectContaining({
+        body: expect.objectContaining({ name: "Daily Security Scan" }),
+      }),
+    );
+  });
+
+  it("throws a descriptive error when api.POST returns an error", async () => {
+    mockPost.mockResolvedValue(failPost("cron expression invalid"));
+    const { result, actHook } = renderHookWithQuery(() => useCreateSchedule());
+    await actHook(async () => {
+      await expect(
+        result.current.mutateAsync({ name: "Bad Schedule" }),
+      ).rejects.toThrow("cron expression invalid");
+    });
+  });
+
+  it("invalidates ['schedules'] queries on success", async () => {
+    mockGet.mockResolvedValue(
+      ok({ data: mockSchedules, pagination: mockPagination }),
+    );
+    mockPost.mockResolvedValue(okPost(mockSchedule));
+    const { result, queryClient, actHook } = renderHookWithQuery(() =>
+      useCreateSchedule(),
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    await actHook(async () => {
+      await result.current.mutateAsync({
+        name: "New Schedule",
+        cron_expression: "0 2 * * *",
+      });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["schedules"] }),
+    );
+  });
+});
+
+// ── useUpdateSchedule ─────────────────────────────────────────────────────────
+
+describe("useUpdateSchedule", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls api.PUT with the correct path and body", async () => {
+    const updated = { ...mockSchedule, name: "Renamed Schedule" };
+    mockPut.mockResolvedValue(okPut(updated));
+    const { result, actHook } = renderHookWithQuery(() => useUpdateSchedule());
+    await actHook(async () => {
+      await result.current.mutateAsync({
+        id: "sched-1",
+        body: { name: "Renamed Schedule" },
+      });
+    });
+    expect(mockPut).toHaveBeenCalledWith(
+      "/schedules/{scheduleId}",
+      expect.objectContaining({
+        params: { path: { scheduleId: "sched-1" } },
+        body: expect.objectContaining({ name: "Renamed Schedule" }),
+      }),
+    );
+  });
+
+  it("throws a descriptive error on failure", async () => {
+    mockPut.mockResolvedValue(failPut("not found"));
+    const { result, actHook } = renderHookWithQuery(() => useUpdateSchedule());
+    await actHook(async () => {
+      await expect(
+        result.current.mutateAsync({ id: "nonexistent", body: {} }),
+      ).rejects.toThrow("not found");
+    });
+  });
+});
+
+// ── useDeleteSchedule ─────────────────────────────────────────────────────────
+
+describe("useDeleteSchedule", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in idle state", () => {
+    const { result } = renderHookWithQuery(() => useDeleteSchedule());
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.isIdle).toBe(true);
+  });
+
+  it("calls api.DELETE with the correct path param", async () => {
+    mockDelete.mockResolvedValue(okDelete());
+    const { result, actHook } = renderHookWithQuery(() => useDeleteSchedule());
+    await actHook(async () => {
+      await result.current.mutateAsync("sched-1");
+    });
+    expect(mockDelete).toHaveBeenCalledWith(
+      "/schedules/{scheduleId}",
+      expect.objectContaining({
+        params: { path: { scheduleId: "sched-1" } },
+      }),
+    );
+  });
+
+  it("throws a descriptive error when api.DELETE returns an error", async () => {
+    mockDelete.mockResolvedValue(failDelete("not found"));
+    const { result, actHook } = renderHookWithQuery(() => useDeleteSchedule());
+    await actHook(async () => {
+      await expect(result.current.mutateAsync("sched-1")).rejects.toThrow(
+        "not found",
+      );
+    });
+  });
+
+  it("invalidates ['schedules'] queries on success", async () => {
+    mockDelete.mockResolvedValue(okDelete());
+    const { result, queryClient, actHook } = renderHookWithQuery(() =>
+      useDeleteSchedule(),
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    await actHook(async () => {
+      await result.current.mutateAsync("sched-1");
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["schedules"] }),
+    );
+  });
+});
+
+// ── useEnableSchedule ─────────────────────────────────────────────────────────
+
+describe("useEnableSchedule", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls api.POST with /schedules/{scheduleId}/enable", async () => {
+    const enabled = { ...mockSchedule, enabled: true };
+    mockPost.mockResolvedValue(okPost(enabled));
+    const { result, actHook } = renderHookWithQuery(() => useEnableSchedule());
+    await actHook(async () => {
+      await result.current.mutateAsync("sched-1");
+    });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/schedules/{scheduleId}/enable",
+      expect.objectContaining({
+        params: { path: { scheduleId: "sched-1" } },
+      }),
+    );
+  });
+
+  it("throws a descriptive error on failure", async () => {
+    mockPost.mockResolvedValue(failPost("schedule not found"));
+    const { result, actHook } = renderHookWithQuery(() => useEnableSchedule());
+    await actHook(async () => {
+      await expect(result.current.mutateAsync("sched-1")).rejects.toThrow(
+        "schedule not found",
+      );
+    });
+  });
+
+  it("invalidates ['schedules'] on success", async () => {
+    mockPost.mockResolvedValue(okPost({ ...mockSchedule, enabled: true }));
+    const { result, queryClient, actHook } = renderHookWithQuery(() =>
+      useEnableSchedule(),
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    await actHook(async () => {
+      await result.current.mutateAsync("sched-1");
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["schedules"] }),
+    );
+  });
+});
+
+// ── useDisableSchedule ────────────────────────────────────────────────────────
+
+describe("useDisableSchedule", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls api.POST with /schedules/{scheduleId}/disable", async () => {
+    const disabled = { ...mockSchedule, enabled: false };
+    mockPost.mockResolvedValue(okPost(disabled));
+    const { result, actHook } = renderHookWithQuery(() => useDisableSchedule());
+    await actHook(async () => {
+      await result.current.mutateAsync("sched-1");
+    });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/schedules/{scheduleId}/disable",
+      expect.objectContaining({
+        params: { path: { scheduleId: "sched-1" } },
+      }),
+    );
+  });
+
+  it("throws a descriptive error on failure", async () => {
+    mockPost.mockResolvedValue(failPost("schedule not found"));
+    const { result, actHook } = renderHookWithQuery(() => useDisableSchedule());
+    await actHook(async () => {
+      await expect(result.current.mutateAsync("sched-1")).rejects.toThrow(
+        "schedule not found",
+      );
+    });
+  });
+
+  it("invalidates ['schedules'] on success", async () => {
+    mockPost.mockResolvedValue(okPost({ ...mockSchedule, enabled: false }));
+    const { result, queryClient, actHook } = renderHookWithQuery(() =>
+      useDisableSchedule(),
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    await actHook(async () => {
+      await result.current.mutateAsync("sched-1");
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["schedules"] }),
+    );
+  });
+});

--- a/frontend/src/api/hooks/use-schedules.ts
+++ b/frontend/src/api/hooks/use-schedules.ts
@@ -1,0 +1,141 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../client";
+import type { components } from "../types";
+
+type CreateScheduleRequest = components["schemas"]["docs.CreateScheduleRequest"];
+
+interface ScheduleListParams {
+  page?: number;
+  page_size?: number;
+  enabled?: boolean;
+}
+
+export function useSchedules(params: ScheduleListParams = {}) {
+  return useQuery({
+    queryKey: ["schedules", params],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/schedules", {
+        params: { query: params },
+      });
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export function useSchedule(id: string) {
+  return useQuery({
+    queryKey: ["schedules", id],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/schedules/{scheduleId}", {
+        params: { path: { scheduleId: id } },
+      });
+      if (error) throw error;
+      return data;
+    },
+    enabled: !!id,
+  });
+}
+
+export function useCreateSchedule() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: CreateScheduleRequest) => {
+      const { data, error } = await api.POST("/schedules", { body });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to create schedule.",
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["schedules"] });
+    },
+  });
+}
+
+export function useUpdateSchedule() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, body }: { id: string; body: CreateScheduleRequest }) => {
+      const { data, error } = await api.PUT("/schedules/{scheduleId}", {
+        params: { path: { scheduleId: id } },
+        body,
+      });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to update schedule.",
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["schedules"] });
+    },
+  });
+}
+
+export function useDeleteSchedule() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (scheduleId: string) => {
+      const { error } = await api.DELETE("/schedules/{scheduleId}", {
+        params: { path: { scheduleId } },
+      });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to delete schedule.",
+        );
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["schedules"] });
+    },
+  });
+}
+
+export function useEnableSchedule() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (scheduleId: string) => {
+      const { data, error } = await api.POST("/schedules/{scheduleId}/enable", {
+        params: { path: { scheduleId } },
+      });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to enable schedule.",
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["schedules"] });
+    },
+  });
+}
+
+export function useDisableSchedule() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (scheduleId: string) => {
+      const { data, error } = await api.POST("/schedules/{scheduleId}/disable", {
+        params: { path: { scheduleId } },
+      });
+      if (error) {
+        const apiError = error as { message?: string; error?: string };
+        throw new Error(
+          apiError.message ?? apiError.error ?? "Failed to disable schedule.",
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["schedules"] });
+    },
+  });
+}

--- a/frontend/src/components/create-discovery-modal.tsx
+++ b/frontend/src/components/create-discovery-modal.tsx
@@ -1,0 +1,225 @@
+import { useState, useId } from "react";
+import { X } from "lucide-react";
+import { Button } from "./button";
+import {
+  useCreateDiscoveryJob,
+  useStartDiscovery,
+} from "../api/hooks/use-discovery";
+import { cn } from "../lib/utils";
+
+const METHODS = [
+  { value: "tcp", label: "TCP" },
+  { value: "icmp", label: "ICMP" },
+  { value: "arp", label: "ARP" },
+] as const;
+
+type Method = (typeof METHODS)[number]["value"];
+
+export interface CreateDiscoveryModalProps {
+  onClose: () => void;
+  onCreated?: () => void;
+}
+
+export function CreateDiscoveryModal({
+  onClose,
+  onCreated,
+}: CreateDiscoveryModalProps) {
+  const id = useId();
+
+  const [name, setName] = useState("");
+  const [network, setNetwork] = useState("");
+  const [method, setMethod] = useState<Method>("tcp");
+  const [startImmediately, setStartImmediately] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const { mutateAsync: createDiscoveryJob, isPending: isCreating } =
+    useCreateDiscoveryJob();
+  const { mutateAsync: startDiscovery, isPending: isStarting } =
+    useStartDiscovery();
+  const isPending = isCreating || isStarting;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const trimmedNetwork = network.trim();
+    if (!trimmedNetwork) {
+      setError("Network / Target is required (e.g. 192.168.1.0/24).");
+      return;
+    }
+
+    try {
+      const result = await createDiscoveryJob({
+        name: name.trim() || undefined,
+        network: trimmedNetwork,
+        method,
+      });
+
+      if (startImmediately && result?.id) {
+        await startDiscovery(result.id);
+      }
+
+      onCreated?.();
+      onClose();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to create discovery job.",
+      );
+    }
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Dialog */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${id}-title`}
+        className={cn(
+          "fixed z-50 inset-0 m-auto",
+          "w-full max-w-md h-fit",
+          "bg-surface border border-border rounded-lg shadow-xl",
+          "flex flex-col",
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+          <h2
+            id={`${id}-title`}
+            className="text-sm font-semibold text-text-primary"
+          >
+            New Discovery Job
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close dialog"
+            className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <form onSubmit={handleSubmit} className="px-5 py-4 space-y-5">
+          {/* Name */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-name`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Name{" "}
+              <span className="text-text-muted font-normal">(optional)</span>
+            </label>
+            <input
+              id={`${id}-name`}
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Network Discovery"
+              autoFocus
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+          </div>
+
+          {/* Network / Target */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-network`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Network / Target
+            </label>
+            <input
+              id={`${id}-network`}
+              type="text"
+              value={network}
+              onChange={(e) => setNetwork(e.target.value)}
+              placeholder="192.168.1.0/24"
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border font-mono",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+            <p className="text-xs text-text-muted">
+              IPv4 or IPv6 CIDR notation (e.g. 192.168.1.0/24).
+            </p>
+          </div>
+
+          {/* Method */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-method`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Method
+            </label>
+            <select
+              id={`${id}-method`}
+              value={method}
+              onChange={(e) => setMethod(e.target.value as Method)}
+              aria-label="Select discovery method"
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            >
+              {METHODS.map((m) => (
+                <option key={m.value} value={m.value}>
+                  {m.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Start immediately */}
+          <div className="flex items-center gap-2">
+            <input
+              id={`${id}-start-immediately`}
+              type="checkbox"
+              checked={startImmediately}
+              onChange={(e) => setStartImmediately(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-border accent-accent"
+            />
+            <label
+              htmlFor={`${id}-start-immediately`}
+              className="text-xs text-text-primary"
+            >
+              Start immediately
+            </label>
+          </div>
+
+          {/* Inline error */}
+          {error && (
+            <p role="alert" className="text-xs text-danger">
+              {error}
+            </p>
+          )}
+
+          {/* Footer */}
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="secondary" type="button" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" loading={isPending}>
+              {isPending ? "Creating…" : "Create"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/create-schedule-modal.tsx
+++ b/frontend/src/components/create-schedule-modal.tsx
@@ -1,0 +1,249 @@
+import { useState, useId } from "react";
+import { X } from "lucide-react";
+import { Button } from "./button";
+import { useCreateSchedule } from "../api/hooks/use-schedules";
+import { useProfiles } from "../api/hooks/use-profiles";
+import { cn, describeCron } from "../lib/utils";
+
+export interface CreateScheduleModalProps {
+  onClose: () => void;
+  onCreated?: () => void;
+}
+
+export function CreateScheduleModal({
+  onClose,
+  onCreated,
+}: CreateScheduleModalProps) {
+  const id = useId();
+
+  const [name, setName] = useState("");
+  const [cronExpr, setCronExpr] = useState("0 2 * * *");
+  const [targets, setTargets] = useState("");
+  const [profileId, setProfileId] = useState("");
+  const [enabled, setEnabled] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const { mutateAsync: createSchedule, isPending } = useCreateSchedule();
+  const { data: profilesData } = useProfiles({ page: 1, page_size: 100 });
+  const profiles = profilesData?.data ?? [];
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const trimmedName = name.trim();
+    const trimmedCron = cronExpr.trim();
+    const targetList = targets
+      .split(/[\s,]+/)
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    if (!trimmedName) {
+      setError("Name is required.");
+      return;
+    }
+
+    if (!trimmedCron) {
+      setError("Cron expression is required.");
+      return;
+    }
+
+    if (targetList.length === 0) {
+      setError("At least one target is required.");
+      return;
+    }
+
+    try {
+      await createSchedule({
+        name: trimmedName,
+        cron_expression: trimmedCron,
+        targets: targetList,
+        profile_id: profileId || undefined,
+        enabled,
+      });
+      onCreated?.();
+      onClose();
+    } catch (err) {
+      const apiErr = err as { message?: string; error?: string };
+      setError(apiErr.message ?? apiErr.error ?? "Failed to create schedule.");
+    }
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Dialog */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${id}-title`}
+        className={cn(
+          "fixed z-50 inset-0 m-auto",
+          "w-full max-w-md h-fit",
+          "bg-surface border border-border rounded-lg shadow-xl",
+          "flex flex-col",
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+          <h2
+            id={`${id}-title`}
+            className="text-sm font-semibold text-text-primary"
+          >
+            Create Schedule
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close dialog"
+            className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <form onSubmit={handleSubmit} className="px-5 py-4 space-y-5">
+          {/* Name */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-name`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Name
+            </label>
+            <input
+              id={`${id}-name`}
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Daily Security Scan"
+              autoFocus
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+          </div>
+
+          {/* Cron expression */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-cron`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Cron expression
+            </label>
+            <input
+              id={`${id}-cron`}
+              type="text"
+              value={cronExpr}
+              onChange={(e) => setCronExpr(e.target.value)}
+              placeholder="0 2 * * *"
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border font-mono",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+            <p className="text-xs text-text-muted">{describeCron(cronExpr)}</p>
+          </div>
+
+          {/* Targets */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-targets`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Targets
+            </label>
+            <textarea
+              id={`${id}-targets`}
+              value={targets}
+              onChange={(e) => setTargets(e.target.value)}
+              placeholder="192.168.1.0/24, 10.0.0.0/8"
+              rows={3}
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border font-mono resize-none",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+            <p className="text-xs text-text-muted">
+              Comma or whitespace-separated CIDRs or IPs.
+            </p>
+          </div>
+
+          {/* Profile */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-profile`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Profile{" "}
+              <span className="text-text-muted font-normal">(optional)</span>
+            </label>
+            <select
+              id={`${id}-profile`}
+              value={profileId}
+              onChange={(e) => setProfileId(e.target.value)}
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            >
+              <option value="">— No profile —</option>
+              {profiles.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Enabled */}
+          <div className="flex items-center gap-2">
+            <input
+              id={`${id}-enabled`}
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-border accent-accent"
+            />
+            <label
+              htmlFor={`${id}-enabled`}
+              className="text-xs text-text-primary"
+            >
+              Enable this schedule
+            </label>
+          </div>
+
+          {/* Inline error */}
+          {error && (
+            <p role="alert" className="text-xs text-danger">
+              {error}
+            </p>
+          )}
+
+          {/* Footer */}
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="secondary" type="button" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" loading={isPending}>
+              Create schedule
+            </Button>
+          </div>
+        </form>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -9,6 +9,7 @@ import {
   Clock,
   Shield,
   ShieldOff,
+  ScanSearch,
   PanelLeftClose,
   PanelLeftOpen,
 } from "lucide-react";
@@ -23,6 +24,7 @@ const mainNav: NavItem[] = [
   { label: "Dashboard", href: "#/", icon: LayoutDashboard },
   { label: "Scans", href: "#/scans", icon: Radar },
   { label: "Hosts", href: "#/hosts", icon: Server },
+  { label: "Discovery", href: "#/discovery", icon: ScanSearch },
   { label: "Networks", href: "#/networks", icon: Network },
   { label: "Exclusions", href: "#/exclusions", icon: ShieldOff },
   { label: "Profiles", href: "#/profiles", icon: SlidersHorizontal },

--- a/frontend/src/components/profile-form-modal.tsx
+++ b/frontend/src/components/profile-form-modal.tsx
@@ -1,0 +1,248 @@
+import { useState, useId } from "react";
+import { X } from "lucide-react";
+import { Button } from "./button";
+import { useCreateProfile, useUpdateProfile } from "../api/hooks/use-profiles";
+import { cn } from "../lib/utils";
+import type { components } from "../api/types";
+
+type CreateProfileRequest = components["schemas"]["docs.CreateProfileRequest"];
+
+const SCAN_TYPES = [
+  { value: "connect", label: "Connect (-sT)" },
+  { value: "syn", label: "SYN stealth (-sS)" },
+  { value: "ack", label: "ACK (-sA)" },
+  { value: "udp", label: "UDP (-sU)" },
+  { value: "aggressive", label: "Aggressive (-sS -sV -A)" },
+  { value: "comprehensive", label: "Comprehensive (-sS -sV --script=default)" },
+] as const;
+
+export interface ProfileFormModalProps {
+  mode: "create" | "edit";
+  initial?: {
+    id?: string;
+    name?: string;
+    description?: string;
+    scan_type?: string;
+    ports?: string;
+  };
+  onClose: () => void;
+  onSaved?: () => void;
+}
+
+export function ProfileFormModal({
+  mode,
+  initial,
+  onClose,
+  onSaved,
+}: ProfileFormModalProps) {
+  const id = useId();
+
+  const [name, setName] = useState(initial?.name ?? "");
+  const [scanType, setScanType] = useState(initial?.scan_type ?? "connect");
+  const [ports, setPorts] = useState(initial?.ports ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [error, setError] = useState<string | null>(null);
+
+  const { mutateAsync: createProfile, isPending: isCreating } =
+    useCreateProfile();
+  const { mutateAsync: updateProfile, isPending: isUpdating } =
+    useUpdateProfile();
+  const isPending = isCreating || isUpdating;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError("Name is required.");
+      return;
+    }
+
+    const body: CreateProfileRequest = {
+      name: trimmedName,
+      scan_type: scanType,
+      ports: ports.trim() || undefined,
+      description: description.trim() || undefined,
+    };
+
+    try {
+      if (mode === "create") {
+        await createProfile(body);
+      } else {
+        await updateProfile({ id: initial?.id ?? "", body });
+      }
+      onSaved?.();
+      onClose();
+    } catch (err) {
+      const apiErr = err as { message?: string; error?: string };
+      setError(
+        apiErr.message ??
+          apiErr.error ??
+          (mode === "create"
+            ? "Failed to create profile."
+            : "Failed to update profile."),
+      );
+    }
+  }
+
+  const title = mode === "create" ? "Create Profile" : "Edit Profile";
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Dialog */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${id}-title`}
+        className={cn(
+          "fixed z-50 inset-0 m-auto",
+          "w-full max-w-md h-fit",
+          "bg-surface border border-border rounded-lg shadow-xl",
+          "flex flex-col",
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+          <h2
+            id={`${id}-title`}
+            className="text-sm font-semibold text-text-primary"
+          >
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close dialog"
+            className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <form onSubmit={handleSubmit} className="px-5 py-4 space-y-5">
+          {/* Name */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-name`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Name
+            </label>
+            <input
+              id={`${id}-name`}
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Quick scan"
+              autoFocus
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+          </div>
+
+          {/* Scan type */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-scan-type`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Scan type
+            </label>
+            <select
+              id={`${id}-scan-type`}
+              value={scanType}
+              onChange={(e) => setScanType(e.target.value)}
+              aria-label="Select scan type"
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            >
+              {SCAN_TYPES.map((t) => (
+                <option key={t.value} value={t.value}>
+                  {t.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Ports */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-ports`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Ports{" "}
+              <span className="text-text-muted font-normal">(optional)</span>
+            </label>
+            <input
+              id={`${id}-ports`}
+              type="text"
+              value={ports}
+              onChange={(e) => setPorts(e.target.value)}
+              placeholder="22,80,443 or 1-65535"
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border font-mono",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+          </div>
+
+          {/* Description */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor={`${id}-description`}
+              className="block text-xs font-medium text-text-primary"
+            >
+              Description{" "}
+              <span className="text-text-muted font-normal">(optional)</span>
+            </label>
+            <input
+              id={`${id}-description`}
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Fast TCP connect scan"
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+          </div>
+
+          {/* Inline error */}
+          {error && (
+            <p role="alert" className="text-xs text-danger">
+              {error}
+            </p>
+          )}
+
+          {/* Footer */}
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="secondary" type="button" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" loading={isPending}>
+              {mode === "create" ? "Create profile" : "Save changes"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { formatRelativeTime, formatAbsoluteTime } from "./utils";
+import { formatRelativeTime, formatAbsoluteTime, describeCron } from "./utils";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -130,5 +130,41 @@ describe("formatAbsoluteTime", () => {
     const a = formatAbsoluteTime("2024-01-01T00:00:00Z");
     const b = formatAbsoluteTime("2024-12-31T23:59:59Z");
     expect(a).not.toBe(b);
+  });
+});
+
+// ── describeCron ──────────────────────────────────────────────────────────────
+
+describe("describeCron", () => {
+  it('returns "Every minute" for "* * * * *"', () => {
+    expect(describeCron("* * * * *")).toBe("Every minute");
+  });
+
+  it('returns "Every day at 02:00" for "0 2 * * *"', () => {
+    expect(describeCron("0 2 * * *")).toBe("Every day at 02:00");
+  });
+
+  it('returns "Every day at 14:30" for "30 14 * * *"', () => {
+    expect(describeCron("30 14 * * *")).toBe("Every day at 14:30");
+  });
+
+  it('returns "Every hour at :30" for "30 * * * *"', () => {
+    expect(describeCron("30 * * * *")).toBe("Every hour at :30");
+  });
+
+  it('returns "Every Monday at 09:00" for "0 9 * * 1"', () => {
+    expect(describeCron("0 9 * * 1")).toBe("Every Monday at 09:00");
+  });
+
+  it('returns "Every Friday at 14:00" for "0 14 * * 5"', () => {
+    expect(describeCron("0 14 * * 5")).toBe("Every Friday at 14:00");
+  });
+
+  it("returns the raw expression when dom is not a wildcard", () => {
+    expect(describeCron("0 2 1 * *")).toBe("0 2 1 * *");
+  });
+
+  it("returns the raw expression when input has fewer than 5 parts", () => {
+    expect(describeCron("0 2 * *")).toBe("0 2 * *");
   });
 });

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -20,3 +20,42 @@ export function formatRelativeTime(date: string | Date): string {
 export function formatAbsoluteTime(date: string | Date): string {
   return new Date(date).toLocaleString();
 }
+
+export function describeCron(expr: string): string {
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length !== 5) return expr;
+  const [min, hr, dom, month, dow] = parts;
+
+  const DAYS = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ];
+  const allStar = (v: string) => v === "*";
+
+  const timeStr = (h: string, m: string) =>
+    `${h.padStart(2, "0")}:${m.padStart(2, "0")}`;
+
+  if ([min, hr, dom, month, dow].every(allStar)) return "Every minute";
+  if (allStar(min) && [hr, dom, month, dow].every(allStar))
+    return "Every minute"; // same
+  if (!allStar(hr) && allStar(min) && [dom, month, dow].every(allStar))
+    return `Every day at ${timeStr(hr, "0")}`;
+  if (!allStar(min) && !allStar(hr) && [dom, month, dow].every(allStar))
+    return `Every day at ${timeStr(hr, min)}`;
+  if (!allStar(min) && allStar(hr) && [dom, month, dow].every(allStar))
+    return `Every hour at :${min.padStart(2, "0")}`;
+  if (!allStar(dow) && /^\d$/.test(dow) && [dom, month].every(allStar)) {
+    const day = DAYS[parseInt(dow)] ?? dow;
+    if (!allStar(hr) && !allStar(min))
+      return `Every ${day} at ${timeStr(hr, min)}`;
+    if (!allStar(hr) && allStar(min))
+      return `Every ${day} at ${timeStr(hr, "0")}`;
+    return `Every ${day}`;
+  }
+  return expr;
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -10,6 +10,7 @@ import { ScansPage } from "./routes/scans";
 import { HostsPage } from "./routes/hosts";
 import { NetworksPage } from "./routes/networks";
 import { ExclusionsPage } from "./routes/exclusions";
+import { DiscoveryPage } from "./routes/discovery";
 import { ProfilesPage } from "./routes/profiles";
 import { SchedulesPage } from "./routes/schedules";
 import { AdminPage } from "./routes/admin";
@@ -48,6 +49,12 @@ const exclusionsRoute = createRoute({
   component: ExclusionsPage,
 });
 
+const discoveryRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/discovery",
+  component: DiscoveryPage,
+});
+
 const profilesRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/profiles",
@@ -72,6 +79,7 @@ const routeTree = rootRoute.addChildren([
   hostsRoute,
   networksRoute,
   exclusionsRoute,
+  discoveryRoute,
   profilesRoute,
   schedulesRoute,
   adminRoute,

--- a/frontend/src/routes/discovery.test.tsx
+++ b/frontend/src/routes/discovery.test.tsx
@@ -1,0 +1,439 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DiscoveryPage } from "./discovery";
+
+vi.mock("../api/hooks/use-discovery", () => ({
+  useDiscoveryJobs: vi.fn(),
+  useStartDiscovery: vi.fn(),
+  useStopDiscovery: vi.fn(),
+}));
+
+vi.mock("../components/create-discovery-modal", () => ({
+  CreateDiscoveryModal: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="create-discovery-modal">
+      <button type="button" onClick={onClose}>
+        Close Modal
+      </button>
+    </div>
+  ),
+}));
+
+import {
+  useDiscoveryJobs,
+  useStartDiscovery,
+  useStopDiscovery,
+} from "../api/hooks/use-discovery";
+
+const mockUseDiscoveryJobs = vi.mocked(useDiscoveryJobs);
+const mockUseStartDiscovery = vi.mocked(useStartDiscovery);
+const mockUseStopDiscovery = vi.mocked(useStopDiscovery);
+
+const mockJobs = [
+  {
+    id: "job-1",
+    name: "Office LAN Discovery",
+    network: "192.168.1.0/24",
+    method: "tcp" as const,
+    status: "completed" as const,
+    progress: 100,
+    started_at: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+  },
+  {
+    id: "job-2",
+    name: "DMZ Discovery",
+    network: "10.0.0.0/8",
+    method: "icmp" as const,
+    status: "pending" as const,
+    progress: 0,
+    started_at: undefined,
+    created_at: new Date().toISOString(),
+  },
+  {
+    id: "job-3",
+    name: undefined,
+    network: "172.16.0.0/12",
+    method: "arp" as const,
+    status: "running" as const,
+    progress: 50,
+    started_at: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+  },
+];
+
+const startMutateMock = vi.fn();
+const stopMutateMock = vi.fn();
+
+function makeUseDiscoveryJobsResult(overrides = {}) {
+  return {
+    data: {
+      data: mockJobs,
+      pagination: { page: 1, page_size: 20, total_items: 3, total_pages: 1 },
+    },
+    isLoading: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useDiscoveryJobs>;
+}
+
+function makeStartMutationResult(overrides = {}) {
+  return {
+    mutate: startMutateMock,
+    mutateAsync: vi.fn(),
+    isPending: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useStartDiscovery>;
+}
+
+function makeStopMutationResult(overrides = {}) {
+  return {
+    mutate: stopMutateMock,
+    mutateAsync: vi.fn(),
+    isPending: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useStopDiscovery>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  startMutateMock.mockReset();
+  stopMutateMock.mockReset();
+  mockUseDiscoveryJobs.mockReturnValue(makeUseDiscoveryJobsResult());
+  mockUseStartDiscovery.mockReturnValue(makeStartMutationResult());
+  mockUseStopDiscovery.mockReturnValue(makeStopMutationResult());
+});
+
+describe("DiscoveryPage", () => {
+  // ── Toolbar ───────────────────────────────────────────────────
+
+  it("renders the 'New discovery job' button", () => {
+    render(<DiscoveryPage />);
+    expect(
+      screen.getByRole("button", { name: /new discovery job/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── Loading state ─────────────────────────────────────────────
+
+  it("renders skeleton rows when loading", () => {
+    mockUseDiscoveryJobs.mockReturnValue(
+      makeUseDiscoveryJobsResult({ isLoading: true, data: undefined }),
+    );
+    const { container } = render(<DiscoveryPage />);
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("does not show empty message while loading", () => {
+    mockUseDiscoveryJobs.mockReturnValue(
+      makeUseDiscoveryJobsResult({ isLoading: true, data: undefined }),
+    );
+    render(<DiscoveryPage />);
+    expect(
+      screen.queryByText(/no discovery jobs found/i),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── Empty state ───────────────────────────────────────────────
+
+  it("shows 'No discovery jobs found.' when the list is empty", () => {
+    mockUseDiscoveryJobs.mockReturnValue(
+      makeUseDiscoveryJobsResult({
+        data: {
+          data: [],
+          pagination: {
+            page: 1,
+            page_size: 20,
+            total_items: 0,
+            total_pages: 1,
+          },
+        },
+      }),
+    );
+    render(<DiscoveryPage />);
+    expect(screen.getByText("No discovery jobs found.")).toBeInTheDocument();
+  });
+
+  // ── Column headers ────────────────────────────────────────────
+
+  it("renders all expected column headers", () => {
+    render(<DiscoveryPage />);
+    const headers = ["Name", "Network", "Method", "Status", "Progress", "Started", "Created"];
+    for (const header of headers) {
+      expect(screen.getByRole("columnheader", { name: header })).toBeInTheDocument();
+    }
+  });
+
+  // ── Row data ──────────────────────────────────────────────────
+
+  it("renders a row for each job", () => {
+    render(<DiscoveryPage />);
+    const rows = screen.getAllByRole("row");
+    // 1 header + 3 data rows
+    expect(rows).toHaveLength(4);
+  });
+
+  it("renders job names", () => {
+    render(<DiscoveryPage />);
+    expect(screen.getByText("Office LAN Discovery")).toBeInTheDocument();
+    expect(screen.getByText("DMZ Discovery")).toBeInTheDocument();
+  });
+
+  it("renders em-dash for missing job name", () => {
+    render(<DiscoveryPage />);
+    const rows = screen.getAllByRole("row");
+    // job-3 has no name (rows[3])
+    const cells = within(rows[3]).getAllByRole("cell");
+    expect(cells[0]).toHaveTextContent("—");
+  });
+
+  it("renders CIDRs in the network column", () => {
+    render(<DiscoveryPage />);
+    expect(screen.getByText("192.168.1.0/24")).toBeInTheDocument();
+    expect(screen.getByText("10.0.0.0/8")).toBeInTheDocument();
+    expect(screen.getByText("172.16.0.0/12")).toBeInTheDocument();
+  });
+
+  it("renders CIDRs with monospace font", () => {
+    render(<DiscoveryPage />);
+    const cidrCell = screen.getByText("192.168.1.0/24");
+    expect(cidrCell).toHaveClass("font-mono");
+  });
+
+  it("renders method labels as uppercase strings", () => {
+    render(<DiscoveryPage />);
+    expect(screen.getByText("TCP")).toBeInTheDocument();
+    expect(screen.getByText("ICMP")).toBeInTheDocument();
+    expect(screen.getByText("ARP")).toBeInTheDocument();
+  });
+
+  it("renders StatusBadge for each job", () => {
+    render(<DiscoveryPage />);
+    expect(screen.getByText("completed")).toBeInTheDocument();
+    expect(screen.getByText("pending")).toBeInTheDocument();
+    expect(screen.getByText("running")).toBeInTheDocument();
+  });
+
+  it("shows em-dash in Progress column for non-running jobs", () => {
+    render(<DiscoveryPage />);
+    const rows = screen.getAllByRole("row");
+    // job-1 is completed (rows[1]) — progress should show "—"
+    const cells = within(rows[1]).getAllByRole("cell");
+    expect(cells[4]).toHaveTextContent("—");
+  });
+
+  it("shows a progress bar in the Progress column for running jobs", () => {
+    render(<DiscoveryPage />);
+    const rows = screen.getAllByRole("row");
+    // job-3 is running (rows[3])
+    const cells = within(rows[3]).getAllByRole("cell");
+    // Should contain a div with rounded-full (progress bar) instead of "—"
+    expect(cells[4].querySelector(".rounded-full")).toBeInTheDocument();
+    expect(cells[4]).not.toHaveTextContent("—");
+  });
+
+  it("shows relative time for started_at when present", () => {
+    render(<DiscoveryPage />);
+    // job-1 and job-3 have started_at; expect at least one relative time
+    const justNow = screen.getAllByText("just now");
+    expect(justNow.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows em-dash for missing started_at", () => {
+    render(<DiscoveryPage />);
+    const rows = screen.getAllByRole("row");
+    // job-2 (pending) has no started_at — rows[2], Started column (index 5)
+    const cells = within(rows[2]).getAllByRole("cell");
+    expect(cells[5]).toHaveTextContent("—");
+  });
+
+  it("shows relative time for created_at when present", () => {
+    render(<DiscoveryPage />);
+    // All jobs have created_at
+    const rows = screen.getAllByRole("row");
+    const cells = within(rows[1]).getAllByRole("cell");
+    expect(cells[6]).not.toHaveTextContent("—");
+  });
+
+  // ── Inline actions ────────────────────────────────────────────
+
+  it("shows a Start button for pending jobs", () => {
+    render(<DiscoveryPage />);
+    expect(screen.getByRole("button", { name: /start/i })).toBeInTheDocument();
+  });
+
+  it("shows a Stop button for running jobs", () => {
+    render(<DiscoveryPage />);
+    expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument();
+  });
+
+  it("does not show Start or Stop button for completed jobs", () => {
+    render(<DiscoveryPage />);
+    const rows = screen.getAllByRole("row");
+    // job-1 is completed (rows[1])
+    expect(
+      within(rows[1]).queryByRole("button", { name: /start/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(rows[1]).queryByRole("button", { name: /stop/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clicking Start calls startDiscovery with the job id", async () => {
+    render(<DiscoveryPage />);
+    const startButton = screen.getByRole("button", { name: /start/i });
+    await userEvent.click(startButton);
+    expect(startMutateMock).toHaveBeenCalledWith("job-2");
+  });
+
+  it("clicking Stop calls stopDiscovery with the job id", async () => {
+    render(<DiscoveryPage />);
+    const stopButton = screen.getByRole("button", { name: /stop/i });
+    await userEvent.click(stopButton);
+    expect(stopMutateMock).toHaveBeenCalledWith("job-3");
+  });
+
+  it("clicking Start does not open the detail panel", async () => {
+    render(<DiscoveryPage />);
+    const startButton = screen.getByRole("button", { name: /start/i });
+    await userEvent.click(startButton);
+    expect(
+      screen.queryByRole("dialog", { name: /discovery job details/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── Detail panel ──────────────────────────────────────────────
+
+  it("opens the detail panel when a row is clicked", async () => {
+    render(<DiscoveryPage />);
+    const rows = screen.getAllByRole("row");
+    await userEvent.click(rows[1]);
+    expect(
+      screen.getByRole("dialog", { name: /discovery job details/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the job name in the detail panel header", async () => {
+    render(<DiscoveryPage />);
+    const rows = screen.getAllByRole("row");
+    await userEvent.click(rows[1]);
+    const dialog = screen.getByRole("dialog", { name: /discovery job details/i });
+    expect(within(dialog).getByText("Office LAN Discovery")).toBeInTheDocument();
+  });
+
+  it("shows the network CIDR in the detail panel header", async () => {
+    render(<DiscoveryPage />);
+    const rows = screen.getAllByRole("row");
+    await userEvent.click(rows[1]);
+    const dialog = screen.getByRole("dialog", { name: /discovery job details/i });
+    // CIDR appears in the panel header
+    expect(within(dialog).getAllByText("192.168.1.0/24").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows the status badge in the detail panel", async () => {
+    render(<DiscoveryPage />);
+    const rows = screen.getAllByRole("row");
+    await userEvent.click(rows[1]);
+    const dialog = screen.getByRole("dialog", { name: /discovery job details/i });
+    const badges = within(dialog).getAllByText("completed");
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows the job ID in the detail panel", async () => {
+    render(<DiscoveryPage />);
+    const rows = screen.getAllByRole("row");
+    await userEvent.click(rows[1]);
+    const dialog = screen.getByRole("dialog", { name: /discovery job details/i });
+    expect(within(dialog).getByText("job-1")).toBeInTheDocument();
+  });
+
+  it("shows 'Discovery #ID' as title when job name is missing", async () => {
+    render(<DiscoveryPage />);
+    const rows = screen.getAllByRole("row");
+    // job-3 has no name
+    await userEvent.click(rows[3]);
+    const dialog = screen.getByRole("dialog", { name: /discovery job details/i });
+    expect(within(dialog).getByText("Discovery #job-3")).toBeInTheDocument();
+  });
+
+  it("closes the detail panel when the close button is clicked", async () => {
+    render(<DiscoveryPage />);
+    const rows = screen.getAllByRole("row");
+    await userEvent.click(rows[1]);
+    expect(
+      screen.getByRole("dialog", { name: /discovery job details/i }),
+    ).toBeInTheDocument();
+
+    const closeButton = screen.getByRole("button", { name: /close panel/i });
+    await userEvent.click(closeButton);
+    expect(
+      screen.queryByRole("dialog", { name: /discovery job details/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("closes the detail panel when the backdrop is clicked", async () => {
+    render(<DiscoveryPage />);
+    const rows = screen.getAllByRole("row");
+    await userEvent.click(rows[1]);
+    expect(
+      screen.getByRole("dialog", { name: /discovery job details/i }),
+    ).toBeInTheDocument();
+
+    const backdrop = document.querySelector(".fixed.inset-0.bg-black\\/40");
+    expect(backdrop).not.toBeNull();
+    await userEvent.click(backdrop!);
+    expect(
+      screen.queryByRole("dialog", { name: /discovery job details/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── Pagination ────────────────────────────────────────────────
+
+  it("shows pagination when there are multiple pages", () => {
+    mockUseDiscoveryJobs.mockReturnValue(
+      makeUseDiscoveryJobsResult({
+        data: {
+          data: mockJobs,
+          pagination: {
+            page: 1,
+            page_size: 20,
+            total_items: 45,
+            total_pages: 3,
+          },
+        },
+      }),
+    );
+    render(<DiscoveryPage />);
+    expect(screen.getByRole("button", { name: /previous page/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /next page/i })).toBeInTheDocument();
+  });
+
+  it("does not show pagination when there is only one page", () => {
+    render(<DiscoveryPage />);
+    expect(
+      screen.queryByRole("button", { name: /previous page/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── Create modal ──────────────────────────────────────────────
+
+  it("opens the create modal when 'New discovery job' is clicked", async () => {
+    render(<DiscoveryPage />);
+    const button = screen.getByRole("button", { name: /new discovery job/i });
+    await userEvent.click(button);
+    expect(screen.getByTestId("create-discovery-modal")).toBeInTheDocument();
+  });
+
+  it("closes the create modal when the modal's onClose is called", async () => {
+    render(<DiscoveryPage />);
+    const button = screen.getByRole("button", { name: /new discovery job/i });
+    await userEvent.click(button);
+    expect(screen.getByTestId("create-discovery-modal")).toBeInTheDocument();
+
+    const closeButton = screen.getByRole("button", { name: /close modal/i });
+    await userEvent.click(closeButton);
+    expect(
+      screen.queryByTestId("create-discovery-modal"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/routes/discovery.tsx
+++ b/frontend/src/routes/discovery.tsx
@@ -1,0 +1,372 @@
+import { useState } from "react";
+import { X, Plus } from "lucide-react";
+import { Button } from "../components/button";
+import {
+  useDiscoveryJobs,
+  useStartDiscovery,
+  useStopDiscovery,
+} from "../api/hooks/use-discovery";
+import { StatusBadge, Skeleton, PaginationBar } from "../components";
+import { CreateDiscoveryModal } from "../components/create-discovery-modal";
+import { formatRelativeTime } from "../lib/utils";
+import { cn } from "../lib/utils";
+import type { components } from "../api/types";
+
+type DiscoveryJobResponse = components["schemas"]["docs.DiscoveryJobResponse"];
+
+const PAGE_SIZE = 20;
+
+const METHOD_LABELS: Record<string, string> = {
+  tcp: "TCP",
+  icmp: "ICMP",
+  arp: "ARP",
+};
+
+// ── Skeleton rows ─────────────────────────────────────────────────────────────
+
+function SkeletonRows({ count }: { count: number }) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, i) => (
+        <tr key={i} className="border-b border-border/50">
+          <td className="py-3 px-4 pr-4">
+            <Skeleton className="h-3 w-32" />
+          </td>
+          <td className="py-3 pr-4">
+            <Skeleton className="h-3 w-28" />
+          </td>
+          <td className="py-3 pr-4">
+            <Skeleton className="h-3 w-12" />
+          </td>
+          <td className="py-3 pr-4">
+            <Skeleton className="h-3 w-16" />
+          </td>
+          <td className="py-3 pr-4">
+            <Skeleton className="h-1 w-20" />
+          </td>
+          <td className="py-3 pr-4">
+            <Skeleton className="h-3 w-16" />
+          </td>
+          <td className="py-3 pr-4">
+            <Skeleton className="h-3 w-16" />
+          </td>
+          <td className="py-3" />
+        </tr>
+      ))}
+    </>
+  );
+}
+
+// ── Detail panel ──────────────────────────────────────────────────────────────
+
+interface DetailPanelProps {
+  job: DiscoveryJobResponse;
+  onClose: () => void;
+}
+
+function MetaRow({ label, value }: { label: string; value?: React.ReactNode }) {
+  if (value === undefined || value === null || value === "") return null;
+  return (
+    <div className="flex gap-3 text-xs">
+      <span className="text-text-muted w-24 shrink-0">{label}</span>
+      <span className="text-text-secondary break-all">{value}</span>
+    </div>
+  );
+}
+
+function DiscoveryDetailPanel({ job, onClose }: DetailPanelProps) {
+  const title = job.name ?? `Discovery #${job.id}`;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/40 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div
+        role="dialog"
+        aria-label="Discovery job details"
+        className={cn(
+          "fixed top-0 right-0 bottom-0 z-50",
+          "w-full max-w-110",
+          "bg-surface border-l border-border",
+          "flex flex-col overflow-hidden",
+          "shadow-xl",
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 px-5 py-4 border-b border-border shrink-0">
+          <div className="flex flex-col gap-1.5 min-w-0">
+            <p className="text-sm font-medium text-text-primary truncate">
+              {title}
+            </p>
+            <p className="text-xs font-mono text-text-secondary">
+              {job.network ?? "—"}
+            </p>
+            <StatusBadge status={job.status ?? "unknown"} />
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close panel"
+            className="shrink-0 p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-6">
+          {/* Progress (only when running) */}
+          {job.status === "running" && (
+            <section>
+              <h3 className="text-xs font-medium text-text-primary mb-3">
+                Progress
+              </h3>
+              <div className="space-y-1.5">
+                <div className="w-full bg-border rounded-full h-1">
+                  <div
+                    className="bg-accent h-1 rounded-full"
+                    style={{ width: `${job.progress ?? 0}%` }}
+                  />
+                </div>
+                <p className="text-xs text-text-muted">{job.progress ?? 0}%</p>
+              </div>
+            </section>
+          )}
+
+          {/* Details */}
+          <section>
+            <h3 className="text-xs font-medium text-text-primary mb-3">
+              Details
+            </h3>
+            <div className="space-y-2">
+              <MetaRow label="ID" value={job.id} />
+              <MetaRow label="Network" value={job.network} />
+              <MetaRow
+                label="Method"
+                value={
+                  job.method
+                    ? (METHOD_LABELS[job.method] ?? job.method)
+                    : undefined
+                }
+              />
+              <MetaRow label="Status" value={job.status} />
+            </div>
+          </section>
+
+          {/* Timestamps */}
+          <section>
+            <h3 className="text-xs font-medium text-text-primary mb-3">
+              Timestamps
+            </h3>
+            <div className="space-y-2">
+              <MetaRow
+                label="Started"
+                value={
+                  job.started_at
+                    ? formatRelativeTime(job.started_at)
+                    : undefined
+                }
+              />
+              <MetaRow
+                label="Created"
+                value={
+                  job.created_at
+                    ? formatRelativeTime(job.created_at)
+                    : undefined
+                }
+              />
+            </div>
+          </section>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export function DiscoveryPage() {
+  const [page, setPage] = useState(1);
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+
+  const queryParams = { page, page_size: PAGE_SIZE };
+  const { data, isLoading } = useDiscoveryJobs(queryParams);
+
+  const jobs = data?.data ?? [];
+  const pagination = data?.pagination;
+  const totalPages = pagination?.total_pages ?? 1;
+
+  const { mutate: startDiscovery } = useStartDiscovery();
+  const { mutate: stopDiscovery } = useStopDiscovery();
+
+  const selectedJob = selectedJobId
+    ? (jobs.find((j) => j.id === selectedJobId) ?? null)
+    : null;
+
+  return (
+    <>
+      <div className="space-y-4">
+        {/* Toolbar */}
+        <div className="flex justify-end">
+          <Button
+            onClick={() => setShowCreate(true)}
+            icon={<Plus className="h-3.5 w-3.5" />}
+          >
+            New discovery job
+          </Button>
+        </div>
+
+        {/* Table card */}
+        <div className="bg-surface rounded-lg border border-border overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border bg-surface">
+                  <th className="text-left font-medium text-text-muted px-4 py-3 pr-4">
+                    Name
+                  </th>
+                  <th className="text-left font-medium text-text-muted py-3 pr-4">
+                    Network
+                  </th>
+                  <th className="text-left font-medium text-text-muted py-3 pr-4">
+                    Method
+                  </th>
+                  <th className="text-left font-medium text-text-muted py-3 pr-4">
+                    Status
+                  </th>
+                  <th className="text-left font-medium text-text-muted py-3 pr-4">
+                    Progress
+                  </th>
+                  <th className="text-left font-medium text-text-muted py-3 pr-4">
+                    Started
+                  </th>
+                  <th className="text-left font-medium text-text-muted py-3 pr-4">
+                    Created
+                  </th>
+                  <th className="py-3" />
+                </tr>
+              </thead>
+              <tbody>
+                {isLoading ? (
+                  <SkeletonRows count={5} />
+                ) : jobs.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={8}
+                      className="py-10 text-center text-xs text-text-muted"
+                    >
+                      No discovery jobs found.
+                    </td>
+                  </tr>
+                ) : (
+                  jobs.map((job) => (
+                    <tr
+                      key={job.id}
+                      onClick={() => setSelectedJobId(job.id ?? null)}
+                      className={cn(
+                        "border-b border-border/50 last:border-0",
+                        "hover:bg-surface-raised/50 transition-colors cursor-pointer",
+                      )}
+                    >
+                      <td className="py-3 px-4 pr-4 text-text-secondary">
+                        {job.name ?? "—"}
+                      </td>
+                      <td className="py-3 pr-4 font-mono text-text-secondary">
+                        {job.network ?? "—"}
+                      </td>
+                      <td className="py-3 pr-4 text-text-secondary">
+                        {job.method
+                          ? (METHOD_LABELS[job.method] ?? job.method)
+                          : "—"}
+                      </td>
+                      <td className="py-3 pr-4">
+                        <StatusBadge status={job.status ?? "unknown"} />
+                      </td>
+                      <td className="py-3 pr-4">
+                        {job.status === "running" ? (
+                          <div className="w-full bg-border rounded-full h-1 min-w-16">
+                            <div
+                              className="bg-accent h-1 rounded-full"
+                              style={{ width: `${job.progress ?? 0}%` }}
+                            />
+                          </div>
+                        ) : (
+                          <span className="text-text-muted">—</span>
+                        )}
+                      </td>
+                      <td className="py-3 pr-4 text-text-muted whitespace-nowrap">
+                        {job.started_at
+                          ? formatRelativeTime(job.started_at)
+                          : "—"}
+                      </td>
+                      <td className="py-3 pr-4 text-text-muted whitespace-nowrap">
+                        {job.created_at
+                          ? formatRelativeTime(job.created_at)
+                          : "—"}
+                      </td>
+                      <td
+                        className="py-3 pr-4"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {job.status === "pending" && (
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            onClick={() => startDiscovery(job.id ?? "")}
+                          >
+                            ▶ Start
+                          </Button>
+                        )}
+                        {job.status === "running" && (
+                          <Button
+                            variant="danger"
+                            size="sm"
+                            onClick={() => stopDiscovery(job.id ?? "")}
+                          >
+                            ■ Stop
+                          </Button>
+                        )}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Pagination */}
+          {!isLoading && jobs.length > 0 && totalPages > 1 && (
+            <div className="px-4 pb-3">
+              <PaginationBar
+                page={page}
+                totalPages={totalPages}
+                onPrev={() => setPage((p) => Math.max(1, p - 1))}
+                onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Detail panel */}
+      {selectedJob && (
+        <DiscoveryDetailPanel
+          job={selectedJob}
+          onClose={() => setSelectedJobId(null)}
+        />
+      )}
+
+      {/* Create modal */}
+      {showCreate && (
+        <CreateDiscoveryModal onClose={() => setShowCreate(false)} />
+      )}
+    </>
+  );
+}

--- a/frontend/src/routes/index.ts
+++ b/frontend/src/routes/index.ts
@@ -2,7 +2,7 @@ export { DashboardPage } from "./dashboard";
 export { ScansPage } from "./scans";
 export { HostsPage } from "./hosts";
 export { NetworksPage } from "./networks";
-
+export { DiscoveryPage } from "./discovery";
 export { ProfilesPage } from "./profiles";
 export { SchedulesPage } from "./schedules";
 export { AdminPage } from "./admin";

--- a/frontend/src/routes/placeholder-routes.test.tsx
+++ b/frontend/src/routes/placeholder-routes.test.tsx
@@ -1,24 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
-import { SchedulesPage } from "./schedules";
-import { ProfilesPage } from "./profiles";
+
 import { AdminPage } from "./admin";
-
-describe("SchedulesPage", () => {
-  it("renders the coming-soon message", () => {
-    render(<SchedulesPage />);
-    expect(
-      screen.getByText("Schedule management coming soon."),
-    ).toBeInTheDocument();
-  });
-});
-
-describe("ProfilesPage", () => {
-  it("renders the coming-soon message", () => {
-    render(<ProfilesPage />);
-    expect(screen.getByText("Scan profiles coming soon.")).toBeInTheDocument();
-  });
-});
 
 describe("AdminPage", () => {
   it("renders the coming-soon message", () => {

--- a/frontend/src/routes/profiles.test.tsx
+++ b/frontend/src/routes/profiles.test.tsx
@@ -1,0 +1,368 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ProfilesPage } from "./profiles";
+
+// ── Mock hooks ────────────────────────────────────────────────────────────────
+
+vi.mock("../api/hooks/use-profiles", () => ({
+  useProfiles: vi.fn(),
+  useDeleteProfile: vi.fn(),
+}));
+
+vi.mock("../components/profile-form-modal", () => ({
+  ProfileFormModal: ({ onClose }: { onClose: () => void }) => (
+    <div role="dialog" aria-label="Profile Form">
+      <button type="button" onClick={onClose}>
+        Close profile form
+      </button>
+    </div>
+  ),
+}));
+
+import {
+  useProfiles,
+  useDeleteProfile,
+} from "../api/hooks/use-profiles";
+
+const mockUseProfiles = vi.mocked(useProfiles);
+const mockUseDeleteProfile = vi.mocked(useDeleteProfile);
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const mockProfiles = [
+  {
+    id: "p1",
+    name: "Quick scan",
+    scan_type: "connect",
+    ports: "22,80,443",
+    description: "Fast TCP connect scan",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: new Date(Date.now() - 3_600_000).toISOString(),
+  },
+  {
+    id: "p2",
+    name: "Full scan",
+    scan_type: "syn",
+    ports: "1-65535",
+    description: "Comprehensive SYN scan",
+    created_at: "2024-01-02T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+  },
+  {
+    id: "p3",
+    name: "UDP check",
+    scan_type: "udp",
+    ports: undefined,
+    description: undefined,
+    created_at: "2024-01-03T00:00:00Z",
+    updated_at: undefined,
+  },
+];
+
+const mockPagination = {
+  page: 1,
+  page_size: 25,
+  total_items: 3,
+  total_pages: 1,
+};
+
+const idleMutation = {
+  mutateAsync: vi.fn(),
+  mutate: vi.fn(),
+  isPending: false,
+  isSuccess: false,
+  isError: false,
+};
+
+function makeUseProfilesResult(overrides = {}) {
+  return {
+    data: {
+      data: mockProfiles,
+      pagination: mockPagination,
+    },
+    isLoading: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useProfiles>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseProfiles.mockReturnValue(makeUseProfilesResult());
+  mockUseDeleteProfile.mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useDeleteProfile>,
+  );
+});
+
+// ── Toolbar ───────────────────────────────────────────────────────────────────
+
+describe("ProfilesPage — toolbar", () => {
+  it("renders search input with label 'Search by name'", () => {
+    render(<ProfilesPage />);
+    expect(
+      screen.getByRole("textbox", { name: /search by name/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the Create Profile button", () => {
+    render(<ProfilesPage />);
+    expect(
+      screen.getByRole("button", { name: /create profile/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+// ── Loading state ─────────────────────────────────────────────────────────────
+
+describe("ProfilesPage — loading", () => {
+  it("renders >=6 skeleton rows when loading", () => {
+    mockUseProfiles.mockReturnValue(
+      makeUseProfilesResult({ isLoading: true, data: undefined }),
+    );
+    const { container } = render(<ProfilesPage />);
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("does not show 'No profiles found.' while loading", () => {
+    mockUseProfiles.mockReturnValue(
+      makeUseProfilesResult({ isLoading: true, data: undefined }),
+    );
+    render(<ProfilesPage />);
+    expect(screen.queryByText("No profiles found.")).not.toBeInTheDocument();
+  });
+});
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+describe("ProfilesPage — empty state", () => {
+  it("shows 'No profiles found.' when the list is empty", () => {
+    mockUseProfiles.mockReturnValue(
+      makeUseProfilesResult({
+        data: {
+          data: [],
+          pagination: {
+            page: 1,
+            page_size: 25,
+            total_items: 0,
+            total_pages: 0,
+          },
+        },
+      }),
+    );
+    render(<ProfilesPage />);
+    expect(screen.getByText("No profiles found.")).toBeInTheDocument();
+  });
+});
+
+// ── Table structure ───────────────────────────────────────────────────────────
+
+describe("ProfilesPage — table structure", () => {
+  it("renders all column headers", () => {
+    render(<ProfilesPage />);
+    expect(
+      screen.getByRole("columnheader", { name: "Name" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Scan Type" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Ports" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Description" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Updated" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders one data row per profile", () => {
+    render(<ProfilesPage />);
+    const rows = screen.getAllByRole("row");
+    expect(rows).toHaveLength(4);
+  });
+});
+
+// ── Row data ──────────────────────────────────────────────────────────────────
+
+describe("ProfilesPage — row data", () => {
+  it("renders profile names", () => {
+    render(<ProfilesPage />);
+    expect(screen.getByText("Quick scan")).toBeInTheDocument();
+    expect(screen.getByText("Full scan")).toBeInTheDocument();
+    expect(screen.getByText("UDP check")).toBeInTheDocument();
+  });
+
+  it("renders short scan type labels", () => {
+    render(<ProfilesPage />);
+    expect(screen.getAllByText("Connect").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("SYN")).toBeInTheDocument();
+    expect(screen.getByText("UDP")).toBeInTheDocument();
+  });
+
+  it("renders ports values", () => {
+    render(<ProfilesPage />);
+    expect(screen.getByText("22,80,443")).toBeInTheDocument();
+    expect(screen.getByText("1-65535")).toBeInTheDocument();
+  });
+
+  it("shows em-dash for missing ports", () => {
+    render(<ProfilesPage />);
+    const rows = screen.getAllByRole("row");
+    const cells = within(rows[3]).getAllByRole("cell");
+    expect(cells[2]).toHaveTextContent("\u2014");
+  });
+
+  it("shows relative time for updated_at when present", () => {
+    render(<ProfilesPage />);
+    const rows = screen.getAllByRole("row");
+    const cells = within(rows[1]).getAllByRole("cell");
+    expect(cells[4].textContent).toMatch(/ago|just now/i);
+  });
+
+  it("shows em-dash for missing updated_at", () => {
+    render(<ProfilesPage />);
+    const rows = screen.getAllByRole("row");
+    const cells = within(rows[3]).getAllByRole("cell");
+    expect(cells[4]).toHaveTextContent("\u2014");
+  });
+});
+
+// ── Pagination ────────────────────────────────────────────────────────────────
+
+describe("ProfilesPage — pagination", () => {
+  it("shows pagination when there are multiple pages", () => {
+    mockUseProfiles.mockReturnValue(
+      makeUseProfilesResult({
+        data: {
+          data: mockProfiles,
+          pagination: {
+            page: 1,
+            page_size: 25,
+            total_items: 60,
+            total_pages: 3,
+          },
+        },
+      }),
+    );
+    render(<ProfilesPage />);
+    expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+  });
+
+  it("does not show pagination when there is only one page", () => {
+    render(<ProfilesPage />);
+    expect(screen.queryByText(/Page \d+ of \d+/)).not.toBeInTheDocument();
+  });
+
+  it("does not show pagination when the list is empty", () => {
+    mockUseProfiles.mockReturnValue(
+      makeUseProfilesResult({
+        data: {
+          data: [],
+          pagination: {
+            page: 1,
+            page_size: 25,
+            total_items: 0,
+            total_pages: 0,
+          },
+        },
+      }),
+    );
+    render(<ProfilesPage />);
+    expect(screen.queryByText(/Page \d+ of \d+/)).not.toBeInTheDocument();
+  });
+});
+
+// ── Detail panel ──────────────────────────────────────────────────────────────
+
+describe("ProfilesPage — detail panel", () => {
+  it("opens the detail panel when a row is clicked", async () => {
+    render(<ProfilesPage />);
+    const row = screen.getByText("Quick scan").closest("tr")!;
+    await userEvent.click(row);
+    expect(
+      screen.getByRole("dialog", { name: /profile details/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the profile name in the panel", async () => {
+    render(<ProfilesPage />);
+    await userEvent.click(screen.getByText("Quick scan").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /profile details/i });
+    expect(within(panel).getByText("Quick scan")).toBeInTheDocument();
+  });
+
+  it("closes the detail panel when the close button is clicked", async () => {
+    render(<ProfilesPage />);
+    await userEvent.click(screen.getByText("Quick scan").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /profile details/i });
+    const closeBtn = within(panel).getByRole("button", {
+      name: /close panel/i,
+    });
+    await userEvent.click(closeBtn);
+    expect(
+      screen.queryByRole("dialog", { name: /profile details/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Edit button in the detail panel", async () => {
+    render(<ProfilesPage />);
+    await userEvent.click(screen.getByText("Quick scan").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /profile details/i });
+    expect(
+      within(panel).getByRole("button", { name: /edit/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens ProfileFormModal when Edit is clicked", async () => {
+    render(<ProfilesPage />);
+    await userEvent.click(screen.getByText("Quick scan").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /profile details/i });
+    await userEvent.click(
+      within(panel).getByRole("button", { name: /edit/i }),
+    );
+    expect(
+      screen.getByRole("dialog", { name: /profile form/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows Delete button then confirm prompt on click", async () => {
+    render(<ProfilesPage />);
+    await userEvent.click(screen.getByText("Quick scan").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /profile details/i });
+    const deleteBtn = within(panel).getByRole("button", { name: /^delete$/i });
+    await userEvent.click(deleteBtn);
+    expect(
+      within(panel).getByText("Delete this profile?"),
+    ).toBeInTheDocument();
+  });
+});
+
+// ── Add modal ─────────────────────────────────────────────────────────────────
+
+describe("ProfilesPage — add modal", () => {
+  it("opens ProfileFormModal when Create Profile is clicked", async () => {
+    render(<ProfilesPage />);
+    await userEvent.click(
+      screen.getByRole("button", { name: /create profile/i }),
+    );
+    expect(
+      screen.getByRole("dialog", { name: /profile form/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes ProfileFormModal when its onClose fires", async () => {
+    render(<ProfilesPage />);
+    await userEvent.click(
+      screen.getByRole("button", { name: /create profile/i }),
+    );
+    const modal = screen.getByRole("dialog", { name: /profile form/i });
+    await userEvent.click(
+      within(modal).getByRole("button", { name: /close profile form/i }),
+    );
+    expect(
+      screen.queryByRole("dialog", { name: /profile form/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/routes/profiles.tsx
+++ b/frontend/src/routes/profiles.tsx
@@ -1,5 +1,442 @@
-import { PlaceholderPage } from "../components/placeholder-page";
+import { useState, useCallback } from "react";
+import { Plus, Pencil, Trash2, X, SlidersHorizontal } from "lucide-react";
+import { Button } from "../components/button";
+import { useProfiles, useDeleteProfile } from "../api/hooks/use-profiles";
+import { Skeleton, PaginationBar } from "../components";
+import { ProfileFormModal } from "../components/profile-form-modal";
+import { formatRelativeTime, formatAbsoluteTime, cn } from "../lib/utils";
+import type { components } from "../api/types";
+
+type ProfileResponse = components["schemas"]["docs.ProfileResponse"];
+
+const PAGE_SIZE = 25;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const SCAN_TYPE_LABELS: Record<string, string> = {
+  connect: "Connect (-sT)",
+  syn: "SYN stealth (-sS)",
+  ack: "ACK (-sA)",
+  udp: "UDP (-sU)",
+  aggressive: "Aggressive (-sS -sV -A)",
+  comprehensive: "Comprehensive (-sS -sV --script=default)",
+};
+
+const SCAN_TYPE_SHORT_LABELS: Record<string, string> = {
+  connect: "Connect",
+  syn: "SYN",
+  ack: "ACK",
+  udp: "UDP",
+  aggressive: "Aggressive",
+  comprehensive: "Comprehensive",
+};
+
+// ── Skeleton rows ─────────────────────────────────────────────────────────────
+
+function SkeletonRows() {
+  return (
+    <>
+      {Array.from({ length: 6 }).map((_, i) => (
+        <tr key={i} className="border-b border-border">
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-32" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-20" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-28 font-mono" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-40" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-16" />
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+// ── Meta row helper ───────────────────────────────────────────────────────────
+
+function MetaRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex gap-2 text-xs">
+      <span className="text-text-muted w-32 shrink-0">{label}</span>
+      <span className="text-text-secondary break-all">{value ?? "—"}</span>
+    </div>
+  );
+}
+
+// ── Profile detail panel ──────────────────────────────────────────────────────
+
+interface ProfileDetailPanelProps {
+  profile: ProfileResponse;
+  onClose: () => void;
+}
+
+function ProfileDetailPanel({
+  profile: initialProfile,
+  onClose,
+}: ProfileDetailPanelProps) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [showEditModal, setShowEditModal] = useState(false);
+
+  const { mutateAsync: deleteProfile, isPending: isDeleting } =
+    useDeleteProfile();
+
+  const p = initialProfile;
+
+  async function handleDelete() {
+    setActionError(null);
+    try {
+      await deleteProfile(p.id ?? "");
+      onClose();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Delete failed.");
+      setShowDeleteConfirm(false);
+    }
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/40 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div
+        role="dialog"
+        aria-label="Profile details"
+        className={cn(
+          "fixed top-0 right-0 bottom-0 z-50",
+          "w-full max-w-110",
+          "bg-surface border-l border-border",
+          "flex flex-col overflow-hidden",
+          "shadow-xl",
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 px-5 py-4 border-b border-border shrink-0">
+          <div className="flex flex-col gap-1.5 min-w-0">
+            <p className="text-xs text-text-muted">Profile</p>
+            <p className="text-sm font-medium text-text-primary truncate">
+              {p.name ?? "—"}
+            </p>
+            {p.scan_type && (
+              <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium bg-accent/15 text-accent w-fit">
+                {SCAN_TYPE_SHORT_LABELS[p.scan_type] ?? p.scan_type}
+              </span>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close panel"
+            className="shrink-0 p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Action bar */}
+        <div className="flex items-center gap-2 px-5 py-3 border-b border-border shrink-0 flex-wrap">
+          <Button
+            variant="secondary"
+            onClick={() => setShowEditModal(true)}
+            className="text-xs h-7 px-3"
+          >
+            <Pencil className="h-3 w-3 mr-1" />
+            Edit
+          </Button>
+
+          {showDeleteConfirm ? (
+            <div className="flex items-center gap-2 ml-auto">
+              <span className="text-xs text-text-muted">
+                Delete this profile?
+              </span>
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(false)}
+                className="text-xs text-text-muted hover:text-text-secondary"
+              >
+                Cancel
+              </button>
+              <Button
+                variant="danger"
+                onClick={() => void handleDelete()}
+                loading={isDeleting}
+                className="text-xs h-7 px-3"
+              >
+                Delete
+              </Button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowDeleteConfirm(true)}
+              className="ml-auto flex items-center gap-1 text-xs text-text-muted hover:text-danger transition-colors"
+            >
+              <Trash2 className="h-3 w-3" />
+              Delete
+            </button>
+          )}
+
+          {actionError && (
+            <p className="w-full text-[11px] text-danger mt-0.5">
+              {actionError}
+            </p>
+          )}
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-6">
+          {/* Configuration */}
+          <section>
+            <h3 className="text-xs font-medium text-text-primary mb-3 flex items-center gap-1.5">
+              <SlidersHorizontal className="h-3.5 w-3.5 text-text-muted" />
+              Configuration
+            </h3>
+            <div className="space-y-2">
+              <MetaRow
+                label="Scan type"
+                value={
+                  p.scan_type
+                    ? (SCAN_TYPE_LABELS[p.scan_type] ?? p.scan_type)
+                    : undefined
+                }
+              />
+              <MetaRow
+                label="Ports"
+                value={
+                  p.ports ? (
+                    <span className="font-mono">{p.ports}</span>
+                  ) : undefined
+                }
+              />
+              <MetaRow label="Description" value={p.description} />
+              <MetaRow label="ID" value={p.id} />
+            </div>
+          </section>
+
+          {/* Timestamps */}
+          <section>
+            <h3 className="text-xs font-medium text-text-primary mb-3">
+              Timestamps
+            </h3>
+            <div className="space-y-2">
+              <MetaRow
+                label="Created at"
+                value={
+                  p.created_at ? formatAbsoluteTime(p.created_at) : undefined
+                }
+              />
+              <MetaRow
+                label="Updated at"
+                value={
+                  p.updated_at ? formatAbsoluteTime(p.updated_at) : undefined
+                }
+              />
+            </div>
+          </section>
+        </div>
+      </div>
+
+      {/* Edit modal — rendered outside the panel div so z-index stacking works */}
+      {showEditModal && (
+        <ProfileFormModal
+          mode="edit"
+          initial={{
+            id: p.id,
+            name: p.name,
+            description: p.description,
+            scan_type: p.scan_type,
+            ports: p.ports,
+          }}
+          onClose={() => setShowEditModal(false)}
+          onSaved={() => setShowEditModal(false)}
+        />
+      )}
+    </>
+  );
+}
+
+// ── Profiles page ─────────────────────────────────────────────────────────────
 
 export function ProfilesPage() {
-  return <PlaceholderPage message="Scan profiles coming soon." />;
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [selectedProfile, setSelectedProfile] =
+    useState<ProfileResponse | null>(null);
+  const [showCreateModal, setShowCreateModal] = useState(false);
+
+  // Debounce name search
+  const debounceRef = { current: 0 as ReturnType<typeof setTimeout> };
+  const handleSearchInput = useCallback(
+    (value: string) => {
+      setSearch(value);
+      clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        setDebouncedSearch(value);
+        setPage(1);
+      }, 300);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const { data, isLoading } = useProfiles({ page, page_size: PAGE_SIZE });
+
+  const allProfiles = data?.data ?? [];
+  const pagination = data?.pagination;
+  const totalPages = pagination?.total_pages ?? 1;
+
+  // Client-side name filter — the API doesn't expose a search query param
+  const profiles = debouncedSearch.trim()
+    ? allProfiles.filter((p) =>
+        (p.name ?? "")
+          .toLowerCase()
+          .includes(debouncedSearch.trim().toLowerCase()),
+      )
+    : allProfiles;
+
+  return (
+    <div className="flex flex-col gap-4 h-full">
+      {/* Toolbar */}
+      <div className="flex items-center gap-3 flex-wrap">
+        {/* Search */}
+        <div className="relative flex-1 min-w-48 max-w-64">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => handleSearchInput(e.target.value)}
+            placeholder="Search by name…"
+            aria-label="Search by name…"
+            className={cn(
+              "w-full pl-3 pr-3 py-1.5 text-xs rounded border border-border",
+              "bg-surface text-text-primary placeholder:text-text-muted",
+              "focus:outline-none focus:ring-1 focus:ring-border",
+            )}
+          />
+        </div>
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Create profile */}
+        <Button
+          onClick={() => setShowCreateModal(true)}
+          className="text-xs h-7 px-3"
+        >
+          <Plus className="h-3 w-3 mr-1" />
+          Create Profile
+        </Button>
+      </div>
+
+      {/* Table */}
+      <div className="flex-1 overflow-auto rounded border border-border">
+        <table className="w-full text-xs border-collapse min-w-[640px]">
+          <thead>
+            <tr className="bg-surface-raised border-b border-border text-left">
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Name
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Scan Type
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Ports
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Description
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Updated
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <SkeletonRows />
+            ) : profiles.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="px-4 py-10 text-center text-text-muted"
+                >
+                  No profiles found.
+                </td>
+              </tr>
+            ) : (
+              profiles.map((profile) => (
+                <tr
+                  key={profile.id}
+                  onClick={() => setSelectedProfile(profile)}
+                  className={cn(
+                    "border-b border-border cursor-pointer transition-colors",
+                    "hover:bg-surface-raised",
+                    selectedProfile?.id === profile.id && "bg-accent/8",
+                  )}
+                >
+                  <td className="px-4 py-2.5 text-text-primary font-medium truncate max-w-[180px]">
+                    {profile.name ?? "—"}
+                  </td>
+                  <td className="px-4 py-2.5 text-text-secondary">
+                    {profile.scan_type
+                      ? (SCAN_TYPE_SHORT_LABELS[profile.scan_type] ??
+                        profile.scan_type)
+                      : "—"}
+                  </td>
+                  <td className="px-4 py-2.5 font-mono text-text-secondary whitespace-nowrap">
+                    {profile.ports ?? "—"}
+                  </td>
+                  <td className="px-4 py-2.5 text-text-secondary truncate max-w-[200px]">
+                    {profile.description ?? "—"}
+                  </td>
+                  <td className="px-4 py-2.5 text-text-muted whitespace-nowrap">
+                    {profile.updated_at
+                      ? formatRelativeTime(profile.updated_at)
+                      : "—"}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {!isLoading && profiles.length > 0 && totalPages > 1 && (
+        <PaginationBar
+          page={page}
+          totalPages={totalPages}
+          onPrev={() => setPage((p) => Math.max(1, p - 1))}
+          onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
+        />
+      )}
+
+      {/* Profile detail panel */}
+      {selectedProfile && (
+        <ProfileDetailPanel
+          profile={selectedProfile}
+          onClose={() => setSelectedProfile(null)}
+        />
+      )}
+
+      {/* Create modal */}
+      {showCreateModal && (
+        <ProfileFormModal
+          mode="create"
+          onClose={() => setShowCreateModal(false)}
+        />
+      )}
+    </div>
+  );
 }

--- a/frontend/src/routes/schedules.test.tsx
+++ b/frontend/src/routes/schedules.test.tsx
@@ -1,0 +1,422 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SchedulesPage } from "./schedules";
+
+// ── Mock hooks ────────────────────────────────────────────────────────────────
+
+vi.mock("../api/hooks/use-schedules", () => ({
+  useSchedules: vi.fn(),
+  useEnableSchedule: vi.fn(),
+  useDisableSchedule: vi.fn(),
+  useDeleteSchedule: vi.fn(),
+}));
+
+vi.mock("../components/create-schedule-modal", () => ({
+  CreateScheduleModal: ({
+    onClose,
+  }: {
+    onClose: () => void;
+    onCreated?: () => void;
+  }) => (
+    <div role="dialog" aria-label="Create Schedule">
+      <button type="button" onClick={onClose}>
+        Close modal
+      </button>
+    </div>
+  ),
+}));
+
+import {
+  useSchedules,
+  useEnableSchedule,
+  useDisableSchedule,
+  useDeleteSchedule,
+} from "../api/hooks/use-schedules";
+
+const mockUseSchedules = vi.mocked(useSchedules);
+const mockUseEnableSchedule = vi.mocked(useEnableSchedule);
+const mockUseDisableSchedule = vi.mocked(useDisableSchedule);
+const mockUseDeleteSchedule = vi.mocked(useDeleteSchedule);
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const mockSchedules = [
+  {
+    id: "sched-1",
+    name: "Daily Scan",
+    cron_expression: "0 2 * * *",
+    enabled: true,
+    targets: ["192.168.1.0/24", "10.0.0.0/8"],
+    next_run: new Date(Date.now() + 3_600_000).toISOString(),
+    last_run: new Date(Date.now() - 3_600_000).toISOString(),
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+    profile_id: "profile-1",
+  },
+  {
+    id: "sched-2",
+    name: "Weekly Recon",
+    cron_expression: "0 0 * * 1",
+    enabled: false,
+    targets: ["172.16.0.0/16"],
+    next_run: undefined,
+    last_run: undefined,
+    created_at: "2024-02-01T00:00:00Z",
+    updated_at: "2024-06-02T00:00:00Z",
+    profile_id: undefined,
+  },
+  {
+    id: "sched-3",
+    name: "Hourly Check",
+    cron_expression: "0 * * * *",
+    enabled: true,
+    targets: [],
+    next_run: undefined,
+    last_run: undefined,
+    created_at: "2024-03-01T00:00:00Z",
+    updated_at: undefined,
+    profile_id: undefined,
+  },
+];
+
+const mockPagination = {
+  page: 1,
+  page_size: 25,
+  total_items: 3,
+  total_pages: 1,
+};
+
+const idleMutation = {
+  mutateAsync: vi.fn(),
+  mutate: vi.fn(),
+  isPending: false,
+  isSuccess: false,
+  isError: false,
+};
+
+function makeUseSchedulesResult(overrides = {}) {
+  return {
+    data: {
+      data: mockSchedules,
+      pagination: mockPagination,
+    },
+    isLoading: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useSchedules>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseSchedules.mockReturnValue(makeUseSchedulesResult());
+  mockUseEnableSchedule.mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useEnableSchedule>,
+  );
+  mockUseDisableSchedule.mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useDisableSchedule>,
+  );
+  mockUseDeleteSchedule.mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useDeleteSchedule>,
+  );
+});
+
+// ── Toolbar ───────────────────────────────────────────────────────────────────
+
+describe("SchedulesPage — toolbar", () => {
+  it("renders status filter select", () => {
+    render(<SchedulesPage />);
+    expect(
+      screen.getByRole("combobox", { name: /filter by status/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("status filter has All, Enabled, Disabled options", () => {
+    render(<SchedulesPage />);
+    const select = screen.getByRole("combobox", { name: /filter by status/i });
+    expect(within(select).getByText("All")).toBeInTheDocument();
+    expect(within(select).getByText("Enabled")).toBeInTheDocument();
+    expect(within(select).getByText("Disabled")).toBeInTheDocument();
+  });
+
+  it("renders Create schedule button", () => {
+    render(<SchedulesPage />);
+    expect(
+      screen.getByRole("button", { name: /create schedule/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+// ── Loading ───────────────────────────────────────────────────────────────────
+
+describe("SchedulesPage — loading", () => {
+  it("renders skeleton rows when loading", () => {
+    mockUseSchedules.mockReturnValue(
+      makeUseSchedulesResult({ isLoading: true, data: undefined }),
+    );
+    const { container } = render(<SchedulesPage />);
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("does not show 'No schedules found.' while loading", () => {
+    mockUseSchedules.mockReturnValue(
+      makeUseSchedulesResult({ isLoading: true, data: undefined }),
+    );
+    render(<SchedulesPage />);
+    expect(screen.queryByText("No schedules found.")).not.toBeInTheDocument();
+  });
+});
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+describe("SchedulesPage — empty state", () => {
+  it("shows 'No schedules found.' when the list is empty", () => {
+    mockUseSchedules.mockReturnValue(
+      makeUseSchedulesResult({
+        data: {
+          data: [],
+          pagination: {
+            page: 1,
+            page_size: 25,
+            total_items: 0,
+            total_pages: 0,
+          },
+        },
+      }),
+    );
+    render(<SchedulesPage />);
+    expect(screen.getByText("No schedules found.")).toBeInTheDocument();
+  });
+});
+
+// ── Table structure ───────────────────────────────────────────────────────────
+
+describe("SchedulesPage — table structure", () => {
+  it("renders all column headers", () => {
+    render(<SchedulesPage />);
+    expect(
+      screen.getByRole("columnheader", { name: "Name" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Cron" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Next Run" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Last Run" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Status" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Targets" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders one data row per schedule", () => {
+    render(<SchedulesPage />);
+    const rows = screen.getAllByRole("row");
+    // 1 header + 3 data rows
+    expect(rows.length).toBe(4);
+  });
+});
+
+// ── Row data ──────────────────────────────────────────────────────────────────
+
+describe("SchedulesPage — row data", () => {
+  it("renders schedule names", () => {
+    render(<SchedulesPage />);
+    expect(screen.getByText("Daily Scan")).toBeInTheDocument();
+    expect(screen.getByText("Weekly Recon")).toBeInTheDocument();
+    expect(screen.getByText("Hourly Check")).toBeInTheDocument();
+  });
+
+  it("renders describeCron output for cron expressions", () => {
+    render(<SchedulesPage />);
+    // "0 2 * * *" => "Every day at 02:00"
+    expect(screen.getByText("Every day at 02:00")).toBeInTheDocument();
+    // "0 0 * * 1" => "Every Monday at 00:00"
+    expect(screen.getByText("Every Monday at 00:00")).toBeInTheDocument();
+  });
+
+  it("renders 'enabled' badge for enabled schedules", () => {
+    render(<SchedulesPage />);
+    const badges = screen.getAllByText("enabled");
+    expect(badges.length).toBeGreaterThan(0);
+  });
+
+  it("renders 'disabled' badge for disabled schedules", () => {
+    render(<SchedulesPage />);
+    expect(screen.getByText("disabled")).toBeInTheDocument();
+  });
+
+  it("shows first target + count for schedules with multiple targets", () => {
+    render(<SchedulesPage />);
+    expect(screen.getByText("192.168.1.0/24 +1 more")).toBeInTheDocument();
+  });
+
+  it("shows single target for schedules with one target", () => {
+    render(<SchedulesPage />);
+    expect(screen.getByText("172.16.0.0/16")).toBeInTheDocument();
+  });
+
+  it("shows em-dash for schedules with no targets", () => {
+    render(<SchedulesPage />);
+    // "Hourly Check" has no targets — should show em-dash in targets column
+    const rows = screen.getAllByRole("row");
+    const hourlyRow = rows.find((r) => within(r).queryByText("Hourly Check"));
+    expect(hourlyRow).toBeTruthy();
+    // The targets cell should contain an em-dash
+    const cells = within(hourlyRow!).getAllByRole("cell");
+    // Targets is the last column (index 5)
+    expect(cells[5].textContent).toBe("—");
+  });
+
+  it("shows em-dash for missing next_run and last_run", () => {
+    render(<SchedulesPage />);
+    const rows = screen.getAllByRole("row");
+    const weeklyRow = rows.find((r) => within(r).queryByText("Weekly Recon"));
+    expect(weeklyRow).toBeTruthy();
+    const cells = within(weeklyRow!).getAllByRole("cell");
+    // Next Run is index 2, Last Run is index 3
+    expect(cells[2].textContent).toBe("—");
+    expect(cells[3].textContent).toBe("—");
+  });
+});
+
+// ── Filter ────────────────────────────────────────────────────────────────────
+
+describe("SchedulesPage — filter", () => {
+  it("selecting 'enabled' passes enabled: true to useSchedules", async () => {
+    const user = userEvent.setup();
+    render(<SchedulesPage />);
+    const select = screen.getByRole("combobox", { name: /filter by status/i });
+    await user.selectOptions(select, "enabled");
+    const lastCall = mockUseSchedules.mock.lastCall?.[0];
+    expect(lastCall).toMatchObject({ enabled: true });
+  });
+
+  it("selecting 'disabled' passes enabled: false to useSchedules", async () => {
+    const user = userEvent.setup();
+    render(<SchedulesPage />);
+    const select = screen.getByRole("combobox", { name: /filter by status/i });
+    await user.selectOptions(select, "disabled");
+    const lastCall = mockUseSchedules.mock.lastCall?.[0];
+    expect(lastCall).toMatchObject({ enabled: false });
+  });
+
+  it("selecting 'all' does not include enabled in params", async () => {
+    const user = userEvent.setup();
+    render(<SchedulesPage />);
+    const select = screen.getByRole("combobox", { name: /filter by status/i });
+    // Switch to enabled then back to all
+    await user.selectOptions(select, "enabled");
+    await user.selectOptions(select, "all");
+    const lastCall = mockUseSchedules.mock.lastCall?.[0];
+    expect(lastCall).not.toHaveProperty("enabled");
+  });
+});
+
+// ── Detail panel ──────────────────────────────────────────────────────────────
+
+describe("SchedulesPage — detail panel", () => {
+  it("opens the detail panel when a row is clicked", async () => {
+    render(<SchedulesPage />);
+    const row = screen.getByText("Daily Scan").closest("tr")!;
+    await userEvent.click(row);
+    expect(
+      screen.getByRole("dialog", { name: /schedule details/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the schedule name in the detail panel", async () => {
+    render(<SchedulesPage />);
+    await userEvent.click(screen.getByText("Daily Scan").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /schedule details/i });
+    expect(within(panel).getByText("Daily Scan")).toBeInTheDocument();
+  });
+
+  it("shows the close button in the detail panel", async () => {
+    render(<SchedulesPage />);
+    await userEvent.click(screen.getByText("Daily Scan").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /schedule details/i });
+    expect(
+      within(panel).getByRole("button", { name: /close panel/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes the detail panel when the close button is clicked", async () => {
+    render(<SchedulesPage />);
+    await userEvent.click(screen.getByText("Daily Scan").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /schedule details/i });
+    await userEvent.click(
+      within(panel).getByRole("button", { name: /close panel/i }),
+    );
+    expect(
+      screen.queryByRole("dialog", { name: /schedule details/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Disable button for enabled schedule", async () => {
+    render(<SchedulesPage />);
+    await userEvent.click(screen.getByText("Daily Scan").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /schedule details/i });
+    expect(
+      within(panel).getByRole("button", { name: /^disable$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows Enable button for disabled schedule", async () => {
+    render(<SchedulesPage />);
+    await userEvent.click(screen.getByText("Weekly Recon").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /schedule details/i });
+    expect(
+      within(panel).getByRole("button", { name: /^enable$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows Delete button in the detail panel", async () => {
+    render(<SchedulesPage />);
+    await userEvent.click(screen.getByText("Daily Scan").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /schedule details/i });
+    expect(
+      within(panel).getByRole("button", { name: /^delete$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows delete confirm prompt after clicking Delete", async () => {
+    render(<SchedulesPage />);
+    await userEvent.click(screen.getByText("Daily Scan").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /schedule details/i });
+    const deleteBtn = within(panel).getByRole("button", { name: /^delete$/i });
+    await userEvent.click(deleteBtn);
+    expect(within(panel).getByText(/confirm delete/i)).toBeInTheDocument();
+  });
+});
+
+// ── Add modal ─────────────────────────────────────────────────────────────────
+
+describe("SchedulesPage — add modal", () => {
+  it("opens CreateScheduleModal when Create schedule is clicked", async () => {
+    render(<SchedulesPage />);
+    await userEvent.click(
+      screen.getByRole("button", { name: /create schedule/i }),
+    );
+    expect(
+      screen.getByRole("dialog", { name: /create schedule/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes CreateScheduleModal when its close button is clicked", async () => {
+    render(<SchedulesPage />);
+    await userEvent.click(
+      screen.getByRole("button", { name: /create schedule/i }),
+    );
+    const modal = screen.getByRole("dialog", { name: /create schedule/i });
+    await userEvent.click(within(modal).getByRole("button", { name: /close modal/i }));
+    expect(
+      screen.queryByRole("dialog", { name: /create schedule/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/routes/schedules.tsx
+++ b/frontend/src/routes/schedules.tsx
@@ -1,5 +1,487 @@
-import { PlaceholderPage } from "../components/placeholder-page";
+import { useState } from "react";
+import { Plus, X } from "lucide-react";
+import { Button } from "../components/button";
+import {
+  useSchedules,
+  useEnableSchedule,
+  useDisableSchedule,
+  useDeleteSchedule,
+} from "../api/hooks/use-schedules";
+import { Skeleton, PaginationBar } from "../components";
+import { CreateScheduleModal } from "../components/create-schedule-modal";
+import { formatRelativeTime, formatAbsoluteTime, cn, describeCron } from "../lib/utils";
+import type { components } from "../api/types";
+
+type ScheduleResponse = components["schemas"]["docs.ScheduleResponse"];
+
+const PAGE_SIZE = 25;
+
+type StatusFilter = "all" | "enabled" | "disabled";
+
+// ── Badge ─────────────────────────────────────────────────────────────────────
+
+function ScheduleEnabledBadge({ enabled }: { enabled: boolean }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] font-medium",
+        enabled
+          ? "bg-success/15 text-success"
+          : "bg-text-muted/15 text-text-muted",
+      )}
+    >
+      {enabled ? "enabled" : "disabled"}
+    </span>
+  );
+}
+
+// ── Skeleton rows ─────────────────────────────────────────────────────────────
+
+function SkeletonRows() {
+  return (
+    <>
+      {Array.from({ length: 6 }).map((_, i) => (
+        <tr key={i} className="border-b border-border">
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-32" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-40" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-20" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-20" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-5 w-16 rounded" />
+          </td>
+          <td className="px-4 py-2.5">
+            <Skeleton className="h-3 w-28" />
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+// ── Meta row helper ───────────────────────────────────────────────────────────
+
+function MetaRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex gap-2 text-xs">
+      <span className="text-text-muted w-32 shrink-0">{label}</span>
+      <span className="text-text-secondary break-all">{value ?? "—"}</span>
+    </div>
+  );
+}
+
+// ── Detail panel ──────────────────────────────────────────────────────────────
+
+interface ScheduleDetailPanelProps {
+  schedule: ScheduleResponse;
+  onClose: () => void;
+}
+
+function ScheduleDetailPanel({
+  schedule: s,
+  onClose,
+}: ScheduleDetailPanelProps) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const { mutateAsync: enableSchedule, isPending: isEnabling } =
+    useEnableSchedule();
+  const { mutateAsync: disableSchedule, isPending: isDisabling } =
+    useDisableSchedule();
+  const { mutateAsync: deleteSchedule, isPending: isDeleting } =
+    useDeleteSchedule();
+
+  const isToggling = isEnabling || isDisabling;
+  const targetList = s.targets ?? [];
+
+  async function handleToggleEnabled() {
+    setActionError(null);
+    try {
+      if (s.enabled) {
+        await disableSchedule(s.id ?? "");
+      } else {
+        await enableSchedule(s.id ?? "");
+      }
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Action failed.");
+    }
+  }
+
+  async function handleDelete() {
+    setActionError(null);
+    try {
+      await deleteSchedule(s.id ?? "");
+      onClose();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Delete failed.");
+      setShowDeleteConfirm(false);
+    }
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/40 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div
+        role="dialog"
+        aria-label="Schedule details"
+        className={cn(
+          "fixed top-0 right-0 bottom-0 z-50",
+          "w-full max-w-110",
+          "bg-surface border-l border-border",
+          "flex flex-col overflow-hidden",
+          "shadow-xl",
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 px-5 py-4 border-b border-border shrink-0">
+          <div className="flex flex-col gap-1.5 min-w-0">
+            <p className="text-xs text-text-muted">Schedule</p>
+            <div className="flex items-center gap-2 min-w-0">
+              <h2 className="text-sm font-semibold text-text-primary truncate">
+                {s.name ?? "—"}
+              </h2>
+              <ScheduleEnabledBadge enabled={s.enabled ?? false} />
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close panel"
+            className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors shrink-0 mt-0.5"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Action bar */}
+        <div className="flex items-center gap-2 px-5 py-3 border-b border-border shrink-0">
+          <Button
+            variant="secondary"
+            onClick={() => void handleToggleEnabled()}
+            loading={isToggling}
+            className="text-xs h-7 px-3"
+          >
+            {s.enabled ? "Disable" : "Enable"}
+          </Button>
+
+          {!showDeleteConfirm ? (
+            <Button
+              variant="danger"
+              onClick={() => setShowDeleteConfirm(true)}
+              className="text-xs h-7 px-3"
+            >
+              Delete
+            </Button>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-text-muted">Confirm delete?</span>
+              <Button
+                variant="danger"
+                onClick={() => void handleDelete()}
+                loading={isDeleting}
+                className="text-xs h-7 px-3"
+              >
+                Yes, delete
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={() => setShowDeleteConfirm(false)}
+                className="text-xs h-7 px-3"
+              >
+                Cancel
+              </Button>
+            </div>
+          )}
+        </div>
+
+        {/* Inline error */}
+        {actionError && (
+          <div className="px-5 py-2 shrink-0">
+            <p role="alert" className="text-xs text-danger">
+              {actionError}
+            </p>
+          </div>
+        )}
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-5">
+          {/* Cron */}
+          <section className="space-y-2">
+            <h3 className="text-xs font-semibold text-text-primary uppercase tracking-wide">
+              Cron
+            </h3>
+            <MetaRow
+              label="Expression"
+              value={
+                s.cron_expression ? (
+                  <span title={s.cron_expression} className="font-mono">
+                    {describeCron(s.cron_expression)}
+                  </span>
+                ) : (
+                  "—"
+                )
+              }
+            />
+            <MetaRow
+              label="Raw"
+              value={
+                s.cron_expression ? (
+                  <span className="font-mono">{s.cron_expression}</span>
+                ) : (
+                  "—"
+                )
+              }
+            />
+          </section>
+
+          {/* Schedule timings */}
+          <section className="space-y-2">
+            <h3 className="text-xs font-semibold text-text-primary uppercase tracking-wide">
+              Schedule
+            </h3>
+            <MetaRow
+              label="Next run"
+              value={s.next_run ? formatRelativeTime(s.next_run) : "—"}
+            />
+            <MetaRow
+              label="Last run"
+              value={s.last_run ? formatRelativeTime(s.last_run) : "—"}
+            />
+          </section>
+
+          {/* Targets */}
+          <section className="space-y-2">
+            <h3 className="text-xs font-semibold text-text-primary uppercase tracking-wide">
+              Targets
+            </h3>
+            {targetList.length === 0 ? (
+              <MetaRow label="Targets" value="—" />
+            ) : (
+              <div className="text-xs text-text-secondary font-mono space-y-1">
+                {targetList.map((t, i) => (
+                  <div key={i}>{t}</div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          {/* Profile */}
+          <section className="space-y-2">
+            <h3 className="text-xs font-semibold text-text-primary uppercase tracking-wide">
+              Profile
+            </h3>
+            <MetaRow label="Profile ID" value={s.profile_id ?? "None"} />
+          </section>
+
+          {/* Timestamps */}
+          <section className="space-y-2">
+            <h3 className="text-xs font-semibold text-text-primary uppercase tracking-wide">
+              Timestamps
+            </h3>
+            <MetaRow
+              label="Created"
+              value={s.created_at ? formatAbsoluteTime(s.created_at) : "—"}
+            />
+            <MetaRow
+              label="Updated"
+              value={s.updated_at ? formatAbsoluteTime(s.updated_at) : "—"}
+            />
+          </section>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Schedules page ────────────────────────────────────────────────────────────
 
 export function SchedulesPage() {
-  return <PlaceholderPage message="Schedule management coming soon." />;
+  const [page, setPage] = useState(1);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [selectedSchedule, setSelectedSchedule] =
+    useState<ScheduleResponse | null>(null);
+  const [showCreateModal, setShowCreateModal] = useState(false);
+
+  const queryParams = {
+    page,
+    page_size: PAGE_SIZE,
+    ...(statusFilter === "enabled" ? { enabled: true } : {}),
+    ...(statusFilter === "disabled" ? { enabled: false } : {}),
+  };
+
+  const { data, isLoading } = useSchedules(queryParams);
+
+  const schedules = data?.data ?? [];
+  const pagination = data?.pagination;
+  const totalPages = pagination?.total_pages ?? 1;
+
+  function handleStatusFilterChange(value: string) {
+    setStatusFilter(value as StatusFilter);
+    setPage(1);
+  }
+
+  return (
+    <div className="flex flex-col gap-4 h-full">
+      {/* Toolbar */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <select
+          value={statusFilter}
+          onChange={(e) => handleStatusFilterChange(e.target.value)}
+          aria-label="Filter by status"
+          className={cn(
+            "px-3 py-1.5 text-xs rounded border border-border",
+            "bg-surface text-text-primary",
+            "focus:outline-none focus:ring-1 focus:ring-border",
+          )}
+        >
+          <option value="all">All</option>
+          <option value="enabled">Enabled</option>
+          <option value="disabled">Disabled</option>
+        </select>
+
+        <div className="flex-1" />
+
+        <Button
+          onClick={() => setShowCreateModal(true)}
+          className="text-xs h-7 px-3"
+        >
+          <Plus className="h-3 w-3 mr-1" />
+          Create schedule
+        </Button>
+      </div>
+
+      {/* Table */}
+      <div className="flex-1 overflow-auto rounded border border-border">
+        <table className="w-full text-xs border-collapse min-w-[640px]">
+          <thead>
+            <tr className="bg-surface-raised border-b border-border text-left">
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Name
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Cron
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Next Run
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Last Run
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Status
+              </th>
+              <th className="px-4 py-2.5 font-medium text-text-secondary whitespace-nowrap">
+                Targets
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <SkeletonRows />
+            ) : schedules.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-4 py-10 text-center text-text-muted"
+                >
+                  No schedules found.
+                </td>
+              </tr>
+            ) : (
+              schedules.map((schedule) => {
+                const targets = schedule.targets ?? [];
+                let targetDisplay: string;
+                if (targets.length === 0) {
+                  targetDisplay = "—";
+                } else if (targets.length === 1) {
+                  targetDisplay = targets[0];
+                } else {
+                  targetDisplay = targets[0] + " +" + (targets.length - 1) + " more";
+                }
+
+                return (
+                  <tr
+                    key={schedule.id}
+                    onClick={() => setSelectedSchedule(schedule)}
+                    className={cn(
+                      "border-b border-border cursor-pointer transition-colors",
+                      "hover:bg-surface-raised",
+                      selectedSchedule?.id === schedule.id && "bg-accent/8",
+                    )}
+                  >
+                    <td className="px-4 py-2.5 text-text-primary font-medium truncate max-w-[180px]">
+                      {schedule.name ?? "—"}
+                    </td>
+                    <td
+                      className="px-4 py-2.5 text-text-secondary font-mono whitespace-nowrap"
+                      title={schedule.cron_expression}
+                    >
+                      {schedule.cron_expression
+                        ? describeCron(schedule.cron_expression)
+                        : "—"}
+                    </td>
+                    <td className="px-4 py-2.5 text-text-muted whitespace-nowrap">
+                      {schedule.next_run
+                        ? formatRelativeTime(schedule.next_run)
+                        : "—"}
+                    </td>
+                    <td className="px-4 py-2.5 text-text-muted whitespace-nowrap">
+                      {schedule.last_run
+                        ? formatRelativeTime(schedule.last_run)
+                        : "—"}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <ScheduleEnabledBadge enabled={schedule.enabled ?? false} />
+                    </td>
+                    <td className="px-4 py-2.5 text-text-secondary font-mono whitespace-nowrap">
+                      {targetDisplay}
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {!isLoading && schedules.length > 0 && totalPages > 1 && (
+        <PaginationBar
+          page={page}
+          totalPages={totalPages}
+          onPrev={() => setPage((p) => Math.max(1, p - 1))}
+          onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
+        />
+      )}
+
+      {/* Schedule detail panel */}
+      {selectedSchedule && (
+        <ScheduleDetailPanel
+          schedule={selectedSchedule}
+          onClose={() => setSelectedSchedule(null)}
+        />
+      )}
+
+      {/* Create schedule modal */}
+      {showCreateModal && (
+        <CreateScheduleModal
+          onClose={() => setShowCreateModal(false)}
+        />
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

Implements all remaining CRUD resource domains — the fifth shippable increment of the frontend build plan. All seven resource domains are now accessible and manageable from the frontend.

## What's new

### Discovery page (`/discovery`) — new route
- Table: Name, Network (CIDR, monospace), Method, Status badge, Progress, Started, Created
- **Inline row actions**: ▶ Start for pending jobs, ■ Stop for running jobs
- **Progress bar**: thin accent-colored bar rendered in the Progress column when a job is running
- Auto-refetch every 3 s while any job is pending/running
- Slide-in detail panel with job info and timestamps
- **New discovery job** modal: name, network CIDR, method select, start-immediately checkbox
- Discovery nav item added to sidebar (ScanSearch icon, between Hosts and Networks)

### Profiles page (`/profiles`) — replaces placeholder
- Table: Name, Scan Type, Ports (monospace), Description, Updated
- Slide-in **ProfileDetailPanel**: scan type badge in header, Edit / Delete with confirm
- **Profile form modal** handles both Create and Edit (mode prop), fields: name, scan type (6 options with nmap flag labels), ports, description
- Name search in toolbar

### Schedules page (`/schedules`) — replaces placeholder
- Table: Name, Cron (human-readable via `describeCron`; raw expression on hover), Next Run, Last Run, Status badge, Targets preview
- Status filter select: All / Enabled / Disabled
- Slide-in **ScheduleDetailPanel**: enable/disable toggle, delete with confirm, full schedule metadata
- **Create schedule modal**: name, cron expression with live preview, targets textarea, profile selector, enabled toggle

### New utility: `describeCron`
Added `describeCron(expr: string)` to `lib/utils.ts` — converts common cron patterns to human-readable strings:

| Expression | Output |
|-----------|--------|
| `* * * * *` | Every minute |
| `0 2 * * *` | Every day at 02:00 |
| `30 * * * *` | Every hour at :30 |
| `0 9 * * 1` | Every Monday at 09:00 |

### API hooks

| File | New hooks |
|------|-----------|
|  | , ,  |
|  (new) | , , , , , ,  |
|  (new) | , , , ,  |

## Tests

**583 tests passing across 25 test files** (up from 430 across 20).

New tests: 31 discovery hooks + 28 schedule hooks + 27 profiles page + 29 schedules page + 35 discovery page + 8 `describeCron` utility = **158 new tests**