### PR TITLE
fix(discovery): pass NetworkID when creating discovery job from network

### DIFF
--- a/internal/api/handlers/networks.go
+++ b/internal/api/handlers/networks.go
@@ -651,8 +651,9 @@ func (h *NetworkHandler) StartNetworkDiscovery(w http.ResponseWriter, r *http.Re
 
 	// Create the discovery job.
 	job, err := h.discoveryStore.CreateDiscoveryJob(r.Context(), db.CreateDiscoveryJobInput{
-		Networks: []string{cidr},
-		Method:   method,
+		Networks:  []string{cidr},
+		Method:    method,
+		NetworkID: &networkID,
 	})
 	if err != nil {
 		h.logger.Error("Failed to create discovery job for network",

--- a/internal/api/handlers/networks_discovery_mock_test.go
+++ b/internal/api/handlers/networks_discovery_mock_test.go
@@ -224,7 +224,7 @@ func TestNetworkHandler_StartNetworkDiscovery(t *testing.T) {
 			CreateDiscoveryJob(gomock.Any(), db.CreateDiscoveryJobInput{
 				Networks:  []string{"192.168.0.0/16"},
 				Method:    "tcp",
-				NetworkID: nil,
+				NetworkID: &networkID,
 			}).
 			Return(pendingJob, nil)
 		store.EXPECT().
@@ -266,7 +266,7 @@ func TestNetworkHandler_StartNetworkDiscovery(t *testing.T) {
 			CreateDiscoveryJob(gomock.Any(), db.CreateDiscoveryJobInput{
 				Networks:  []string{"10.0.0.0/8"},
 				Method:    "tcp",
-				NetworkID: nil,
+				NetworkID: &networkID,
 			}).
 			Return(pendingJob, nil)
 		store.EXPECT().StartDiscoveryJob(gomock.Any(), jobID).Return(nil)


### PR DESCRIPTION
## Bug

Running discovery from a network's detail view (`POST /api/v1/networks/{id}/discover`) never linked the resulting job to that network. The job was always inserted with `network_id = NULL`.

## Root cause

`StartNetworkDiscovery` extracted `networkID` from the URL path but never forwarded it to `CreateDiscoveryJobInput`:

```go
// before
job, err := h.discoveryStore.CreateDiscoveryJob(r.Context(), db.CreateDiscoveryJobInput{
    Networks: []string{cidr},
    Method:   method,
    // NetworkID missing — always NULL
})
```

## Consequences of the NULL

- The `stamp_network_last_discovery` trigger guards on `network_id IS NOT NULL`, so `networks.last_discovery` was never stamped.
- No discovery job ever appeared in the network's discovery history.
- The network detail view therefore always showed no previous discoveries.

## Fix

Pass `NetworkID: &networkID` so the FK is written on job creation. Updated the two handler tests that were explicitly asserting `NetworkID: nil`.