### PR TITLE
feat(profiles): clone profile UI

### DIFF
--- a/frontend/src/api/hooks/use-profiles.ts
+++ b/frontend/src/api/hooks/use-profiles.ts
@@ -93,3 +93,25 @@ export function useDeleteProfile() {
     },
   });
 }
+
+export function useCloneProfile() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, name }: { id: string; name: string }) => {
+      const baseUrl = import.meta.env.VITE_API_BASE_URL ?? "/api/v1";
+      const res = await fetch(`${baseUrl}/profiles/${id}/clone`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new ApiError(res.status, body);
+      }
+      return res.json() as Promise<components["schemas"]["docs.ProfileResponse"]>;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["profiles"] });
+    },
+  });
+}

--- a/frontend/src/routes/profiles.test.tsx
+++ b/frontend/src/routes/profiles.test.tsx
@@ -8,6 +8,7 @@ import { ProfilesPage } from "./profiles";
 vi.mock("../api/hooks/use-profiles", () => ({
   useProfiles: vi.fn(),
   useDeleteProfile: vi.fn(),
+  useCloneProfile: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
 }));
 
 vi.mock("../components/profile-form-modal", () => ({

--- a/frontend/src/routes/profiles.tsx
+++ b/frontend/src/routes/profiles.tsx
@@ -1,9 +1,9 @@
 import { useState, useCallback } from "react";
-import { Plus, Pencil, Trash2, X, SlidersHorizontal } from "lucide-react";
+import { Plus, Pencil, Trash2, X, SlidersHorizontal, Copy } from "lucide-react";
 import { SortHeader } from "../components/sort-header";
 import type { SortOrder } from "../components/sort-header";
 import { Button } from "../components/button";
-import { useProfiles, useDeleteProfile } from "../api/hooks/use-profiles";
+import { useProfiles, useDeleteProfile, useCloneProfile } from "../api/hooks/use-profiles";
 import { useToast } from "../components/toast-provider";
 import { Skeleton, PaginationBar } from "../components";
 import { ProfileFormModal } from "../components/profile-form-modal";
@@ -105,9 +105,12 @@ function ProfileDetailPanel({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [showEditModal, setShowEditModal] = useState(false);
+  const [showCloneDialog, setShowCloneDialog] = useState(false);
+  const [cloneName, setCloneName] = useState("");
 
   const { mutateAsync: deleteProfile, isPending: isDeleting } =
     useDeleteProfile();
+  const { mutateAsync: cloneProfile, isPending: isCloning } = useCloneProfile();
 
   const { toast } = useToast();
   const p = initialProfile;
@@ -122,6 +125,31 @@ function ProfileDetailPanel({
       const msg = err instanceof Error ? err.message : "Delete failed.";
       setActionError(msg);
       setShowDeleteConfirm(false);
+      toast.error(msg);
+    }
+  }
+
+  function openCloneDialog() {
+    setCloneName(`Copy of ${p.name ?? ""}`);
+    setShowCloneDialog(true);
+    setActionError(null);
+  }
+
+  async function handleClone(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = cloneName.trim();
+    if (!trimmed) return;
+    setActionError(null);
+    try {
+      await cloneProfile({ id: p.id ?? "", name: trimmed });
+      toast.success("Profile cloned successfully");
+      setShowCloneDialog(false);
+      onClose();
+    } catch (err) {
+      const apiErr = err as { message?: string; error?: string };
+      const msg =
+        apiErr.message ?? apiErr.error ?? "Failed to clone profile.";
+      setActionError(msg);
       toast.error(msg);
     }
   }
@@ -180,6 +208,46 @@ function ProfileDetailPanel({
             <Pencil className="h-3 w-3 mr-1" />
             Edit
           </Button>
+
+          <Button
+            variant="secondary"
+            onClick={openCloneDialog}
+            className="text-xs h-7 px-3"
+          >
+            <Copy className="h-3 w-3 mr-1" />
+            Clone
+          </Button>
+
+          {showCloneDialog && (
+            <form
+              onSubmit={(e) => void handleClone(e)}
+              className="flex items-center gap-2 w-full mt-1"
+            >
+              <input
+                type="text"
+                value={cloneName}
+                onChange={(e) => setCloneName(e.target.value)}
+                autoFocus
+                placeholder="New profile name"
+                className="flex-1 px-2 py-1 text-xs rounded border border-border bg-surface text-text-primary focus:outline-none focus:ring-1 focus:ring-border"
+              />
+              <Button
+                type="submit"
+                loading={isCloning}
+                className="text-xs h-7 px-3"
+                disabled={!cloneName.trim()}
+              >
+                Clone
+              </Button>
+              <button
+                type="button"
+                onClick={() => setShowCloneDialog(false)}
+                className="text-xs text-text-muted hover:text-text-secondary"
+              >
+                Cancel
+              </button>
+            </form>
+          )}
 
           {showDeleteConfirm ? (
             <div className="flex items-center gap-2 ml-auto">


### PR DESCRIPTION
## Summary

- Adds a **Clone** button to the profile detail panel
- Clicking opens an inline dialog pre-filled with \`"Copy of {original name}"\`
- On success: cache is invalidated (cloned profile appears immediately in the list) and a toast fires
- On duplicate name: the API's 409 error message is shown inline

## Changes

- \`frontend/src/api/hooks/use-profiles.ts\` — \`useCloneProfile()\` mutation calling \`POST /api/v1/profiles/{id}/clone\`
- \`frontend/src/routes/profiles.tsx\` — Clone button + inline name dialog in \`ProfileDetailPanel\`
- \`frontend/src/routes/profiles.test.tsx\` — mock updated to export \`useCloneProfile\`

## Test plan

- [x] All 835 frontend tests pass
- [x] TypeScript clean (\`tsc --noEmit\`)
- [x] Clone button visible in profile detail panel
- [x] Dialog pre-fills "Copy of {name}"
- [x] Cloned profile appears in list after dialog closes
- [x] Toast: "Profile cloned successfully"
- [x] Duplicate name shows inline error

Closes #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)