### PR TITLE
chore(renovate): add daily lockfile maintenance for transitive dep updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,13 @@
   "separateMajorMinor": true,
   "separateMinorPatch": false,
   "rangeStrategy": "bump",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "commitMessageAction": "Refresh",
+    "commitMessageTopic": "lockfile",
+    "labels": ["dependencies"],
+    "schedule": ["every day before 5am"]
+  },
   "gomod": {
     "postUpdateOptions": ["gomodTidy"]
   },
@@ -82,7 +89,7 @@
     {
       "description": "Group npm dev dependencies",
       "matchManagers": ["npm"],
-      "matchDepTypes": ["devDependencies", "indirect"],
+      "matchDepTypes": ["devDependencies"],
       "groupName": "npm dev dependencies",
       "labels": ["dependencies", "npm"],
       "commitMessagePrefix": "deps(npm):"


### PR DESCRIPTION
Enables Renovate's `lockFileMaintenance` feature, which refreshes the lockfile daily (before 5am) without changing declared dependency versions in `package.json` or `go.mod`. This picks up transitive dependency updates — such as npm packages that only appear in `package-lock.json` — that the regular dependency update PRs don't cover.