### PR TITLE
chore: run go mod tidy after Go updates in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,9 @@
   "separateMajorMinor": true,
   "separateMinorPatch": false,
   "rangeStrategy": "bump",
+  "gomod": {
+    "postUpdateOptions": ["gomodTidy"]
+  },
   "npm": {
     "enabled": true,
     "rangeStrategy": "pin",


### PR DESCRIPTION
Adds `postUpdateOptions: ["gomodTidy"]` to the `gomod` manager config so Renovate automatically runs `go mod tidy` after applying Go module updates, keeping `go.sum` and indirect dependencies clean and in sync.