### PR TITLE
fix(renovate): correct invalid JSON escape sequences in managerFilePatterns

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -238,6 +238,24 @@ make coverage-show
 - Handle `sql.ErrNoRows` specifically
 - Use transactions for batch operations
 
+## Renovate Configuration
+
+### After Any Change to `renovate.json`
+
+Always validate before committing. Use `python3` for strict JSON first, then the config validator:
+
+```bash
+python3 -c "import json; json.load(open('renovate.json')); print('valid JSON')"
+npx renovate-config-validator
+```
+
+**Version caveat**: `npx renovate-config-validator` installs the latest Renovate, which may not match the pinned bot version running on the repo. If the validator rejects a field that the Renovate bot itself wrote (e.g. via a `chore(config): migrate` commit), trust the bot — the JSON validity check matters more. Always confirm the file passes `python3` regardless.
+
+Common mistakes:
+- Invalid escape sequences in regex strings — use `\\.` not `\.` (e.g. `"/^\\.github/"` not `"/^\.github/"`)
+- Using `fileMatch` vs `managerFilePatterns` in `customManagers` — check which the running bot version expects
+- Invalid schedule strings — use `"before 5am"` not `"every day before 5am"`
+
 ## Build and Deployment
 
 ### Build Targets

--- a/renovate.json
+++ b/renovate.json
@@ -21,9 +21,7 @@
     {
       "description": "Sync GO_VERSION in CI workflows with go.mod",
       "customType": "regex",
-      "managerFilePatterns": [
-        "/^\.github/workflows/.+\.ya?ml$/"
-      ],
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
       "matchStrings": [
         "# renovate: datasource=golang-version depName=go\\s+GO_VERSION: \"(?<currentValue>[^\"]+)\""
       ],


### PR DESCRIPTION
The Renovate bot's own config migration commit (`chore(config): migrate config renovate.json`) rewrote `fileMatch` to `managerFilePatterns` but used bare `\.` escape sequences, which are not valid JSON — only JSON5 tolerates them. This is what caused the warning in the Dependency Dashboard:

> ⚠️ WARN: File contents are invalid JSONC but parse using JSON5.

**Fix:** replace `\.` with `\\.` so the regex string is valid strict JSON while preserving the correct regex pattern at runtime.

Also adds the Renovate validation workflow to `.claude/instructions.md`, including a note that `npx renovate-config-validator` may not match the pinned bot version.