### PR TITLE
feat(groups): Group UI + bulk ops

### DIFF
--- a/frontend/src/api/hooks/use-groups.ts
+++ b/frontend/src/api/hooks/use-groups.ts
@@ -1,0 +1,157 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { ApiError } from "../errors";
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? "/api/v1";
+
+export interface HostGroup {
+  id: string;
+  name: string;
+  description?: string;
+  color?: string;
+  member_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GroupMember {
+  id: string;
+  ip_address: string;
+  hostname?: string;
+  status: string;
+  tags?: string[];
+  last_seen: string;
+}
+
+async function apiFetch<T>(
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, init);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new ApiError(res.status, body);
+  }
+  if (res.status === 204) return undefined as T;
+  return res.json() as Promise<T>;
+}
+
+// ── Queries ───────────────────────────────────────────────────────────────────
+
+export function useGroups() {
+  return useQuery({
+    queryKey: ["groups"],
+    queryFn: () =>
+      apiFetch<{ groups: HostGroup[]; total: number }>("/groups").then(
+        (d) => d.groups,
+      ),
+  });
+}
+
+export function useGroup(id: string | undefined) {
+  return useQuery({
+    queryKey: ["groups", id],
+    queryFn: () => apiFetch<HostGroup>(`/groups/${id!}`),
+    enabled: !!id,
+  });
+}
+
+export function useGroupMembers(
+  id: string | undefined,
+  params: { page?: number; page_size?: number } = {},
+) {
+  const qs = new URLSearchParams();
+  if (params.page) qs.set("page", String(params.page));
+  if (params.page_size) qs.set("page_size", String(params.page_size));
+  const query = qs.toString();
+  return useQuery({
+    queryKey: ["groups", id, "members", params],
+    queryFn: () =>
+      apiFetch<{ data: GroupMember[]; pagination: { total_pages: number; total: number } }>(
+        `/groups/${id!}/hosts${query ? `?${query}` : ""}`,
+      ),
+    enabled: !!id,
+  });
+}
+
+// ── Mutations ─────────────────────────────────────────────────────────────────
+
+export function useCreateGroup() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { name: string; description?: string; color?: string }) =>
+      apiFetch<HostGroup>("/groups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["groups"] });
+    },
+  });
+}
+
+export function useUpdateGroup() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      body,
+    }: {
+      id: string;
+      body: { name?: string; description?: string; color?: string };
+    }) =>
+      apiFetch<HostGroup>(`/groups/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["groups"] });
+    },
+  });
+}
+
+export function useDeleteGroup() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiFetch<void>(`/groups/${id}`, { method: "DELETE" }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["groups"] });
+    },
+  });
+}
+
+export function useAddHostsToGroup() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ groupId, hostIds }: { groupId: string; hostIds: string[] }) =>
+      apiFetch<{ added: number }>(`/groups/${groupId}/hosts`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ host_ids: hostIds }),
+      }),
+    onSuccess: (_data, { groupId }) => {
+      void queryClient.invalidateQueries({ queryKey: ["groups", groupId] });
+      void queryClient.invalidateQueries({ queryKey: ["groups"] });
+      void queryClient.invalidateQueries({ queryKey: ["hosts"] });
+    },
+  });
+}
+
+export function useRemoveHostsFromGroup() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ groupId, hostIds }: { groupId: string; hostIds: string[] }) =>
+      apiFetch<{ removed: number }>(`/groups/${groupId}/hosts`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ host_ids: hostIds }),
+      }),
+    onSuccess: (_data, { groupId }) => {
+      void queryClient.invalidateQueries({ queryKey: ["groups", groupId] });
+      void queryClient.invalidateQueries({ queryKey: ["groups"] });
+      void queryClient.invalidateQueries({ queryKey: ["hosts"] });
+    },
+  });
+}

--- a/frontend/src/components/filter-builder.tsx
+++ b/frontend/src/components/filter-builder.tsx
@@ -37,13 +37,19 @@ function isGroup(expr: FilterExpr): expr is FilterGroup {
 
 // ── Value input ───────────────────────────────────────────────────────────────
 
+interface GroupOption {
+  id: string;
+  name: string;
+}
+
 interface ValueInputProps {
   condition: FilterCondition;
   onChange: (updates: Partial<FilterCondition>) => void;
   tagSuggestions?: string[];
+  groupOptions?: GroupOption[];
 }
 
-function ValueInput({ condition, onChange, tagSuggestions = [] }: ValueInputProps) {
+function ValueInput({ condition, onChange, tagSuggestions = [], groupOptions = [] }: ValueInputProps) {
   const meta = getFieldMeta(condition.field);
   const type = meta?.type ?? "text";
   const isBetween = condition.cmp === "between";
@@ -142,6 +148,24 @@ function ValueInput({ condition, onChange, tagSuggestions = [] }: ValueInputProp
     );
   }
 
+  if (type === "group") {
+    return (
+      <select
+        value={condition.value}
+        onChange={(e) => onChange({ value: e.target.value })}
+        className={cn(inputClass, "min-w-36")}
+        aria-label="Filter value"
+      >
+        <option value="">Select group…</option>
+        {groupOptions.map((g) => (
+          <option key={g.id} value={g.name}>
+            {g.name}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
   if (type === "tag") {
     const filtered = tagSuggestions.filter(
       (t) =>
@@ -208,6 +232,7 @@ interface ConditionRowProps {
   onRemove: () => void;
   isOnly: boolean;
   tagSuggestions?: string[];
+  groupOptions?: GroupOption[];
 }
 
 function ConditionRow({
@@ -216,6 +241,7 @@ function ConditionRow({
   onRemove,
   isOnly,
   tagSuggestions,
+  groupOptions,
 }: ConditionRowProps) {
   const meta = getFieldMeta(condition.field);
   const ops = getOperatorsForType(meta?.type ?? "text");
@@ -276,7 +302,7 @@ function ConditionRow({
       </select>
 
       {/* Value input */}
-      <ValueInput condition={condition} onChange={handleValueChange} tagSuggestions={tagSuggestions} />
+      <ValueInput condition={condition} onChange={handleValueChange} tagSuggestions={tagSuggestions} groupOptions={groupOptions} />
 
       {/* Remove button */}
       <button
@@ -331,9 +357,10 @@ interface SubGroupProps {
   onChange: (g: FilterGroup) => void;
   onRemove: () => void;
   tagSuggestions?: string[];
+  groupOptions?: GroupOption[];
 }
 
-function SubGroup({ group, onChange, onRemove, tagSuggestions }: SubGroupProps) {
+function SubGroup({ group, onChange, onRemove, tagSuggestions, groupOptions }: SubGroupProps) {
   function updateCondition(idx: number, cond: FilterCondition) {
     const conditions = group.conditions.map((c, i) => (i === idx ? cond : c));
     onChange({ ...group, conditions });
@@ -380,6 +407,7 @@ function SubGroup({ group, onChange, onRemove, tagSuggestions }: SubGroupProps) 
             onRemove={() => removeCondition(idx)}
             isOnly={group.conditions.length === 1}
             tagSuggestions={tagSuggestions}
+            groupOptions={groupOptions}
           />
         );
       })}
@@ -551,6 +579,7 @@ export interface FilterBuilderProps {
   value: FilterGroup | null;
   onApply: (filter: FilterGroup | null) => void;
   tagSuggestions?: string[];
+  groupOptions?: GroupOption[];
 }
 
 function makeDefaultGroup(): FilterGroup {
@@ -560,7 +589,7 @@ function makeDefaultGroup(): FilterGroup {
   };
 }
 
-export function FilterBuilder({ value, onApply, tagSuggestions = [] }: FilterBuilderProps) {
+export function FilterBuilder({ value, onApply, tagSuggestions = [], groupOptions = [] }: FilterBuilderProps) {
   const [draft, setDraft] = useState<FilterGroup>(
     () => value ?? makeDefaultGroup(),
   );
@@ -682,6 +711,7 @@ export function FilterBuilder({ value, onApply, tagSuggestions = [] }: FilterBui
                 onChange={(g) => updateTopCondition(idx, g)}
                 onRemove={() => removeTopCondition(idx)}
                 tagSuggestions={allTags}
+                groupOptions={groupOptions}
               />
             );
           }
@@ -694,6 +724,7 @@ export function FilterBuilder({ value, onApply, tagSuggestions = [] }: FilterBui
               onRemove={() => removeTopCondition(idx)}
               isOnly={topLeafCount <= 1 && draft.conditions.length === 1}
               tagSuggestions={allTags}
+              groupOptions={groupOptions}
             />
           );
         })}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -10,6 +10,7 @@ import {
   Clock,
   Shield,
   ShieldOff,
+  Layers,
   PanelLeftClose,
   PanelLeftOpen,
 } from "lucide-react";
@@ -27,6 +28,7 @@ const mainNav: NavItem[] = [
   { label: "Discovery", href: "#/discovery", icon: ScanSearch },
   { label: "Networks", href: "#/networks", icon: Network },
   { label: "Exclusions", href: "#/exclusions", icon: ShieldOff },
+  { label: "Groups", href: "#/groups", icon: Layers },
   { label: "Profiles", href: "#/profiles", icon: SlidersHorizontal },
   { label: "Schedules", href: "#/schedules", icon: Clock },
 ];

--- a/frontend/src/lib/filter-expr.ts
+++ b/frontend/src/lib/filter-expr.ts
@@ -46,7 +46,8 @@ export type FilterFieldType =
   | "number_count"
   | "date"
   | "port"
-  | "tag";
+  | "tag"
+  | "group";
 
 export interface FilterFieldMeta {
   field: string;
@@ -66,6 +67,7 @@ export const FILTER_FIELDS: FilterFieldMeta[] = [
   { field: "open_port", label: "Open Port", type: "port" },
   { field: "scan_count", label: "Scan Count", type: "number_count" },
   { field: "tags", label: "Tags", type: "tag" },
+  { field: "group", label: "Group", type: "group" },
 ];
 
 export function getFieldMeta(field: string): FilterFieldMeta | undefined {
@@ -81,6 +83,7 @@ export function getOperatorsForType(type: FilterFieldType): FilterCmp[] {
     case "date":   return ["gt", "lt", "between"];
     case "port":   return ["is", "is_not"];
     case "tag":    return ["contains", "is_not"];
+    case "group":  return ["is", "is_not"];
   }
 }
 

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -15,6 +15,7 @@ import { DiscoveryPage } from "./routes/discovery";
 import { ProfilesPage } from "./routes/profiles";
 import { SchedulesPage } from "./routes/schedules";
 import { AdminPage } from "./routes/admin";
+import { GroupsPage } from "./routes/groups";
 
 const rootRoute = createRootRoute({
   component: RootLayout,
@@ -84,6 +85,12 @@ const adminRoute = createRoute({
   component: AdminPage,
 });
 
+const groupsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/groups",
+  component: GroupsPage,
+});
+
 const routeTree = rootRoute.addChildren([
   dashboardRoute,
   scansRoute,
@@ -93,6 +100,7 @@ const routeTree = rootRoute.addChildren([
   discoveryRoute,
   profilesRoute,
   schedulesRoute,
+  groupsRoute,
   adminRoute,
 ]);
 

--- a/frontend/src/routes/groups.test.tsx
+++ b/frontend/src/routes/groups.test.tsx
@@ -1,0 +1,312 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GroupsPage } from "./groups";
+
+// ── Mock hooks ────────────────────────────────────────────────────────────────
+
+vi.mock("../api/hooks/use-groups", () => ({
+  useGroups: vi.fn(),
+  useGroupMembers: vi.fn(),
+  useCreateGroup: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  useUpdateGroup: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  useDeleteGroup: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  useRemoveHostsFromGroup: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+}));
+
+vi.mock("../components/toast-provider", () => ({
+  useToast: () => ({
+    toast: { success: vi.fn(), error: vi.fn() },
+  }),
+}));
+
+vi.mock("../components", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../components")>();
+  return {
+    ...actual,
+    PaginationBar: ({ page, totalPages }: { page: number; totalPages: number }) => (
+      <div>{`Page ${page} of ${totalPages}`}</div>
+    ),
+  };
+});
+
+import {
+  useGroups,
+  useGroupMembers,
+} from "../api/hooks/use-groups";
+
+const mockUseGroups = vi.mocked(useGroups);
+const mockUseGroupMembers = vi.mocked(useGroupMembers);
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const mockGroups = [
+  {
+    id: "g1",
+    name: "Production",
+    description: "Production hosts",
+    color: "#ef4444",
+    member_count: 5,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: new Date(Date.now() - 3_600_000).toISOString(),
+  },
+  {
+    id: "g2",
+    name: "Development",
+    description: undefined,
+    color: "#22c55e",
+    member_count: 3,
+    created_at: "2024-01-02T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+  },
+];
+
+const mockMembers = [
+  {
+    id: "h1",
+    ip_address: "192.168.1.1",
+    hostname: "server-1",
+    status: "up",
+    tags: ["web"],
+    last_seen: new Date(Date.now() - 60_000).toISOString(),
+  },
+  {
+    id: "h2",
+    ip_address: "192.168.1.2",
+    hostname: undefined,
+    status: "down",
+    tags: [],
+    last_seen: "2024-06-01T00:00:00Z",
+  },
+];
+
+function makeUseGroupsResult(overrides = {}) {
+  return {
+    data: mockGroups,
+    isLoading: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useGroups>;
+}
+
+function makeUseGroupMembersResult(overrides = {}) {
+  return {
+    data: {
+      data: mockMembers,
+      pagination: { total_pages: 1, total: 2 },
+    },
+    isLoading: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useGroupMembers>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseGroups.mockReturnValue(makeUseGroupsResult());
+  mockUseGroupMembers.mockReturnValue(makeUseGroupMembersResult());
+});
+
+// ── Toolbar ───────────────────────────────────────────────────────────────────
+
+describe("GroupsPage — toolbar", () => {
+  it("renders search input", () => {
+    render(<GroupsPage />);
+    expect(screen.getByRole("textbox", { name: /search groups/i })).toBeInTheDocument();
+  });
+
+  it("renders the Create group button", () => {
+    render(<GroupsPage />);
+    expect(screen.getByRole("button", { name: /create group/i })).toBeInTheDocument();
+  });
+});
+
+// ── Loading state ─────────────────────────────────────────────────────────────
+
+describe("GroupsPage — loading", () => {
+  it("renders skeleton rows when loading", () => {
+    mockUseGroups.mockReturnValue(
+      makeUseGroupsResult({ isLoading: true, data: undefined }),
+    );
+    const { container } = render(<GroupsPage />);
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+describe("GroupsPage — empty state", () => {
+  it("shows 'No groups found.' when list is empty", () => {
+    mockUseGroups.mockReturnValue(makeUseGroupsResult({ data: [] }));
+    render(<GroupsPage />);
+    expect(screen.getByText("No groups found.")).toBeInTheDocument();
+  });
+});
+
+// ── Table ─────────────────────────────────────────────────────────────────────
+
+describe("GroupsPage — table", () => {
+  it("renders all column headers", () => {
+    render(<GroupsPage />);
+    expect(screen.getByRole("columnheader", { name: "Name" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Description" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Members" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Updated" })).toBeInTheDocument();
+  });
+
+  it("renders group names", () => {
+    render(<GroupsPage />);
+    expect(screen.getByText("Production")).toBeInTheDocument();
+    expect(screen.getByText("Development")).toBeInTheDocument();
+  });
+
+  it("renders member counts", () => {
+    render(<GroupsPage />);
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("renders one row per group plus header", () => {
+    render(<GroupsPage />);
+    expect(screen.getAllByRole("row")).toHaveLength(3);
+  });
+});
+
+// ── Search ────────────────────────────────────────────────────────────────────
+
+describe("GroupsPage — search", () => {
+  it("filters groups by name", async () => {
+    render(<GroupsPage />);
+    await userEvent.type(screen.getByRole("textbox", { name: /search groups/i }), "Prod");
+    expect(screen.getByText("Production")).toBeInTheDocument();
+    expect(screen.queryByText("Development")).not.toBeInTheDocument();
+  });
+
+  it("shows 'No groups match your search.' when no results", async () => {
+    render(<GroupsPage />);
+    await userEvent.type(
+      screen.getByRole("textbox", { name: /search groups/i }),
+      "xyznonexistent",
+    );
+    expect(screen.getByText("No groups match your search.")).toBeInTheDocument();
+  });
+});
+
+// ── Detail panel ──────────────────────────────────────────────────────────────
+
+describe("GroupsPage — detail panel", () => {
+  it("opens the detail panel when a row is clicked", async () => {
+    render(<GroupsPage />);
+    await userEvent.click(screen.getByText("Production").closest("tr")!);
+    expect(screen.getByRole("dialog", { name: /group details/i })).toBeInTheDocument();
+  });
+
+  it("shows group name in detail panel", async () => {
+    render(<GroupsPage />);
+    await userEvent.click(screen.getByText("Production").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /group details/i });
+    expect(within(panel).getAllByText("Production").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("closes the detail panel when close button is clicked", async () => {
+    render(<GroupsPage />);
+    await userEvent.click(screen.getByText("Production").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /group details/i });
+    await userEvent.click(within(panel).getByRole("button", { name: /close panel/i }));
+    expect(screen.queryByRole("dialog", { name: /group details/i })).not.toBeInTheDocument();
+  });
+
+  it("shows member IP addresses in panel", async () => {
+    render(<GroupsPage />);
+    await userEvent.click(screen.getByText("Production").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /group details/i });
+    expect(within(panel).getByText("192.168.1.1")).toBeInTheDocument();
+    expect(within(panel).getByText("192.168.1.2")).toBeInTheDocument();
+  });
+
+  it("shows 'No members' message when group is empty", async () => {
+    mockUseGroupMembers.mockReturnValue(
+      makeUseGroupMembersResult({
+        data: { data: [], pagination: { total_pages: 0, total: 0 } },
+      }),
+    );
+    render(<GroupsPage />);
+    await userEvent.click(screen.getByText("Production").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /group details/i });
+    expect(within(panel).getByText("No members in this group.")).toBeInTheDocument();
+  });
+
+  it("shows 'Delete group' in panel footer", async () => {
+    render(<GroupsPage />);
+    await userEvent.click(screen.getByText("Production").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /group details/i });
+    expect(within(panel).getByText("Delete group")).toBeInTheDocument();
+  });
+
+  it("shows delete confirmation when delete is clicked", async () => {
+    render(<GroupsPage />);
+    await userEvent.click(screen.getByText("Production").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /group details/i });
+    await userEvent.click(within(panel).getByText("Delete group"));
+    expect(within(panel).getByText("Delete this group?")).toBeInTheDocument();
+  });
+
+  it("shows 'Edit group' button", async () => {
+    render(<GroupsPage />);
+    await userEvent.click(screen.getByText("Production").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /group details/i });
+    expect(within(panel).getByRole("button", { name: /edit group/i })).toBeInTheDocument();
+  });
+});
+
+// ── Create modal ──────────────────────────────────────────────────────────────
+
+describe("GroupsPage — create modal", () => {
+  it("opens create modal when 'Create group' is clicked", async () => {
+    render(<GroupsPage />);
+    await userEvent.click(screen.getByRole("button", { name: /create group/i }));
+    expect(screen.getByRole("dialog", { name: /create group/i })).toBeInTheDocument();
+  });
+
+  it("renders name input in create modal", async () => {
+    render(<GroupsPage />);
+    await userEvent.click(screen.getByRole("button", { name: /create group/i }));
+    expect(screen.getByPlaceholderText(/e.g. Production servers/i)).toBeInTheDocument();
+  });
+
+  it("renders color swatches in create modal", async () => {
+    render(<GroupsPage />);
+    await userEvent.click(screen.getByRole("button", { name: /create group/i }));
+    const modal = screen.getByRole("dialog", { name: /create group/i });
+    const swatches = within(modal).getAllByRole("button", { name: /^Color #/i });
+    expect(swatches.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("closes create modal when Cancel is clicked", async () => {
+    render(<GroupsPage />);
+    await userEvent.click(screen.getByRole("button", { name: /create group/i }));
+    const modal = screen.getByRole("dialog", { name: /create group/i });
+    await userEvent.click(within(modal).getByRole("button", { name: /cancel/i }));
+    expect(screen.queryByRole("dialog", { name: /create group/i })).not.toBeInTheDocument();
+  });
+});
+
+// ── Edit modal ────────────────────────────────────────────────────────────────
+
+describe("GroupsPage — edit modal", () => {
+  it("opens edit modal from detail panel", async () => {
+    render(<GroupsPage />);
+    await userEvent.click(screen.getByText("Production").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /group details/i });
+    await userEvent.click(within(panel).getByRole("button", { name: /edit group/i }));
+    expect(screen.getByRole("dialog", { name: /edit group/i })).toBeInTheDocument();
+  });
+
+  it("pre-fills name in edit modal", async () => {
+    render(<GroupsPage />);
+    await userEvent.click(screen.getByText("Production").closest("tr")!);
+    const panel = screen.getByRole("dialog", { name: /group details/i });
+    await userEvent.click(within(panel).getByRole("button", { name: /edit group/i }));
+    const modal = screen.getByRole("dialog", { name: /edit group/i });
+    expect(within(modal).getByDisplayValue("Production")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/routes/groups.tsx
+++ b/frontend/src/routes/groups.tsx
@@ -1,0 +1,615 @@
+import { useState, useCallback } from "react";
+import { X, Plus, Pencil, Trash2, Users, Search } from "lucide-react";
+import { Button } from "../components/button";
+import { StatusBadge, Skeleton, PaginationBar } from "../components";
+import { formatRelativeTime, cn } from "../lib/utils";
+import { useToast } from "../components/toast-provider";
+import {
+  useGroups,
+  useGroupMembers,
+  useCreateGroup,
+  useUpdateGroup,
+  useDeleteGroup,
+  useRemoveHostsFromGroup,
+} from "../api/hooks/use-groups";
+import type { HostGroup } from "../api/hooks/use-groups";
+
+// ── Color palette ─────────────────────────────────────────────────────────────
+
+const PRESET_COLORS = [
+  "#6366f1", // indigo
+  "#8b5cf6", // violet
+  "#ec4899", // pink
+  "#ef4444", // red
+  "#f97316", // orange
+  "#eab308", // yellow
+  "#22c55e", // green
+  "#14b8a6", // teal
+  "#3b82f6", // blue
+  "#06b6d4", // cyan
+  "#84cc16", // lime
+  "#64748b", // slate
+];
+
+// ── Group form modal ──────────────────────────────────────────────────────────
+
+interface GroupFormModalProps {
+  group?: HostGroup;
+  onClose: () => void;
+}
+
+function GroupFormModal({ group, onClose }: GroupFormModalProps) {
+  const { toast } = useToast();
+  const [name, setName] = useState(group?.name ?? "");
+  const [description, setDescription] = useState(group?.description ?? "");
+  const [color, setColor] = useState(group?.color ?? PRESET_COLORS[0]!);
+  const [error, setError] = useState<string | null>(null);
+
+  const { mutateAsync: createGroup, isPending: isCreating } = useCreateGroup();
+  const { mutateAsync: updateGroup, isPending: isUpdating } = useUpdateGroup();
+  const isPending = isCreating || isUpdating;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError("Name is required.");
+      return;
+    }
+    try {
+      if (group) {
+        await updateGroup({ id: group.id, body: { name: trimmedName, description: description.trim() || undefined, color } });
+        toast.success("Group updated.");
+      } else {
+        await createGroup({ name: trimmedName, description: description.trim() || undefined, color });
+        toast.success("Group created.");
+      }
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save group.");
+    }
+  }
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 bg-black/50 z-50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-label={group ? "Edit group" : "Create group"}
+        className={cn(
+          "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50",
+          "w-full max-w-md bg-surface border border-border rounded-lg shadow-xl",
+          "p-6 space-y-4",
+        )}
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-text-primary">
+            {group ? "Edit Group" : "Create Group"}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close modal"
+            className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+          {/* Name */}
+          <div>
+            <label className="block text-xs font-medium text-text-secondary mb-1">
+              Name <span className="text-danger">*</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Production servers"
+              autoFocus
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="block text-xs font-medium text-text-secondary mb-1">
+              Description
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional description…"
+              rows={2}
+              className={cn(
+                "w-full px-3 py-1.5 text-xs rounded border border-border resize-none",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+          </div>
+
+          {/* Color */}
+          <div>
+            <label className="block text-xs font-medium text-text-secondary mb-2">
+              Color
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {PRESET_COLORS.map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  aria-label={`Color ${c}`}
+                  onClick={() => setColor(c)}
+                  className={cn(
+                    "h-6 w-6 rounded-full transition-transform hover:scale-110",
+                    color === c && "ring-2 ring-offset-2 ring-offset-surface ring-text-primary scale-110",
+                  )}
+                  style={{ backgroundColor: c }}
+                />
+              ))}
+            </div>
+          </div>
+
+          {error && <p className="text-xs text-danger">{error}</p>}
+
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="secondary" onClick={onClose} type="button">
+              Cancel
+            </Button>
+            <Button type="submit" loading={isPending} disabled={!name.trim()}>
+              {group ? "Save changes" : "Create group"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </>
+  );
+}
+
+// ── Group detail panel ────────────────────────────────────────────────────────
+
+interface GroupDetailPanelProps {
+  group: HostGroup;
+  onClose: () => void;
+  onEdit: () => void;
+}
+
+const MEMBERS_PER_PAGE = 10;
+
+function GroupDetailPanel({ group, onClose, onEdit }: GroupDetailPanelProps) {
+  const { toast } = useToast();
+  const [memberPage, setMemberPage] = useState(1);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [memberSearch, setMemberSearch] = useState("");
+
+  const { data: membersData, isLoading: membersLoading } = useGroupMembers(group.id, {
+    page: memberPage,
+    page_size: MEMBERS_PER_PAGE,
+  });
+  const { mutateAsync: deleteGroup, isPending: isDeleting } = useDeleteGroup();
+  const { mutateAsync: removeHosts, isPending: isRemoving } = useRemoveHostsFromGroup();
+
+  const members = membersData?.data ?? [];
+  const totalMemberPages = membersData?.pagination?.total_pages ?? 0;
+
+  const filteredMembers = memberSearch.trim()
+    ? members.filter(
+        (m) =>
+          m.ip_address.includes(memberSearch) ||
+          m.hostname?.toLowerCase().includes(memberSearch.toLowerCase()),
+      )
+    : members;
+
+  async function handleDelete() {
+    try {
+      await deleteGroup(group.id);
+      toast.success("Group deleted.");
+      onClose();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to delete group.");
+      setShowDeleteConfirm(false);
+    }
+  }
+
+  async function handleRemoveMember(hostId: string) {
+    try {
+      await removeHosts({ groupId: group.id, hostIds: [hostId] });
+      toast.success("Host removed from group.");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to remove host.");
+    }
+  }
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 bg-black/40 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-label="Group details"
+        className={cn(
+          "fixed top-0 right-0 bottom-0 z-50",
+          "w-full max-w-110",
+          "bg-surface border-l border-border",
+          "flex flex-col overflow-hidden shadow-xl",
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 px-5 py-4 border-b border-border shrink-0">
+          <div className="flex flex-col gap-1.5 min-w-0">
+            <p className="text-xs text-text-muted">Group</p>
+            <div className="flex items-center gap-2 min-w-0">
+              {group.color && (
+                <span
+                  className="h-3 w-3 rounded-full shrink-0"
+                  style={{ backgroundColor: group.color }}
+                />
+              )}
+              <p className="text-sm font-medium text-text-primary truncate">
+                {group.name}
+              </p>
+            </div>
+            <p className="text-xs text-text-muted">
+              {group.member_count} member{group.member_count !== 1 ? "s" : ""}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close panel"
+            className="shrink-0 p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-5">
+          {/* Description */}
+          {group.description && (
+            <p className="text-xs text-text-secondary">{group.description}</p>
+          )}
+
+          {/* Meta */}
+          <div className="space-y-1.5">
+            <div className="flex gap-2 text-xs">
+              <span className="text-text-muted w-24 shrink-0">Created</span>
+              <span className="text-text-secondary">
+                {formatRelativeTime(group.created_at)}
+              </span>
+            </div>
+            <div className="flex gap-2 text-xs">
+              <span className="text-text-muted w-24 shrink-0">Updated</span>
+              <span className="text-text-secondary">
+                {formatRelativeTime(group.updated_at)}
+              </span>
+            </div>
+          </div>
+
+          {/* Members */}
+          <section>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-xs font-medium text-text-primary flex items-center gap-1.5">
+                <Users className="h-3.5 w-3.5 text-text-muted" />
+                Members
+              </h3>
+            </div>
+
+            {/* Member search */}
+            <div className="relative mb-2">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3 w-3 text-text-muted pointer-events-none" />
+              <input
+                type="text"
+                placeholder="Search members…"
+                value={memberSearch}
+                onChange={(e) => setMemberSearch(e.target.value)}
+                className={cn(
+                  "w-full pl-7 pr-3 py-1 text-xs rounded border border-border",
+                  "bg-surface text-text-primary placeholder:text-text-muted",
+                  "focus:outline-none focus:ring-1 focus:ring-border",
+                )}
+                aria-label="Search members"
+              />
+            </div>
+
+            {membersLoading ? (
+              <div className="space-y-2">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div key={i} className="flex gap-2">
+                    <Skeleton className="h-3 w-28" />
+                    <Skeleton className="h-3 w-20" />
+                  </div>
+                ))}
+              </div>
+            ) : filteredMembers.length === 0 ? (
+              <p className="text-xs text-text-muted">
+                {members.length === 0 ? "No members in this group." : "No results."}
+              </p>
+            ) : (
+              <div className="space-y-0.5">
+                {filteredMembers.map((m) => (
+                  <div
+                    key={m.id}
+                    className="flex items-center justify-between gap-2 py-1.5 border-b border-border/40 last:border-0"
+                  >
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className="font-mono text-xs text-text-primary shrink-0">
+                        {m.ip_address}
+                      </span>
+                      {m.hostname && (
+                        <span className="text-xs text-text-muted truncate">
+                          {m.hostname}
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <StatusBadge status={m.status ?? "unknown"} />
+                      <button
+                        type="button"
+                        aria-label={`Remove ${m.ip_address} from group`}
+                        onClick={() => void handleRemoveMember(m.id)}
+                        disabled={isRemoving}
+                        className="p-0.5 rounded text-text-muted hover:text-danger hover:bg-danger/10 transition-colors"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {!membersLoading && totalMemberPages > 1 && (
+              <PaginationBar
+                page={memberPage}
+                totalPages={totalMemberPages}
+                onPageChange={setMemberPage}
+                className="mt-3"
+              />
+            )}
+          </section>
+        </div>
+
+        {/* Footer */}
+        <div className="px-5 py-3 border-t border-border shrink-0 space-y-2">
+          <Button
+            icon={<Pencil className="h-3.5 w-3.5" />}
+            onClick={onEdit}
+            className="w-full justify-center"
+          >
+            Edit group
+          </Button>
+
+          {!showDeleteConfirm ? (
+            <button
+              type="button"
+              onClick={() => setShowDeleteConfirm(true)}
+              className="w-full flex items-center justify-center gap-1.5 text-xs text-text-muted hover:text-danger transition-colors py-1"
+            >
+              <Trash2 className="h-3 w-3" />
+              Delete group
+            </button>
+          ) : (
+            <div className="flex items-center justify-center gap-2">
+              <span className="text-xs text-text-muted">Delete this group?</span>
+              <Button
+                variant="danger"
+                onClick={() => void handleDelete()}
+                loading={isDeleting}
+                className="text-xs h-6 px-2"
+              >
+                Confirm
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={() => setShowDeleteConfirm(false)}
+                className="text-xs h-6 px-2"
+              >
+                Cancel
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Groups page ───────────────────────────────────────────────────────────────
+
+export function GroupsPage() {
+  const { toast } = useToast();
+  const [selectedGroup, setSelectedGroup] = useState<HostGroup | null>(null);
+  const [editingGroup, setEditingGroup] = useState<HostGroup | undefined>(undefined);
+  const [showFormModal, setShowFormModal] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const { data: groups = [], isLoading } = useGroups();
+
+  const filteredGroups = search.trim()
+    ? groups.filter(
+        (g) =>
+          g.name.toLowerCase().includes(search.toLowerCase()) ||
+          g.description?.toLowerCase().includes(search.toLowerCase()),
+      )
+    : groups;
+
+  const handleEdit = useCallback((group: HostGroup) => {
+    setEditingGroup(group);
+    setShowFormModal(true);
+  }, []);
+
+  const handleCloseForm = useCallback(() => {
+    setShowFormModal(false);
+    setEditingGroup(undefined);
+  }, []);
+
+  void toast; // used in sub-components
+
+  return (
+    <>
+      <div className="space-y-4">
+        {/* Toolbar */}
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="relative flex-1 min-w-40 max-w-sm">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-text-muted pointer-events-none" />
+            <input
+              type="text"
+              placeholder="Search groups…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className={cn(
+                "w-full pl-8 pr-3 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+              aria-label="Search groups"
+            />
+          </div>
+          <Button
+            icon={<Plus className="h-3.5 w-3.5" />}
+            onClick={() => {
+              setEditingGroup(undefined);
+              setShowFormModal(true);
+            }}
+            className="sm:ml-auto"
+          >
+            Create group
+          </Button>
+        </div>
+
+        {/* Table */}
+        <div className="bg-surface rounded-lg border border-border overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border bg-surface">
+                  <th className="text-left font-medium text-text-muted py-3 px-4">
+                    Name
+                  </th>
+                  <th className="text-left font-medium text-text-muted py-3 pr-4">
+                    Description
+                  </th>
+                  <th className="text-left font-medium text-text-muted py-3 pr-4">
+                    Members
+                  </th>
+                  <th className="text-left font-medium text-text-muted py-3 pr-4">
+                    Updated
+                  </th>
+                  <th className="py-3" />
+                </tr>
+              </thead>
+              <tbody>
+                {isLoading
+                  ? Array.from({ length: 6 }).map((_, i) => (
+                      <tr key={i} className="border-b border-border/50">
+                        <td className="py-3 px-4">
+                          <div className="flex items-center gap-2">
+                            <Skeleton className="h-3 w-3 rounded-full" />
+                            <Skeleton className="h-3.5 w-28" />
+                          </div>
+                        </td>
+                        <td className="py-3 pr-4">
+                          <Skeleton className="h-3.5 w-40" />
+                        </td>
+                        <td className="py-3 pr-4">
+                          <Skeleton className="h-3.5 w-8" />
+                        </td>
+                        <td className="py-3 pr-4">
+                          <Skeleton className="h-3.5 w-16" />
+                        </td>
+                        <td className="py-3" />
+                      </tr>
+                    ))
+                  : filteredGroups.length === 0
+                    ? (
+                      <tr>
+                        <td
+                          colSpan={5}
+                          className="py-12 text-center text-text-muted"
+                        >
+                          {search ? "No groups match your search." : "No groups found."}
+                        </td>
+                      </tr>
+                    )
+                    : filteredGroups.map((group) => (
+                      <tr
+                        key={group.id}
+                        onClick={() => setSelectedGroup(group)}
+                        className={cn(
+                          "border-b border-border/50 cursor-pointer transition-colors",
+                          "hover:bg-surface-raised",
+                          selectedGroup?.id === group.id && "bg-surface-raised",
+                        )}
+                      >
+                        <td className="py-3 px-4">
+                          <div className="flex items-center gap-2">
+                            <span
+                              className="h-2.5 w-2.5 rounded-full shrink-0"
+                              style={{ backgroundColor: group.color ?? "#64748b" }}
+                            />
+                            <span className="font-medium text-text-primary">
+                              {group.name}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="py-3 pr-4 text-text-secondary max-w-xs truncate">
+                          {group.description ?? "—"}
+                        </td>
+                        <td className="py-3 pr-4 text-text-secondary tabular-nums">
+                          {group.member_count}
+                        </td>
+                        <td className="py-3 pr-4 text-text-muted whitespace-nowrap">
+                          {formatRelativeTime(group.updated_at)}
+                        </td>
+                        <td className="py-3 pr-4">
+                          <button
+                            type="button"
+                            aria-label={`Edit ${group.name}`}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleEdit(group);
+                            }}
+                            className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface transition-colors opacity-0 group-hover:opacity-100"
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      {/* Detail panel */}
+      {selectedGroup && (
+        <GroupDetailPanel
+          group={selectedGroup}
+          onClose={() => setSelectedGroup(null)}
+          onEdit={() => handleEdit(selectedGroup)}
+        />
+      )}
+
+      {/* Create / edit modal */}
+      {showFormModal && (
+        <GroupFormModal group={editingGroup} onClose={handleCloseForm} />
+      )}
+    </>
+  );
+}

--- a/frontend/src/routes/hosts.test.tsx
+++ b/frontend/src/routes/hosts.test.tsx
@@ -17,6 +17,11 @@ vi.mock("../api/hooks/use-tags", () => ({
   useUpdateHostTags: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
 }));
 
+vi.mock("../api/hooks/use-groups", () => ({
+  useGroups: vi.fn(() => ({ data: [] })),
+  useAddHostsToGroup: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+}));
+
 import {
   useHosts,
   useHost,

--- a/frontend/src/routes/hosts.tsx
+++ b/frontend/src/routes/hosts.tsx
@@ -12,6 +12,7 @@ import {
   Activity,
   Play,
   SlidersHorizontal,
+  Plus,
 } from "lucide-react";
 import { SortHeader } from "../components/sort-header";
 import type { SortOrder } from "../components/sort-header";
@@ -42,6 +43,7 @@ import { TagInput } from "../components/tag-input";
 import type { FilterGroup } from "../lib/filter-expr";
 import { deserializeFilter, serializeFilter } from "../lib/filter-expr";
 import { useTags, useUpdateHostTags } from "../api/hooks/use-tags";
+import { useGroups, useAddHostsToGroup } from "../api/hooks/use-groups";
 
 type HostResponse = components["schemas"]["docs.HostResponse"];
 
@@ -68,6 +70,7 @@ type HostWithDetails = HostResponse & {
   response_time_max_ms?: number | null;
   response_time_avg_ms?: number | null;
   timeout_count?: number;
+  groups?: Array<{ id: string; name: string; color?: string }>;
 };
 
 const PAGE_SIZE = 25;
@@ -91,12 +94,14 @@ function HostDetailPanel({
   onScan,
   allTags,
   onTagFilter,
+  allGroups,
 }: {
   host: HostResponse;
   onClose: () => void;
   onScan: (ip: string) => void;
   allTags: string[];
   onTagFilter: (tag: string) => void;
+  allGroups: Array<{ id: string; name: string; color?: string }>;
 }) {
   const { data: full, isLoading, isError, error } = useHost(host.id ?? "");
   const h = (full ?? host) as HostWithDetails;
@@ -111,6 +116,12 @@ function HostDetailPanel({
   const { mutateAsync: updateTags } = useUpdateHostTags();
   const displayTags = localTags ?? (h.tags ?? []);
 
+  // Groups
+  const { mutateAsync: addToGroup, isPending: isAddingToGroup } = useAddHostsToGroup();
+  const [addGroupOpen, setAddGroupOpen] = useState(false);
+  const hostGroupIds = new Set((h.groups ?? []).map((g) => g.id));
+  const availableGroups = allGroups.filter((g) => !hostGroupIds.has(g.id));
+
   async function handleTagsChange(tags: string[]) {
     setLocalTags(tags);
     try {
@@ -118,6 +129,16 @@ function HostDetailPanel({
     } catch {
       setLocalTags(null);
       toast.error("Failed to update tags.");
+    }
+  }
+
+  async function handleAddToGroup(groupId: string) {
+    setAddGroupOpen(false);
+    try {
+      await addToGroup({ groupId, hostIds: [h.id ?? ""] });
+      toast.success("Host added to group.");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to add to group.");
     }
   }
 
@@ -398,6 +419,64 @@ function HostDetailPanel({
                     ))}
                   </div>
                 )}
+              </div>
+            )}
+          </section>
+
+          {/* Groups */}
+          <section>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-xs font-medium text-text-primary">Groups</h3>
+              {availableGroups.length > 0 && (
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => setAddGroupOpen((o) => !o)}
+                    disabled={isAddingToGroup}
+                    className="text-[11px] text-text-muted hover:text-text-primary transition-colors flex items-center gap-1"
+                  >
+                    <Plus className="h-3 w-3" /> Add to group
+                  </button>
+                  {addGroupOpen && (
+                    <div className="absolute right-0 top-full mt-1 z-30 w-44 bg-surface border border-border rounded-md shadow-lg py-1 max-h-40 overflow-y-auto">
+                      {availableGroups.map((g) => (
+                        <button
+                          key={g.id}
+                          type="button"
+                          onClick={() => void handleAddToGroup(g.id)}
+                          className="w-full text-left px-3 py-1.5 text-xs hover:bg-surface-raised flex items-center gap-2"
+                        >
+                          <span
+                            className="h-2 w-2 rounded-full shrink-0"
+                            style={{ backgroundColor: g.color ?? "#64748b" }}
+                          />
+                          <span className="truncate">{g.name}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+            {isLoading ? (
+              <Skeleton className="h-5 w-32 rounded" />
+            ) : (h.groups ?? []).length === 0 ? (
+              <p className="text-xs text-text-muted">Not in any group.</p>
+            ) : (
+              <div className="flex flex-wrap gap-1.5">
+                {(h.groups ?? []).map((g) => (
+                  <span
+                    key={g.id}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium border"
+                    style={{
+                      backgroundColor: g.color ? `${g.color}20` : undefined,
+                      borderColor: g.color ? `${g.color}50` : undefined,
+                      color: g.color ?? undefined,
+                    }}
+                  >
+                    {g.name}
+                  </span>
+                ))}
               </div>
             )}
           </section>
@@ -784,6 +863,7 @@ export function HostsPage() {
   const [selectedHost, setSelectedHost] = useState<HostResponse | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkScanIPs, setBulkScanIPs] = useState<string[] | null>(null);
+  const [bulkGroupOpen, setBulkGroupOpen] = useState(false);
   const [colVis, setColVis] = useState<Record<string, boolean>>(() =>
     Object.fromEntries(HOST_COLUMNS.map((c) => [c.key, true])),
   );
@@ -791,7 +871,10 @@ export function HostsPage() {
   const [activeFilter, setActiveFilter] = useState<FilterGroup | null>(null);
   const { mutateAsync: bulkDeleteHosts, isPending: isBulkDeleting } =
     useBulkDeleteHosts();
+  const { mutateAsync: bulkAddToGroup, isPending: isBulkAddingToGroup } =
+    useAddHostsToGroup();
   const { data: allTags = [] } = useTags();
+  const { data: allGroups = [] } = useGroups();
   const { toast } = useToast();
   const navigate = useNavigate();
   const search = useSearch({ from: "/hosts" });
@@ -962,6 +1045,17 @@ export function HostsPage() {
     }
   }
 
+  async function handleBulkAddToGroup(groupId: string) {
+    setBulkGroupOpen(false);
+    const ids = Array.from(selectedIds);
+    try {
+      const result = await bulkAddToGroup({ groupId, hostIds: ids });
+      toast.success(`Added ${result?.added ?? ids.length} host${ids.length !== 1 ? "s" : ""} to group.`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to add hosts to group.");
+    }
+  }
+
   return (
     <>
       <div className="space-y-4">
@@ -1101,12 +1195,17 @@ export function HostsPage() {
 
         {/* Filter builder panel */}
         {showFilterBuilder && (
-          <FilterBuilder value={activeFilter} onApply={handleApplyFilter} tagSuggestions={allTags} />
+          <FilterBuilder
+            value={activeFilter}
+            onApply={handleApplyFilter}
+            tagSuggestions={allTags}
+            groupOptions={allGroups.map((g) => ({ id: g.id, name: g.name }))}
+          />
         )}
 
         {/* Bulk action bar */}
         {selectedIds.size > 0 && (
-          <div className="flex items-center gap-3 px-4 py-2 rounded-lg border border-border bg-surface-raised text-xs">
+          <div className="flex items-center gap-3 px-4 py-2 rounded-lg border border-border bg-surface-raised text-xs flex-wrap">
             <span className="text-text-secondary font-medium">
               {selectedIds.size} selected
             </span>
@@ -1117,6 +1216,36 @@ export function HostsPage() {
             >
               Scan selected
             </Button>
+            {allGroups.length > 0 && (
+              <div className="relative">
+                <Button
+                  icon={<Plus className="h-3.5 w-3.5" />}
+                  onClick={() => setBulkGroupOpen((o) => !o)}
+                  loading={isBulkAddingToGroup}
+                  className="text-xs h-7 px-2"
+                >
+                  Add to group
+                </Button>
+                {bulkGroupOpen && (
+                  <div className="absolute left-0 top-full mt-1 z-30 w-44 bg-surface border border-border rounded-md shadow-lg py-1 max-h-48 overflow-y-auto">
+                    {allGroups.map((g) => (
+                      <button
+                        key={g.id}
+                        type="button"
+                        onClick={() => void handleBulkAddToGroup(g.id)}
+                        className="w-full text-left px-3 py-1.5 text-xs hover:bg-surface-raised flex items-center gap-2"
+                      >
+                        <span
+                          className="h-2 w-2 rounded-full shrink-0"
+                          style={{ backgroundColor: g.color ?? "#64748b" }}
+                        />
+                        <span className="truncate">{g.name}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
             <Button
               variant="danger"
               icon={<Trash2 className="h-3.5 w-3.5" />}
@@ -1462,6 +1591,7 @@ export function HostsPage() {
             });
             setShowFilterBuilder(true);
           }}
+          allGroups={allGroups}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

- **Groups page** (`/groups`): list with color-coded table, create/edit modal with preset color swatches, slide-in detail panel with paginated member list and per-member remove
- **Sidebar** + **router**: Groups nav item (`Layers` icon) and route registration
- **Groups API hooks** (`use-groups.ts`): full CRUD + membership — `useGroups`, `useGroupMembers`, `useCreateGroup`, `useUpdateGroup`, `useDeleteGroup`, `useAddHostsToGroup`, `useRemoveHostsFromGroup`
- **FilterBuilder**: group condition renders as a dropdown of group names; `groupOptions` prop threaded through all levels
- **Hosts page enhancements**: group badges in host detail panel, "Add to group" dropdown per-host, bulk "Add to group" in multi-select bar, `groupOptions` passed to `FilterBuilder`

## Test plan

- [x] 24 new tests for `GroupsPage` — toolbar, loading skeleton, empty state, table structure, search filtering, detail panel (open/close/members/delete confirm/edit), create/edit modals
- [x] Existing hosts tests updated with `use-groups` mock (`useGroups`, `useAddHostsToGroup`)
- [x] 859 total tests, all passing
- [x] TypeScript strict mode — 0 errors
- [x] Lint — 0 issues
- [x] Pre-push hook (Go + Vitest) — passed

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)