### PR TITLE
chore: separate Go and npm update groups in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -82,7 +82,7 @@
     {
       "description": "Group npm dev dependencies",
       "matchManagers": ["npm"],
-      "matchDepTypes": ["devDependencies"],
+      "matchDepTypes": ["devDependencies", "indirect"],
       "groupName": "npm dev dependencies",
       "labels": ["dependencies", "npm"],
       "commitMessagePrefix": "deps(npm):"


### PR DESCRIPTION
Fixes Renovate grouping so Go and npm updates are never batched together.

**Changes:**
- Remove `group:allNonMajor` preset which was the root cause — it created a single cross-ecosystem catch-all group
- Split the "Go modules" rule into two: one matching all `gomod` packages (previously only the toolchain `go` dep was matched), and one for the `custom.regex` `GO_VERSION` workflow pin
- Add an "npm dependencies" rule for production deps, so they have a group instead of falling through
- Add `indirect` to the dev dependencies rule so transitive lockfile-only packages (e.g. `brace-expansion`) are grouped instead of getting standalone PRs