### PR TITLE
feat(config): centralize validation via ValidateAndNormalize at all entry points

### DIFF
--- a/cmd/cli/server.go
+++ b/cmd/cli/server.go
@@ -429,8 +429,19 @@ func setupServerEnvironment(logger *logging.Logger) (*config.Config, *db.DB, err
 			"Enable it by setting 'api.enabled: true' in config")
 	}
 
-	if err := cfg.Validate(); err != nil {
-		return nil, nil, fmt.Errorf("configuration validation failed: %w", err)
+	// Re-validate after flag overrides using the comprehensive validator so that
+	// any warnings (e.g. privileged ports, missing optional settings) are surfaced
+	// at startup rather than silently ignored.
+	if result := config.ValidateAndNormalize(cfg); result.HasErrors() {
+		return nil, nil, fmt.Errorf("configuration validation failed: %w", result.AsError())
+	} else {
+		for _, w := range result.Warnings {
+			logger.Warn("configuration warning",
+				"section", w.Section,
+				"field", w.Field,
+				"message", w.Message,
+			)
+		}
 	}
 
 	// Setup database

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -540,9 +540,10 @@ func Load(path string) (*Config, error) {
 		}
 	}
 
-	// Validate configuration
-	if err := config.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid configuration: %w", err)
+	// Validate and normalize configuration (lowercasing, path cleaning, etc.).
+	// Warnings are non-fatal; only hard errors abort loading.
+	if result := ValidateAndNormalize(config); result.HasErrors() {
+		return nil, fmt.Errorf("invalid configuration: %w", result.AsError())
 	}
 
 	return config, nil
@@ -685,156 +686,12 @@ func safeJSONUnmarshal(data []byte, dest interface{}) error {
 	return nil
 }
 
-// Validate validates the configuration.
+// Validate validates the full configuration, returning the first hard error
+// found across all sections. Warnings (e.g. missing optional fields) are
+// silently discarded. Call ValidateConfig directly when you need the full
+// ValidationResult including warnings.
 func (c *Config) Validate() error {
-	if err := c.validateDatabase(); err != nil {
-		return err
-	}
-	if err := c.validateScanning(); err != nil {
-		return err
-	}
-	if err := c.validateAPI(); err != nil {
-		return err
-	}
-	if err := c.validateTLS(); err != nil {
-		return err
-	}
-	if err := c.validateLogging(); err != nil {
-		return err
-	}
-	return nil
-}
-
-// validateDatabase validates the database configuration.
-func (c *Config) validateDatabase() error {
-	if c.Database.Host == "" {
-		return fmt.Errorf("database host is required (set SCANORAMA_DB_HOST or configure in file)")
-	}
-	if c.Database.Database == "" {
-		return fmt.Errorf("database name is required (set SCANORAMA_DB_NAME or configure in file)")
-	}
-	if c.Database.Username == "" {
-		return fmt.Errorf("database username is required (set SCANORAMA_DB_USER or configure in file)")
-	}
-	return nil
-}
-
-// validateScanning validates the scanning configuration.
-func (c *Config) validateScanning() error {
-	if c.Scanning.WorkerPoolSize <= 0 {
-		return fmt.Errorf("worker pool size must be positive")
-	}
-	if c.Scanning.MaxConcurrentTargets <= 0 {
-		return fmt.Errorf("max concurrent targets must be positive")
-	}
-	if c.Scanning.DefaultInterval <= 0 {
-		return fmt.Errorf("default scan interval must be positive")
-	}
-
-	// Validate scan mode
-	validScanTypes := map[string]bool{
-		"connect":       true,
-		"syn":           true,
-		"ack":           true,
-		"udp":           true,
-		"aggressive":    true,
-		"comprehensive": true,
-	}
-	if !validScanTypes[c.Scanning.ScanMode] {
-		return fmt.Errorf("invalid scan_mode: %s", c.Scanning.ScanMode)
-	}
-	return nil
-}
-
-// validateAPI validates the API configuration.
-func (c *Config) validateAPI() error {
-	if !c.API.Enabled {
-		return nil
-	}
-
-	if c.API.Port <= 0 || c.API.Port > 65535 {
-		return fmt.Errorf("API port must be between 1 and 65535")
-	}
-	if c.API.Host == "" {
-		return fmt.Errorf("API host address is required when API is enabled")
-	}
-
-	// Validate timeouts
-	if c.API.ReadTimeout <= 0 {
-		return fmt.Errorf("API read timeout must be positive")
-	}
-	if c.API.WriteTimeout <= 0 {
-		return fmt.Errorf("API write timeout must be positive")
-	}
-	if c.API.IdleTimeout <= 0 {
-		return fmt.Errorf("API idle timeout must be positive")
-	}
-
-	// Validate max header bytes
-	if c.API.MaxHeaderBytes <= 0 {
-		return fmt.Errorf("API max header bytes must be positive")
-	}
-
-	// Validate rate limiting
-	if err := c.validateAPIRateLimiting(); err != nil {
-		return err
-	}
-
-	// Validate authentication
-	if c.API.AuthEnabled && len(c.API.APIKeys) == 0 {
-		return fmt.Errorf("at least one API key must be provided when authentication is enabled")
-	}
-
-	return nil
-}
-
-// validateAPIRateLimiting validates the API rate limiting configuration.
-func (c *Config) validateAPIRateLimiting() error {
-	if !c.API.RateLimitEnabled {
-		return nil
-	}
-	if c.API.RateLimitRequests <= 0 {
-		return fmt.Errorf("rate limit requests must be positive when rate limiting is enabled")
-	}
-	if c.API.RateLimitWindow <= 0 {
-		return fmt.Errorf("rate limit window must be positive when rate limiting is enabled")
-	}
-	return nil
-}
-
-// validateTLS validates the TLS configuration.
-func (c *Config) validateTLS() error {
-	if c.API.TLS.Enabled {
-		if c.API.TLS.CertFile == "" {
-			return fmt.Errorf("TLS certificate file is required when TLS is enabled")
-		}
-		if c.API.TLS.KeyFile == "" {
-			return fmt.Errorf("TLS key file is required when TLS is enabled")
-		}
-	}
-	return nil
-}
-
-// validateLogging validates the logging configuration.
-func (c *Config) validateLogging() error {
-	validLogLevels := map[string]bool{
-		"debug": true,
-		"info":  true,
-		"warn":  true,
-		"error": true,
-	}
-	if !validLogLevels[c.Logging.Level] {
-		return fmt.Errorf("invalid log level: %s", c.Logging.Level)
-	}
-
-	validLogFormats := map[string]bool{
-		"text": true,
-		"json": true,
-	}
-	if !validLogFormats[c.Logging.Format] {
-		return fmt.Errorf("invalid log format: %s", c.Logging.Format)
-	}
-	return nil
+	return ValidateConfig(c).AsError()
 }
 
 // GetDatabaseConfig returns the database configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -416,3 +416,63 @@ func TestValidate(t *testing.T) {
 		})
 	}
 }
+
+// TestLoad_NormalizesValues verifies that Load applies normalisation via
+// ValidateAndNormalize so that enum fields (e.g. scan_mode) are folded to
+// lower-case before the config is returned to the caller.
+func TestLoad_NormalizesValues(t *testing.T) {
+	content := `
+database:
+  host: localhost
+  port: 5432
+  database: testdb
+  username: testuser
+  password: testpass
+  ssl_mode: disable
+scanning:
+  worker_pool_size: 4
+  scan_mode: SYN
+`
+	path, cleanup := createTestConfigFile(t, content)
+	defer cleanup()
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	if cfg.Scanning.ScanMode != "syn" {
+		t.Errorf("ScanMode = %q after normalisation, want %q", cfg.Scanning.ScanMode, "syn")
+	}
+}
+
+// TestLoad_WarningsAreSilent verifies that configurations that produce
+// validation warnings (e.g. daemonize enabled without a pid_file) are
+// still loaded successfully — warnings must not abort loading.
+func TestLoad_WarningsAreSilent(t *testing.T) {
+	content := `
+database:
+  host: localhost
+  port: 5432
+  database: testdb
+  username: testuser
+  password: testpass
+  ssl_mode: disable
+daemon:
+  daemonize: true
+  # no pid_file — triggers a warning from ValidateDaemonConfig
+scanning:
+  worker_pool_size: 4
+`
+	path, cleanup := createTestConfigFile(t, content)
+	defer cleanup()
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() unexpected error for warning-only config: %v", err)
+	}
+
+	if !cfg.Daemon.Daemonize {
+		t.Error("Daemonize should be true")
+	}
+}

--- a/internal/daemon/daemon_coverage_test.go
+++ b/internal/daemon/daemon_coverage_test.go
@@ -412,6 +412,7 @@ func TestStart_FailsWhenWorkDirUnreachable(t *testing.T) {
 	cfg := &config.Config{
 		Database: db.Config{
 			Host:     "localhost",
+			Port:     5432,
 			Database: "testdb",
 			Username: "testuser",
 		},


### PR DESCRIPTION
Closes #220.

## Summary

`internal/config/validate.go` already contained a comprehensive `ValidateConfig` / `ValidateAndNormalize` implementation with ~1 100 lines of tests — but nothing called it. A parallel, weaker validation lived inline in `config.go`. This PR wires the centralised validator into every entry point and deletes the duplicate code.

## Changes

### `internal/config/config.go` (net −154 lines)
- `Config.Validate()` now delegates to `ValidateConfig(c).AsError()` — single line, no more six private helpers
- `Load()` calls `ValidateAndNormalize(config)` instead of `config.Validate()`, so enum fields (`scan_mode`, log level/format, file paths) are **normalised on load** — callers always receive a clean `Config`
- Deleted private methods: `validateDatabase`, `validateScanning`, `validateAPI`, `validateAPIRateLimiting`, `validateTLS`, `validateLogging`

### `cmd/cli/server.go`
- `setupServerEnvironment()` replaces the post-flag-override `cfg.Validate()` with `config.ValidateAndNormalize(cfg)` + a `logger.Warn` loop so warnings (privileged ports, large worker pools, etc.) are surfaced at startup

### `internal/config/config_test.go` (+2 tests)
- `TestLoad_NormalizesValues` — `scan_mode: SYN` comes back as `"syn"`
- `TestLoad_WarningsAreSilent` — `daemonize: true` without `pid_file` is a warning, not a load failure

### `internal/daemon/daemon_coverage_test.go` (1-line fix)
- `TestStart_FailsWhenWorkDirUnreachable` had `Database.Port: 0`; the new validator correctly catches that. Added `Port: 5432`.

## What the new validator catches that the old one missed

| Check | Old | New |
|-------|-----|-----|
| Database port range | ❌ | ✅ |
| Database SSL mode enum | ❌ | ✅ |
| Empty database password (warning) | ❌ | ✅ |
| Daemon shutdown timeout = 0 (warning) | ❌ | ✅ |
| Daemon/logging path directory traversal | ❌ | ✅ |
| Scanning retry / rate-limit sub-fields | ❌ | ✅ |
| API CORS wildcard with auth (warning) | ❌ | ✅ |
| Discovery config | ❌ | ✅ |
| Normalisation (case folding, path cleaning) | ❌ | ✅ |

## Test results

```
go test -short ./...   → all 22 packages pass
make lint              → 0 issues
```