### PR TITLE
feat(dashboard-settings): stats summary, activity feed, and settings editor

### DIFF
--- a/frontend/src/api/hooks/use-dashboard.ts
+++ b/frontend/src/api/hooks/use-dashboard.ts
@@ -1,0 +1,76 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? "/api/v1";
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, init);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw Object.assign(new Error("API error"), { status: res.status, body });
+  }
+  return res.json() as Promise<T>;
+}
+
+// ── Stats summary ─────────────────────────────────────────────────────────────
+
+export interface OSFamilyCount {
+  family: string;
+  count: number;
+}
+
+export interface PortCount {
+  port: number;
+  count: number;
+}
+
+export interface StatsSummary {
+  hosts_by_status: Record<string, number>;
+  hosts_by_os_family: OSFamilyCount[];
+  top_ports: PortCount[];
+  stale_host_count: number;
+  avg_scan_duration_s: number;
+}
+
+export function useStatsSummary() {
+  return useQuery({
+    queryKey: ["stats", "summary"],
+    queryFn: () => apiFetch<StatsSummary>("/stats/summary"),
+    refetchInterval: 60_000,
+  });
+}
+
+// ── Settings ──────────────────────────────────────────────────────────────────
+
+export interface AppSetting {
+  key: string;
+  value: string;
+  type: string;
+  description: string;
+  updated_at: string;
+}
+
+export function useSettings() {
+  return useQuery({
+    queryKey: ["admin", "settings"],
+    queryFn: () =>
+      apiFetch<{ settings: AppSetting[] }>("/admin/settings").then(
+        (d) => d.settings,
+      ),
+    refetchInterval: false,
+  });
+}
+
+export function useUpdateSetting() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ key, value }: { key: string; value: string }) =>
+      apiFetch<{ key: string; updated: boolean }>("/admin/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key, value }),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["admin", "settings"] });
+    },
+  });
+}

--- a/frontend/src/components/activity-feed.test.tsx
+++ b/frontend/src/components/activity-feed.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ActivityFeed } from "./activity-feed";
+import type { ActivityEvent } from "../hooks/use-activity-feed";
+import type { WsStatus } from "../lib/ws";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("../hooks/use-activity-feed", () => ({
+  useActivityFeed: vi.fn(() => []),
+}));
+
+vi.mock("../lib/use-ws", () => ({
+  useWsStatus: vi.fn(() => "disconnected" as WsStatus),
+}));
+
+import { useActivityFeed } from "../hooks/use-activity-feed";
+import { useWsStatus } from "../lib/use-ws";
+
+const mockUseActivityFeed = vi.mocked(useActivityFeed);
+const mockUseWsStatus = vi.mocked(useWsStatus);
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeEvent(overrides: Partial<ActivityEvent>): ActivityEvent {
+  return {
+    id: "ev-1",
+    kind: "scan_started",
+    title: "Scan started",
+    detail: "Scan #1",
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseActivityFeed.mockReturnValue([]);
+  mockUseWsStatus.mockReturnValue("disconnected");
+});
+
+describe("ActivityFeed", () => {
+  // ── Empty state ─────────────────────────────────────────────────────────────
+
+  it("shows empty state when no events", () => {
+    render(<ActivityFeed />);
+    expect(screen.getByText("No recent activity")).toBeInTheDocument();
+  });
+
+  it("shows Activity header label", () => {
+    render(<ActivityFeed />);
+    expect(screen.getByText("Activity")).toBeInTheDocument();
+  });
+
+  // ── WS status badge ─────────────────────────────────────────────────────────
+
+  it("shows Live badge when connected", () => {
+    mockUseWsStatus.mockReturnValue("connected");
+    render(<ActivityFeed />);
+    expect(screen.getByText("Live")).toBeInTheDocument();
+  });
+
+  it("shows Connecting badge when connecting", () => {
+    mockUseWsStatus.mockReturnValue("connecting");
+    render(<ActivityFeed />);
+    expect(screen.getByText("Connecting…")).toBeInTheDocument();
+  });
+
+  it("shows Disconnected badge when disconnected", () => {
+    mockUseWsStatus.mockReturnValue("disconnected");
+    render(<ActivityFeed />);
+    expect(screen.getByText("Disconnected")).toBeInTheDocument();
+  });
+
+  // ── Event rendering ─────────────────────────────────────────────────────────
+
+  it("renders event title and detail", () => {
+    mockUseActivityFeed.mockReturnValue([
+      makeEvent({ title: "Scan started", detail: "Scan #42" }),
+    ]);
+    render(<ActivityFeed />);
+    expect(screen.getByText("Scan started")).toBeInTheDocument();
+    expect(screen.getByText("Scan #42")).toBeInTheDocument();
+  });
+
+  it("renders multiple events", () => {
+    mockUseActivityFeed.mockReturnValue([
+      makeEvent({ id: "1", title: "Scan started", detail: "Scan #1" }),
+      makeEvent({ id: "2", title: "Discovery completed", detail: "No changes", kind: "discovery_completed" }),
+    ]);
+    render(<ActivityFeed />);
+    expect(screen.getByText("Scan started")).toBeInTheDocument();
+    expect(screen.getByText("Discovery completed")).toBeInTheDocument();
+  });
+
+  it("renders event with href as a link", () => {
+    mockUseActivityFeed.mockReturnValue([
+      makeEvent({ href: "/scans" }),
+    ]);
+    render(<ActivityFeed />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "#/scans");
+  });
+
+  it("renders event without href as a div (no link)", () => {
+    mockUseActivityFeed.mockReturnValue([
+      makeEvent({ href: undefined }),
+    ]);
+    render(<ActivityFeed />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("limits display to 20 events even if more are provided", () => {
+    const events: ActivityEvent[] = Array.from({ length: 25 }, (_, i) =>
+      makeEvent({ id: String(i), title: `Event ${i}` }),
+    );
+    mockUseActivityFeed.mockReturnValue(events);
+    render(<ActivityFeed />);
+
+    // Events 0-19 visible, 20-24 not
+    expect(screen.getByText("Event 0")).toBeInTheDocument();
+    expect(screen.getByText("Event 19")).toBeInTheDocument();
+    expect(screen.queryByText("Event 20")).not.toBeInTheDocument();
+  });
+
+  // ── Event kinds ─────────────────────────────────────────────────────────────
+
+  it.each([
+    "scan_started",
+    "scan_completed",
+    "scan_failed",
+    "discovery_started",
+    "discovery_completed",
+    "host_status_change",
+  ] as const)("renders %s event without error", (kind) => {
+    mockUseActivityFeed.mockReturnValue([makeEvent({ kind, title: kind })]);
+    render(<ActivityFeed />);
+    expect(screen.getByText(kind)).toBeInTheDocument();
+  });
+
+  it("does not show 'No recent activity' when events exist", () => {
+    mockUseActivityFeed.mockReturnValue([makeEvent({})]);
+    render(<ActivityFeed />);
+    expect(screen.queryByText("No recent activity")).not.toBeInTheDocument();
+  });
+
+  it("omits detail paragraph when detail is empty string", () => {
+    mockUseActivityFeed.mockReturnValue([
+      makeEvent({ title: "Scan started", detail: "" }),
+    ]);
+    render(<ActivityFeed />);
+    // The title is rendered but detail paragraph should not appear
+    expect(screen.getByText("Scan started")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/activity-feed.tsx
+++ b/frontend/src/components/activity-feed.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useRef } from "react";
+import {
+  ScanLine,
+  CheckCircle2,
+  XCircle,
+  ScanSearch,
+  Server,
+  Radio,
+} from "lucide-react";
+import { cn, formatRelativeTime } from "../lib/utils";
+import { useActivityFeed } from "../hooks/use-activity-feed";
+import { useWsStatus } from "../lib/use-ws";
+import type { ActivityEventKind } from "../hooks/use-activity-feed";
+
+// ── Icon + color per event kind ───────────────────────────────────────────────
+
+function eventIcon(kind: ActivityEventKind) {
+  switch (kind) {
+    case "scan_started":
+      return ScanLine;
+    case "scan_completed":
+      return CheckCircle2;
+    case "scan_failed":
+      return XCircle;
+    case "discovery_started":
+    case "discovery_completed":
+      return ScanSearch;
+    case "host_status_change":
+      return Server;
+  }
+}
+
+function eventColorClass(kind: ActivityEventKind): string {
+  switch (kind) {
+    case "scan_started":
+      return "text-accent";
+    case "scan_completed":
+      return "text-success";
+    case "scan_failed":
+      return "text-danger";
+    case "discovery_started":
+      return "text-accent";
+    case "discovery_completed":
+      return "text-success";
+    case "host_status_change":
+      return "text-warning";
+  }
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function ActivityFeed() {
+  const events = useActivityFeed();
+  const wsStatus = useWsStatus();
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // Auto-scroll to top when new event arrives
+  useEffect(() => {
+    if (listRef.current) {
+      listRef.current.scrollTop = 0;
+    }
+  }, [events.length]);
+
+  return (
+    <div className="bg-surface rounded-lg border border-border overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <div className="flex items-center gap-2">
+          <Radio className="h-4 w-4 text-text-muted" />
+          <span className="text-xs font-medium text-text-primary">
+            Activity
+          </span>
+        </div>
+        <span
+          className={cn(
+            "text-[10px] font-medium px-1.5 py-0.5 rounded",
+            wsStatus === "connected"
+              ? "bg-success/15 text-success"
+              : wsStatus === "connecting"
+                ? "bg-warning/15 text-warning"
+                : "bg-text-muted/15 text-text-muted",
+          )}
+        >
+          {wsStatus === "connected"
+            ? "Live"
+            : wsStatus === "connecting"
+              ? "Connecting…"
+              : "Disconnected"}
+        </span>
+      </div>
+
+      {/* Feed */}
+      <ul
+        ref={listRef}
+        className="max-h-72 overflow-y-auto divide-y divide-border/40"
+      >
+        {events.length === 0 ? (
+          <li className="px-4 py-8 text-center text-xs text-text-muted">
+            No recent activity
+          </li>
+        ) : (
+          events.slice(0, 20).map((ev) => {
+            const Icon = eventIcon(ev.kind);
+            return (
+              <li key={ev.id}>
+                {ev.href ? (
+                  <a
+                    href={`#${ev.href}`}
+                    className="flex items-start gap-3 px-4 py-2.5 hover:bg-surface-raised transition-colors"
+                  >
+                    <Icon
+                      className={cn(
+                        "h-3.5 w-3.5 shrink-0 mt-0.5",
+                        eventColorClass(ev.kind),
+                      )}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xs font-medium text-text-primary truncate">
+                        {ev.title}
+                      </p>
+                      {ev.detail && (
+                        <p className="text-[11px] text-text-muted truncate">
+                          {ev.detail}
+                        </p>
+                      )}
+                    </div>
+                    <span className="text-[10px] text-text-muted whitespace-nowrap shrink-0 mt-0.5">
+                      {formatRelativeTime(ev.timestamp)}
+                    </span>
+                  </a>
+                ) : (
+                  <div className="flex items-start gap-3 px-4 py-2.5">
+                    <Icon
+                      className={cn(
+                        "h-3.5 w-3.5 shrink-0 mt-0.5",
+                        eventColorClass(ev.kind),
+                      )}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xs font-medium text-text-primary truncate">
+                        {ev.title}
+                      </p>
+                      {ev.detail && (
+                        <p className="text-[11px] text-text-muted truncate">
+                          {ev.detail}
+                        </p>
+                      )}
+                    </div>
+                    <span className="text-[10px] text-text-muted whitespace-nowrap shrink-0 mt-0.5">
+                      {formatRelativeTime(ev.timestamp)}
+                    </span>
+                  </div>
+                )}
+              </li>
+            );
+          })
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/hooks/use-activity-feed.test.ts
+++ b/frontend/src/hooks/use-activity-feed.test.ts
@@ -1,0 +1,375 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock use-ws before importing the hook under test.
+const mockOn = vi.fn();
+const mockManager = { on: mockOn };
+
+vi.mock("../lib/use-ws", () => ({
+  useWs: vi.fn(() => ({ manager: mockManager })),
+}));
+
+import { useActivityFeed } from "./use-activity-feed";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+type EventCallback = (msg: object) => void;
+
+/**
+ * Returns the registered handler for a given WS event type, or throws if none.
+ * Relies on mockOn having been called as: manager.on("event_type", handler).
+ */
+function getHandler(eventType: string): EventCallback {
+  const call = mockOn.mock.calls.find((c) => c[0] === eventType);
+  if (!call) throw new Error(`No handler registered for "${eventType}"`);
+  return call[1] as EventCallback;
+}
+
+function ts() {
+  return new Date().toISOString();
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Reset so each test has a fresh subscription list.
+  mockOn.mockReturnValue(() => {}); // returns an unsubscribe fn
+});
+
+describe("useActivityFeed", () => {
+  it("returns empty array initially", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    expect(result.current).toEqual([]);
+  });
+
+  it("subscribes to scan_update, discovery_update, host_status_change", () => {
+    renderHook(() => useActivityFeed());
+    const eventTypes = mockOn.mock.calls.map((c) => c[0]);
+    expect(eventTypes).toContain("scan_update");
+    expect(eventTypes).toContain("discovery_update");
+    expect(eventTypes).toContain("host_status_change");
+  });
+
+  // ── scan_update ────────────────────────────────────────────────────────────
+
+  it("adds scan_started event on running status", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("scan_update");
+
+    act(() => {
+      handler({ data: { scan_id: "42", status: "running" }, timestamp: ts() });
+    });
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].kind).toBe("scan_started");
+    expect(result.current[0].title).toBe("Scan started");
+    expect(result.current[0].detail).toBe("Scan #42");
+  });
+
+  it("adds scan_started event on queued status", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("scan_update");
+
+    act(() => {
+      handler({ data: { scan_id: "7", status: "queued" }, timestamp: ts() });
+    });
+
+    expect(result.current[0].kind).toBe("scan_started");
+  });
+
+  it("adds scan_completed event with results count", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("scan_update");
+
+    act(() => {
+      handler({
+        data: { scan_id: "1", status: "completed", results_count: 5 },
+        timestamp: ts(),
+      });
+    });
+
+    expect(result.current[0].kind).toBe("scan_completed");
+    expect(result.current[0].title).toBe("Scan completed");
+    expect(result.current[0].detail).toContain("5 results");
+  });
+
+  it("adds scan_failed event with error message", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("scan_update");
+
+    act(() => {
+      handler({
+        data: { scan_id: "2", status: "failed", error: "nmap not found" },
+        timestamp: ts(),
+      });
+    });
+
+    expect(result.current[0].kind).toBe("scan_failed");
+    expect(result.current[0].detail).toContain("nmap not found");
+  });
+
+  it("adds scan_failed event on error status", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("scan_update");
+
+    act(() => {
+      handler({ data: { scan_id: "3", status: "error" }, timestamp: ts() });
+    });
+
+    expect(result.current[0].kind).toBe("scan_failed");
+  });
+
+  it("suppresses duplicate scan status ticks", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("scan_update");
+    const now = ts();
+
+    act(() => {
+      handler({ data: { scan_id: "5", status: "running" }, timestamp: now });
+      handler({ data: { scan_id: "5", status: "running" }, timestamp: now });
+      handler({ data: { scan_id: "5", status: "running" }, timestamp: now });
+    });
+
+    // Only the first transition fires.
+    expect(result.current).toHaveLength(1);
+  });
+
+  it("fires again when scan transitions to a new status", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("scan_update");
+
+    act(() => {
+      handler({ data: { scan_id: "6", status: "running" }, timestamp: ts() });
+      handler({ data: { scan_id: "6", status: "completed" }, timestamp: ts() });
+    });
+
+    expect(result.current).toHaveLength(2);
+    expect(result.current[0].kind).toBe("scan_completed"); // newest first
+    expect(result.current[1].kind).toBe("scan_started");
+  });
+
+  it("ignores scan_update with unknown status", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("scan_update");
+
+    act(() => {
+      handler({ data: { scan_id: "9", status: "pending" }, timestamp: ts() });
+    });
+
+    expect(result.current).toHaveLength(0);
+  });
+
+  // ── discovery_update ───────────────────────────────────────────────────────
+
+  it("adds discovery_started event on running status", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("discovery_update");
+
+    act(() => {
+      handler({
+        data: { job_id: "abc123def", status: "running" },
+        timestamp: ts(),
+      });
+    });
+
+    expect(result.current[0].kind).toBe("discovery_started");
+    expect(result.current[0].detail).toContain("abc123de");
+  });
+
+  it("adds discovery_completed event with new/gone counts", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("discovery_update");
+
+    act(() => {
+      handler({
+        data: {
+          job_id: "xyz",
+          status: "completed",
+          new_hosts_count: 3,
+          gone_hosts_count: 1,
+        },
+        timestamp: ts(),
+      });
+    });
+
+    expect(result.current[0].kind).toBe("discovery_completed");
+    expect(result.current[0].detail).toContain("+3 new");
+    expect(result.current[0].detail).toContain("-1 gone");
+  });
+
+  it("adds discovery_completed with 'No changes' when counts are zero", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("discovery_update");
+
+    act(() => {
+      handler({
+        data: { job_id: "no-change", status: "completed" },
+        timestamp: ts(),
+      });
+    });
+
+    expect(result.current[0].detail).toBe("No changes");
+  });
+
+  it("suppresses duplicate discovery status ticks", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("discovery_update");
+
+    act(() => {
+      handler({ data: { job_id: "j1", status: "running" }, timestamp: ts() });
+      handler({ data: { job_id: "j1", status: "running" }, timestamp: ts() });
+    });
+
+    expect(result.current).toHaveLength(1);
+  });
+
+  it("ignores discovery_update with unknown status", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("discovery_update");
+
+    act(() => {
+      handler({ data: { job_id: "j2", status: "queued" }, timestamp: ts() });
+    });
+
+    expect(result.current).toHaveLength(0);
+  });
+
+  // ── host_status_change ─────────────────────────────────────────────────────
+
+  it("adds host_status_change event for host going up", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("host_status_change");
+
+    act(() => {
+      handler({
+        data: { ip_address: "192.168.1.1", new_status: "up" },
+        timestamp: ts(),
+      });
+    });
+
+    expect(result.current[0].kind).toBe("host_status_change");
+    expect(result.current[0].title).toBe("Host online");
+    expect(result.current[0].detail).toBe("192.168.1.1");
+  });
+
+  it("adds host_status_change event for host going down", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("host_status_change");
+
+    act(() => {
+      handler({
+        data: { ip_address: "10.0.0.5", new_status: "down" },
+        timestamp: ts(),
+      });
+    });
+
+    expect(result.current[0].title).toBe("Host offline");
+  });
+
+  it("adds host_status_change event for host gone", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("host_status_change");
+
+    act(() => {
+      handler({
+        data: { ip_address: "10.0.0.9", new_status: "gone" },
+        timestamp: ts(),
+      });
+    });
+
+    expect(result.current[0].title).toBe("Host gone");
+  });
+
+  it("uses generic title for unknown host status", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("host_status_change");
+
+    act(() => {
+      handler({
+        data: { ip_address: "10.0.0.8", new_status: "unknown" },
+        timestamp: ts(),
+      });
+    });
+
+    expect(result.current[0].title).toBe("Host status changed");
+  });
+
+  it("ignores host_status_change with no ip_address", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("host_status_change");
+
+    act(() => {
+      handler({ data: { new_status: "up" }, timestamp: ts() });
+    });
+
+    expect(result.current).toHaveLength(0);
+  });
+
+  it("ignores host_status_change with no status", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("host_status_change");
+
+    act(() => {
+      handler({ data: { ip_address: "10.0.0.1" }, timestamp: ts() });
+    });
+
+    expect(result.current).toHaveLength(0);
+  });
+
+  // ── General ───────────────────────────────────────────────────────────────
+
+  it("deduplicates events by id", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("host_status_change");
+    const fixedTs = "2025-01-01T00:00:00.000Z";
+
+    act(() => {
+      // Same ip + status + timestamp → same id → should only appear once
+      handler({ data: { ip_address: "10.0.0.1", new_status: "up" }, timestamp: fixedTs });
+      handler({ data: { ip_address: "10.0.0.1", new_status: "up" }, timestamp: fixedTs });
+    });
+
+    expect(result.current).toHaveLength(1);
+  });
+
+  it("prepends new events (newest first)", () => {
+    const { result } = renderHook(() => useActivityFeed());
+    const handler = getHandler("host_status_change");
+
+    act(() => {
+      handler({ data: { ip_address: "10.0.0.1", new_status: "up" }, timestamp: ts() });
+      handler({ data: { ip_address: "10.0.0.2", new_status: "down" }, timestamp: ts() });
+    });
+
+    expect(result.current[0].detail).toBe("10.0.0.2"); // newest first
+    expect(result.current[1].detail).toBe("10.0.0.1");
+  });
+
+  it("unsubscribes all handlers on unmount", () => {
+    const unsub1 = vi.fn();
+    const unsub2 = vi.fn();
+    const unsub3 = vi.fn();
+    mockOn
+      .mockReturnValueOnce(unsub1)
+      .mockReturnValueOnce(unsub2)
+      .mockReturnValueOnce(unsub3);
+
+    const { unmount } = renderHook(() => useActivityFeed());
+    unmount();
+
+    expect(unsub1).toHaveBeenCalled();
+    expect(unsub2).toHaveBeenCalled();
+    expect(unsub3).toHaveBeenCalled();
+  });
+
+  it("does nothing when manager is null", async () => {
+    const { useWs } = await import("../lib/use-ws");
+    vi.mocked(useWs).mockReturnValueOnce({ manager: null, status: "disconnected" });
+
+    const { result } = renderHook(() => useActivityFeed());
+    expect(result.current).toEqual([]);
+    // No subscriptions should have been attempted
+    expect(mockOn).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/use-activity-feed.ts
+++ b/frontend/src/hooks/use-activity-feed.ts
@@ -1,0 +1,185 @@
+import { useState, useEffect, useRef } from "react";
+import { useWs } from "../lib/use-ws";
+import type { WsMessage } from "../lib/ws";
+
+// ── Event model ───────────────────────────────────────────────────────────────
+
+export type ActivityEventKind =
+  | "scan_started"
+  | "scan_completed"
+  | "scan_failed"
+  | "discovery_started"
+  | "discovery_completed"
+  | "host_status_change";
+
+export interface ActivityEvent {
+  id: string;
+  kind: ActivityEventKind;
+  title: string;
+  detail: string;
+  timestamp: string;
+  href?: string; // optional navigation target
+}
+
+const MAX_EVENTS = 100;
+
+// ── Parsers ───────────────────────────────────────────────────────────────────
+
+function parseScanUpdate(msg: WsMessage): ActivityEvent | null {
+  const d = msg.data as Record<string, unknown>;
+  const scanId = String(d.scan_id ?? "");
+  const status = String(d.status ?? "");
+  const ts = (msg.timestamp as string) ?? new Date().toISOString();
+
+  if (status === "running" || status === "queued") {
+    return {
+      id: `scan-${scanId}-started-${ts}`,
+      kind: "scan_started",
+      title: "Scan started",
+      detail: scanId ? `Scan #${scanId}` : "Scan",
+      timestamp: ts,
+      href: scanId ? `/scans` : undefined,
+    };
+  }
+  if (status === "completed") {
+    const count = d.results_count as number | undefined;
+    return {
+      id: `scan-${scanId}-completed-${ts}`,
+      kind: "scan_completed",
+      title: "Scan completed",
+      detail: `${count != null ? `${count} results` : ""}${scanId ? ` · #${scanId}` : ""}`.trim(),
+      timestamp: ts,
+      href: `/scans`,
+    };
+  }
+  if (status === "failed" || status === "error") {
+    const errMsg = d.error ? String(d.error) : "Unknown error";
+    return {
+      id: `scan-${scanId}-failed-${ts}`,
+      kind: "scan_failed",
+      title: "Scan failed",
+      detail: errMsg.slice(0, 80),
+      timestamp: ts,
+      href: `/scans`,
+    };
+  }
+  return null;
+}
+
+function parseDiscoveryUpdate(msg: WsMessage): ActivityEvent | null {
+  const d = msg.data as Record<string, unknown>;
+  const jobId = String(d.job_id ?? "");
+  const status = String(d.status ?? "");
+  const ts = (msg.timestamp as string) ?? new Date().toISOString();
+
+  if (status === "running") {
+    return {
+      id: `disc-${jobId}-started-${ts}`,
+      kind: "discovery_started",
+      title: "Discovery started",
+      detail: jobId ? `Job ${jobId.slice(0, 8)}` : "Discovery",
+      timestamp: ts,
+      href: `/discovery`,
+    };
+  }
+  if (status === "completed") {
+    const newH = (d.new_hosts_count as number | undefined) ?? 0;
+    const goneH = (d.gone_hosts_count as number | undefined) ?? 0;
+    const detail = [
+      newH > 0 ? `+${newH} new` : "",
+      goneH > 0 ? `-${goneH} gone` : "",
+    ]
+      .filter(Boolean)
+      .join(", ");
+    return {
+      id: `disc-${jobId}-completed-${ts}`,
+      kind: "discovery_completed",
+      title: "Discovery completed",
+      detail: detail || "No changes",
+      timestamp: ts,
+      href: `/discovery`,
+    };
+  }
+  return null;
+}
+
+function parseHostStatusChange(msg: WsMessage): ActivityEvent | null {
+  const d = msg.data as Record<string, unknown>;
+  const ip = String(d.ip_address ?? "");
+  const newStatus = String(d.new_status ?? d.status ?? "");
+  const ts = (msg.timestamp as string) ?? new Date().toISOString();
+
+  if (!ip || !newStatus) return null;
+
+  const title =
+    newStatus === "up"
+      ? "Host online"
+      : newStatus === "down"
+        ? "Host offline"
+        : newStatus === "gone"
+          ? "Host gone"
+          : "Host status changed";
+
+  return {
+    id: `host-${ip}-${newStatus}-${ts}`,
+    kind: "host_status_change",
+    title,
+    detail: ip,
+    timestamp: ts,
+    href: `/hosts`,
+  };
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+export function useActivityFeed(): ActivityEvent[] {
+  const [events, setEvents] = useState<ActivityEvent[]>([]);
+  const { manager } = useWs();
+  // Track last-seen scan/discovery state to suppress duplicate progress ticks
+  const lastScanStatus = useRef<Record<string, string>>({});
+  const lastDiscStatus = useRef<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!manager) return;
+
+    function addEvent(ev: ActivityEvent | null) {
+      if (!ev) return;
+      setEvents((prev) => {
+        // Deduplicate by id
+        if (prev.some((e) => e.id === ev.id)) return prev;
+        return [ev, ...prev].slice(0, MAX_EVENTS);
+      });
+    }
+
+    const unsubScan = manager.on("scan_update", (msg: WsMessage) => {
+      const d = msg.data as Record<string, unknown>;
+      const scanId = String(d.scan_id ?? "");
+      const status = String(d.status ?? "");
+      // Only fire on state transitions, not repeated progress ticks
+      if (lastScanStatus.current[scanId] === status) return;
+      lastScanStatus.current[scanId] = status;
+      addEvent(parseScanUpdate(msg));
+    });
+
+    const unsubDisc = manager.on("discovery_update", (msg: WsMessage) => {
+      const d = msg.data as Record<string, unknown>;
+      const jobId = String(d.job_id ?? "");
+      const status = String(d.status ?? "");
+      if (lastDiscStatus.current[jobId] === status) return;
+      lastDiscStatus.current[jobId] = status;
+      addEvent(parseDiscoveryUpdate(msg));
+    });
+
+    const unsubHost = manager.on("host_status_change", (msg: WsMessage) => {
+      addEvent(parseHostStatusChange(msg));
+    });
+
+    return () => {
+      unsubScan();
+      unsubDisc();
+      unsubHost();
+    };
+  }, [manager]);
+
+  return events;
+}

--- a/frontend/src/routes/admin.tsx
+++ b/frontend/src/routes/admin.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   Server,
   Activity,
@@ -8,15 +9,20 @@ import {
   GitCommit,
   Package,
   AlertCircle,
+  Save,
+  AlertTriangle,
 } from "lucide-react";
 import {
   useAdminStatus,
   useWorkers,
   useVersion,
 } from "../api/hooks/use-system";
+import { useSettings, useUpdateSetting } from "../api/hooks/use-dashboard";
 import { StatusBadge, Skeleton } from "../components";
 import { cn, formatRelativeTime } from "../lib/utils";
 import { LogViewer } from "../components/log-viewer";
+import { Button } from "../components/button";
+import { useToast } from "../components/toast-provider";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -366,23 +372,192 @@ function WorkersCard() {
   );
 }
 
-// ── Section 3 — Stub cards ─────────────────────────────────────────────────────
+// ── Section 3 — Settings editor ───────────────────────────────────────────────
 
-function StubCard({
-  icon: Icon,
-  title,
+const SETTING_SECTIONS: Record<string, { label: string; keys: string[] }> = {
+  scanning: {
+    label: "Scanning",
+    keys: ["scan.default_timing", "scan.max_concurrent"],
+  },
+  discovery: {
+    label: "Discovery",
+    keys: ["discovery.ping_timeout_ms", "discovery.methods"],
+  },
+  retention: {
+    label: "Data Retention",
+    keys: ["retention.auto_purge_days", "retention.max_scan_history"],
+  },
+  notifications: {
+    label: "Notifications",
+    keys: [
+      "notifications.scan_complete",
+      "notifications.host_down",
+      "notifications.new_host",
+    ],
+  },
+};
+
+// Keys that require server restart to take effect
+const RESTART_REQUIRED = new Set<string>([]);
+
+function SettingField({
+  setting,
 }: {
-  icon: React.ElementType;
-  title: string;
+  setting: { key: string; value: string; type: string; description: string };
 }) {
+  const { toast } = useToast();
+  const [localValue, setLocalValue] = useState(setting.value);
+  const [dirty, setDirty] = useState(false);
+  const { mutateAsync: updateSetting, isPending } = useUpdateSetting();
+
+  const needsRestart = RESTART_REQUIRED.has(setting.key);
+
+  function handleChange(v: string) {
+    setLocalValue(v);
+    setDirty(v !== setting.value);
+  }
+
+  async function handleSave() {
+    // Serialize value correctly
+    let jsonValue: string;
+    if (setting.type === "bool") {
+      jsonValue = localValue === "true" ? "true" : "false";
+    } else if (setting.type === "int") {
+      const n = parseInt(localValue, 10);
+      jsonValue = isNaN(n) ? setting.value : String(n);
+    } else {
+      jsonValue = localValue;
+    }
+    try {
+      await updateSetting({ key: setting.key, value: jsonValue });
+      setDirty(false);
+      toast.success("Setting saved.");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to save setting.");
+    }
+  }
+
+  const label = setting.key.split(".").pop()!.replace(/_/g, " ");
+
   return (
-    <div className="bg-surface rounded-lg border border-border p-4">
-      <div className="flex items-center gap-2 mb-3">
-        <Icon className="h-4 w-4 text-text-muted" />
-        <span className="text-xs font-medium text-text-primary">{title}</span>
+    <div className="flex items-start gap-3 py-2.5 border-b border-border/40 last:border-0">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5 mb-0.5">
+          <span className="text-xs font-medium text-text-primary capitalize">
+            {label}
+          </span>
+          {needsRestart && (
+            <span
+              title="Requires server restart"
+              className="inline-flex items-center gap-0.5 text-[10px] text-warning"
+            >
+              <AlertTriangle className="h-3 w-3" />
+              restart required
+            </span>
+          )}
+        </div>
+        {setting.description && (
+          <p className="text-[11px] text-text-muted">{setting.description}</p>
+        )}
       </div>
-      <div className="h-px bg-border mb-3" />
-      <p className="text-xs text-text-muted">Coming soon</p>
+      <div className="flex items-center gap-2 shrink-0">
+        {setting.type === "bool" ? (
+          <select
+            value={localValue}
+            onChange={(e) => handleChange(e.target.value)}
+            className={cn(
+              "px-2 py-1 text-xs rounded border border-border",
+              "bg-surface text-text-primary",
+              "focus:outline-none focus:ring-1 focus:ring-border",
+            )}
+          >
+            <option value="true">Enabled</option>
+            <option value="false">Disabled</option>
+          </select>
+        ) : (
+          <input
+            type={setting.type === "int" ? "number" : "text"}
+            value={localValue}
+            onChange={(e) => handleChange(e.target.value)}
+            className={cn(
+              "px-2 py-1 text-xs rounded border border-border w-28",
+              "bg-surface text-text-primary placeholder:text-text-muted",
+              "focus:outline-none focus:ring-1 focus:ring-border",
+            )}
+          />
+        )}
+        <Button
+          onClick={() => void handleSave()}
+          loading={isPending}
+          disabled={!dirty}
+          icon={<Save className="h-3 w-3" />}
+          className="text-xs h-7 px-2"
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function SettingsCard() {
+  const { data: settings = [], isLoading } = useSettings();
+  const [activeTab, setActiveTab] = useState("scanning");
+  const tabs = Object.entries(SETTING_SECTIONS);
+  const activeSection = SETTING_SECTIONS[activeTab]!;
+  const sectionSettings = settings.filter((s) =>
+    activeSection.keys.includes(s.key),
+  );
+
+  return (
+    <div className="bg-surface rounded-lg border border-border overflow-hidden">
+      <div className="px-4 py-3 border-b border-border flex items-center gap-2">
+        <Settings className="h-4 w-4 text-text-muted" />
+        <span className="text-xs font-medium text-text-primary">
+          Configuration
+        </span>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex border-b border-border overflow-x-auto">
+        {tabs.map(([key, { label }]) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setActiveTab(key)}
+            className={cn(
+              "px-4 py-2 text-xs whitespace-nowrap transition-colors",
+              activeTab === key
+                ? "border-b-2 border-accent text-accent font-medium"
+                : "text-text-muted hover:text-text-primary",
+            )}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Content */}
+      <div className="px-4 py-2">
+        {isLoading ? (
+          <div className="space-y-3 py-2">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="flex items-center justify-between">
+                <Skeleton className="h-3 w-40" />
+                <Skeleton className="h-6 w-24" />
+              </div>
+            ))}
+          </div>
+        ) : sectionSettings.length === 0 ? (
+          <p className="text-xs text-text-muted py-4 text-center">
+            No settings available. Settings are loaded from the database.
+          </p>
+        ) : (
+          sectionSettings.map((s) => (
+            <SettingField key={s.key} setting={s} />
+          ))
+        )}
+      </div>
     </div>
   );
 }
@@ -406,8 +581,8 @@ export function AdminPage() {
       {/* Section 2 — Workers */}
       <WorkersCard />
 
-      {/* Section 3 — Configuration (stub) */}
-      <StubCard icon={Settings} title="Configuration" />
+      {/* Section 3 — Configuration */}
+      <SettingsCard />
 
       {/* Section 4 — Log Viewer */}
       <div className="bg-surface rounded-lg border border-border overflow-hidden">

--- a/frontend/src/routes/dashboard.test.tsx
+++ b/frontend/src/routes/dashboard.test.tsx
@@ -26,11 +26,20 @@ vi.mock("../api/hooks/use-discovery", () => ({
   useDiscoveryDiff: vi.fn(),
 }));
 
+vi.mock("../api/hooks/use-dashboard", () => ({
+  useStatsSummary: vi.fn(),
+}));
+
+vi.mock("../components/activity-feed", () => ({
+  ActivityFeed: () => null,
+}));
+
 import { useVersion } from "../api/hooks/use-system";
 import { useNetworkStats } from "../api/hooks/use-networks";
 import { useRecentScans, useScanActivity } from "../api/hooks/use-scans";
 import { useActiveHostCount } from "../api/hooks/use-hosts";
 import { useDiscoveryJobs, useDiscoveryDiff } from "../api/hooks/use-discovery";
+import { useStatsSummary } from "../api/hooks/use-dashboard";
 
 const mockUseVersion = vi.mocked(useVersion);
 const mockUseNetworkStats = vi.mocked(useNetworkStats);
@@ -39,6 +48,7 @@ const mockUseScanActivity = vi.mocked(useScanActivity);
 const mockUseActiveHostCount = vi.mocked(useActiveHostCount);
 const mockUseDiscoveryJobs = vi.mocked(useDiscoveryJobs);
 const mockUseDiscoveryDiff = vi.mocked(useDiscoveryDiff);
+const mockUseStatsSummary = vi.mocked(useStatsSummary);
 
 function setupDefaultMocks() {
   mockUseVersion.mockReturnValue({
@@ -97,6 +107,11 @@ function setupDefaultMocks() {
     isLoading: false,
     isError: false,
   } as unknown as ReturnType<typeof useDiscoveryDiff>);
+
+  mockUseStatsSummary.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useStatsSummary>);
 }
 
 beforeEach(() => {

--- a/frontend/src/routes/dashboard.tsx
+++ b/frontend/src/routes/dashboard.tsx
@@ -1,16 +1,31 @@
 import { useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import { useVersion } from "../api/hooks/use-system";
 import { useNetworkStats } from "../api/hooks/use-networks";
 import { useRecentScans } from "../api/hooks/use-scans";
 import { useActiveHostCount } from "../api/hooks/use-hosts";
 import { useDiscoveryJobs, useDiscoveryDiff } from "../api/hooks/use-discovery";
+import { useStatsSummary } from "../api/hooks/use-dashboard";
 import { StatCard } from "../components/stat-card";
 import { SystemInfoCard } from "../components/system-info-card";
 import { RecentScansTable } from "../components/recent-scans-table";
 import { ScanActivityChart } from "../components/scan-activity-chart";
 import { ScanDetailPanel, Skeleton } from "../components";
-import { Network, Server, MonitorCheck, ShieldOff } from "lucide-react";
-import { formatRelativeTime } from "../lib/utils";
+import { ActivityFeed } from "../components/activity-feed";
+import {
+  Network,
+  Server,
+  MonitorCheck,
+  ShieldOff,
+  ScanLine,
+  ScanSearch,
+  AlertCircle,
+  Clock,
+} from "lucide-react";
+import { Button } from "../components/button";
+import { RunScanModal } from "../components";
+import { serializeFilter } from "../lib/filter-expr";
+import { formatRelativeTime, cn } from "../lib/utils";
 import type { components } from "../api/types";
 
 type ScanResponse = components["schemas"]["docs.ScanResponse"];
@@ -88,6 +103,297 @@ function RecentDiscoveryChanges() {
   );
 }
 
+// ── Status donut ──────────────────────────────────────────────────────────────
+
+const STATUS_COLORS: Record<string, string> = {
+  up: "#22c55e",
+  down: "#ef4444",
+  unknown: "#94a3b8",
+  gone: "#64748b",
+};
+
+function StatusBreakdown({
+  data,
+  loading,
+}: {
+  data: Record<string, number> | undefined;
+  loading: boolean;
+}) {
+  const entries = data
+    ? Object.entries(data).sort(([a], [b]) => a.localeCompare(b))
+    : [];
+  const total = entries.reduce((s, [, v]) => s + v, 0);
+
+  return (
+    <div className="bg-surface rounded-lg border border-border p-4">
+      <p className="text-xs font-medium text-text-primary mb-3">
+        Host Status
+      </p>
+      {loading ? (
+        <div className="space-y-2">
+          {[3, 2, 2, 1].map((w, i) => (
+            <Skeleton key={i} className={`h-3 w-${w * 10}`} />
+          ))}
+        </div>
+      ) : entries.length === 0 ? (
+        <p className="text-xs text-text-muted">No hosts.</p>
+      ) : (
+        <div className="space-y-2">
+          {entries.map(([status, count]) => {
+            const pct = total > 0 ? Math.round((count / total) * 100) : 0;
+            const color = STATUS_COLORS[status] ?? "#94a3b8";
+            return (
+              <div key={status} className="flex items-center gap-2">
+                <span
+                  className="h-2 w-2 rounded-full shrink-0"
+                  style={{ backgroundColor: color }}
+                />
+                <span className="text-xs text-text-secondary capitalize flex-1">
+                  {status}
+                </span>
+                <span className="text-xs font-medium text-text-primary tabular-nums">
+                  {count}
+                </span>
+                <div className="w-20 h-1.5 rounded-full bg-surface-raised overflow-hidden">
+                  <div
+                    className="h-full rounded-full transition-all"
+                    style={{ width: `${pct}%`, backgroundColor: color }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+          <p className="text-[10px] text-text-muted pt-1">
+            {total} total hosts
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── OS Family distribution ────────────────────────────────────────────────────
+
+function OSDistribution({
+  data,
+  loading,
+}: {
+  data: Array<{ family: string; count: number }> | undefined;
+  loading: boolean;
+}) {
+  const top = data?.slice(0, 6) ?? [];
+  const maxCount = top[0]?.count ?? 1;
+
+  return (
+    <div className="bg-surface rounded-lg border border-border p-4">
+      <p className="text-xs font-medium text-text-primary mb-3">
+        OS Distribution
+      </p>
+      {loading ? (
+        <div className="space-y-2">
+          {[4, 3, 2, 2, 1].map((w, i) => (
+            <Skeleton key={i} className={`h-3 w-${w * 10}`} />
+          ))}
+        </div>
+      ) : top.length === 0 ? (
+        <p className="text-xs text-text-muted">No OS data yet.</p>
+      ) : (
+        <div className="space-y-2">
+          {top.map(({ family, count }) => {
+            const pct = Math.round((count / maxCount) * 100);
+            return (
+              <div key={family} className="flex items-center gap-2">
+                <span className="text-xs text-text-secondary truncate flex-1 min-w-0">
+                  {family}
+                </span>
+                <span className="text-xs font-medium text-text-primary tabular-nums shrink-0">
+                  {count}
+                </span>
+                <div className="w-20 h-1.5 rounded-full bg-surface-raised overflow-hidden shrink-0">
+                  <div
+                    className="h-full rounded-full bg-accent/60 transition-all"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Top ports ─────────────────────────────────────────────────────────────────
+
+function TopPorts({
+  data,
+  loading,
+}: {
+  data: Array<{ port: number; count: number }> | undefined;
+  loading: boolean;
+}) {
+  const maxCount = data?.[0]?.count ?? 1;
+
+  return (
+    <div className="bg-surface rounded-lg border border-border p-4">
+      <p className="text-xs font-medium text-text-primary mb-3">
+        Top Open Ports
+      </p>
+      {loading ? (
+        <div className="space-y-2">
+          {[3, 2, 2, 2, 1].map((w, i) => (
+            <Skeleton key={i} className={`h-3 w-${w * 10}`} />
+          ))}
+        </div>
+      ) : !data || data.length === 0 ? (
+        <p className="text-xs text-text-muted">No port data yet.</p>
+      ) : (
+        <div className="space-y-2">
+          {data.map(({ port, count }) => {
+            const pct = Math.round((count / maxCount) * 100);
+            return (
+              <div key={port} className="flex items-center gap-2">
+                <span className="text-xs font-mono text-text-secondary shrink-0 w-10 text-right">
+                  {port}
+                </span>
+                <div className="flex-1 h-1.5 rounded-full bg-surface-raised overflow-hidden">
+                  <div
+                    className="h-full rounded-full bg-accent/70 transition-all"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+                <span className="text-xs text-text-muted tabular-nums shrink-0 w-8 text-right">
+                  {count}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Quick actions row ─────────────────────────────────────────────────────────
+
+function QuickActions({
+  onQuickScan,
+  staleCount,
+  loading,
+}: {
+  onQuickScan: () => void;
+  staleCount: number;
+  loading: boolean;
+}) {
+  const navigate = useNavigate();
+
+  function viewNewHosts() {
+    const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split("T")[0]!;
+    const filter = serializeFilter({
+      op: "AND",
+      conditions: [{ field: "first_seen", cmp: "gt", value: since }],
+    });
+    void navigate({ to: "/hosts", search: { filter }, replace: false });
+  }
+
+  function viewStaleHosts() {
+    const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split("T")[0]!;
+    const filter = serializeFilter({
+      op: "AND",
+      conditions: [{ field: "last_seen", cmp: "lt", value: cutoff }],
+    });
+    void navigate({ to: "/hosts", search: { filter }, replace: false });
+  }
+
+  return (
+    <div className="bg-surface rounded-lg border border-border p-4">
+      <p className="text-xs font-medium text-text-primary mb-3">
+        Quick Actions
+      </p>
+      <div className="flex flex-wrap gap-2">
+        <Button
+          icon={<ScanLine className="h-3.5 w-3.5" />}
+          onClick={onQuickScan}
+          className="text-xs h-7 px-3"
+        >
+          Quick Scan
+        </Button>
+        <Button
+          variant="secondary"
+          icon={<ScanSearch className="h-3.5 w-3.5" />}
+          onClick={() => void navigate({ to: "/discovery" })}
+          className="text-xs h-7 px-3"
+        >
+          Run Discovery
+        </Button>
+        <Button
+          variant="secondary"
+          icon={<Server className="h-3.5 w-3.5" />}
+          onClick={viewNewHosts}
+          className="text-xs h-7 px-3"
+        >
+          New Hosts
+        </Button>
+        {(loading || staleCount > 0) && (
+          <button
+            type="button"
+            onClick={viewStaleHosts}
+            className={cn(
+              "flex items-center gap-1.5 text-xs px-3 h-7 rounded border transition-colors",
+              staleCount > 0
+                ? "border-warning/50 text-warning bg-warning/10 hover:bg-warning/15"
+                : "border-border text-text-muted",
+            )}
+          >
+            <AlertCircle className="h-3.5 w-3.5" />
+            {loading ? (
+              <Skeleton className="h-3 w-16 inline-block" />
+            ) : (
+              `${staleCount} stale host${staleCount !== 1 ? "s" : ""}`
+            )}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Avg scan duration widget ──────────────────────────────────────────────────
+
+function AvgDurationCard({
+  seconds,
+  loading,
+}: {
+  seconds: number;
+  loading: boolean;
+}) {
+  function format(s: number): string {
+    if (s === 0) return "—";
+    if (s < 60) return `${Math.round(s)}s`;
+    const m = Math.floor(s / 60);
+    const rem = Math.round(s % 60);
+    return rem > 0 ? `${m}m ${rem}s` : `${m}m`;
+  }
+
+  return (
+    <div className="bg-surface rounded-lg border border-border p-4">
+      <div className="flex items-center gap-2 mb-1">
+        <Clock className="h-3.5 w-3.5 text-text-muted" />
+        <p className="text-xs font-medium text-text-primary">Avg Scan Time</p>
+      </div>
+      <p className="text-xs text-text-muted mb-1">Last 30 days</p>
+      {loading ? (
+        <Skeleton className="h-6 w-16" />
+      ) : (
+        <p className="text-lg font-mono font-semibold text-text-primary">
+          {format(seconds)}
+        </p>
+      )}
+    </div>
+  );
+}
+
 // ── Page ──────────────────────────────────────────────────────────────────────
 
 export function DashboardPage() {
@@ -96,8 +402,10 @@ export function DashboardPage() {
   const { data: recentScans, isLoading: scansLoading } = useRecentScans();
   const { data: activeHostCount, isLoading: activeHostsLoading } =
     useActiveHostCount();
+  const { data: summary, isLoading: summaryLoading } = useStatsSummary();
 
   const [selectedScan, setSelectedScan] = useState<ScanResponse | null>(null);
+  const [showScanModal, setShowScanModal] = useState(false);
 
   return (
     <>
@@ -138,27 +446,65 @@ export function DashboardPage() {
         </div>
       </div>
 
+      {/* Quick actions + stale hosts */}
+      <div className="mb-6">
+        <QuickActions
+          onQuickScan={() => setShowScanModal(true)}
+          staleCount={summary?.stale_host_count ?? 0}
+          loading={summaryLoading}
+        />
+      </div>
+
+      {/* Rich stats row */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <StatusBreakdown
+          data={summary?.hosts_by_status}
+          loading={summaryLoading}
+        />
+        <OSDistribution
+          data={summary?.hosts_by_os_family}
+          loading={summaryLoading}
+        />
+        <div className="flex flex-col gap-4">
+          <TopPorts data={summary?.top_ports} loading={summaryLoading} />
+          <AvgDurationCard
+            seconds={summary?.avg_scan_duration_s ?? 0}
+            loading={summaryLoading}
+          />
+        </div>
+      </div>
+
       {/* Scan activity chart */}
       <div className="mb-6">
         <ScanActivityChart />
       </div>
 
-      {/* Recent scans */}
-      <RecentScansTable
-        scans={recentScans?.data}
-        loading={scansLoading}
-        onScanClick={(scan) => setSelectedScan(scan as ScanResponse)}
-      />
+      {/* Bottom row: recent scans + activity feed */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+        <div className="lg:col-span-2">
+          <RecentScansTable
+            scans={recentScans?.data}
+            loading={scansLoading}
+            onScanClick={(scan) => setSelectedScan(scan as ScanResponse)}
+          />
+        </div>
+        <div>
+          <ActivityFeed />
+        </div>
+      </div>
 
       {/* Recent discovery changes */}
       <RecentDiscoveryChanges />
 
-      {/* Scan detail panel */}
+      {/* Modals / panels */}
       {selectedScan && (
         <ScanDetailPanel
           scan={selectedScan}
           onClose={() => setSelectedScan(null)}
         />
+      )}
+      {showScanModal && (
+        <RunScanModal onClose={() => setShowScanModal(false)} />
       )}
     </>
   );

--- a/frontend/src/routes/placeholder-routes.test.tsx
+++ b/frontend/src/routes/placeholder-routes.test.tsx
@@ -29,16 +29,24 @@ vi.mock("../api/hooks/use-system", () => ({
   useLogs: vi.fn(),
 }));
 
+vi.mock("../api/hooks/use-dashboard", () => ({
+  useSettings: vi.fn(),
+  useUpdateSetting: vi.fn(),
+}));
+
 import {
   useAdminStatus,
   useWorkers,
   useVersion,
   useLogs,
 } from "../api/hooks/use-system";
+import { useSettings, useUpdateSetting } from "../api/hooks/use-dashboard";
 const mockUseAdminStatus = vi.mocked(useAdminStatus);
 const mockUseWorkers = vi.mocked(useWorkers);
 const mockUseVersion = vi.mocked(useVersion);
 const mockUseLogs = vi.mocked(useLogs);
+const mockUseSettings = vi.mocked(useSettings);
+const mockUseUpdateSetting = vi.mocked(useUpdateSetting);
 
 beforeEach(() => {
   // Default: not loading, no data — SystemStatusCard renders real UI (including "System Status" heading)
@@ -60,6 +68,11 @@ beforeEach(() => {
     },
     isLoading: false,
     isError: false,
+  } as any);
+  mockUseSettings.mockReturnValue({ data: [], isLoading: false } as any);
+  mockUseUpdateSetting.mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
   } as any);
 });
 

--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -4,10 +4,13 @@
 package handlers
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
 
+	"github.com/anstrom/scanorama/internal/db"
+	"github.com/anstrom/scanorama/internal/errors"
 	"github.com/anstrom/scanorama/internal/logging"
 	"github.com/anstrom/scanorama/internal/metrics"
 	"github.com/anstrom/scanorama/internal/scanning"
@@ -124,4 +127,85 @@ func (h *AdminHandler) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 	// Configuration persistence is not yet implemented.
 	writeError(w, r, http.StatusNotImplemented,
 		fmt.Errorf("update config is not yet implemented"))
+}
+
+// SettingsHandler handles the /api/v1/admin/settings endpoints.
+type SettingsHandler struct {
+	repo   *db.SettingsRepository
+	logger *slog.Logger
+}
+
+// NewSettingsHandler creates a new SettingsHandler.
+func NewSettingsHandler(repo *db.SettingsRepository, logger *slog.Logger) *SettingsHandler {
+	return &SettingsHandler{
+		repo:   repo,
+		logger: logger.With("handler", "settings"),
+	}
+}
+
+// settingsListResponse is the envelope for GET /admin/settings.
+type settingsListResponse struct {
+	Settings []db.Setting `json:"settings"`
+}
+
+// settingsUpdateRequest is the body for PUT /admin/settings.
+type settingsUpdateRequest struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// settingsUpdateResponse is the response body for PUT /admin/settings.
+type settingsUpdateResponse struct {
+	Key     string `json:"key"`
+	Updated bool   `json:"updated"`
+}
+
+// GetSettings handles GET /api/v1/admin/settings.
+func (h *SettingsHandler) GetSettings(w http.ResponseWriter, r *http.Request) {
+	requestID := getRequestIDFromContext(r.Context())
+	h.logger.Info("Listing settings", "request_id", requestID)
+
+	settings, err := h.repo.ListSettings(r.Context())
+	if err != nil {
+		h.logger.Error("Failed to list settings", "error", err, "request_id", requestID)
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, settingsListResponse{Settings: settings})
+}
+
+// UpdateSettings handles PUT /api/v1/admin/settings.
+func (h *SettingsHandler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
+	requestID := getRequestIDFromContext(r.Context())
+	h.logger.Info("Updating setting", "request_id", requestID)
+
+	var req settingsUpdateRequest
+	if err := parseJSON(r, &req); err != nil {
+		writeError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	if req.Key == "" {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("key is required"))
+		return
+	}
+
+	// Validate that value is valid JSON.
+	if !json.Valid([]byte(req.Value)) {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("value must be valid JSON"))
+		return
+	}
+
+	if err := h.repo.SetSetting(r.Context(), req.Key, req.Value); err != nil {
+		if errors.IsNotFound(err) {
+			writeError(w, r, http.StatusNotFound, fmt.Errorf("setting %q not found", req.Key))
+			return
+		}
+		h.logger.Error("Failed to update setting", "key", req.Key, "error", err, "request_id", requestID)
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, settingsUpdateResponse{Key: req.Key, Updated: true})
 }

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -1,0 +1,204 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+func newSettingsHandlerWithMock(t *testing.T) (*SettingsHandler, sqlmock.Sqlmock) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	database := &db.DB{DB: sqlx.NewDb(sqlDB, "sqlmock")}
+	repo := db.NewSettingsRepository(database)
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	return NewSettingsHandler(repo, logger), mock
+}
+
+var settingHandlerCols = []string{"key", "value", "description", "type", "updated_at"}
+
+// ── GetSettings ────────────────────────────────────────────────────────────────
+
+func TestSettingsHandler_GetSettings_Empty(t *testing.T) {
+	h, mock := newSettingsHandlerWithMock(t)
+	mock.ExpectQuery("SELECT key").WillReturnRows(sqlmock.NewRows(settingHandlerCols))
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/settings", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ContextKey("request_id"), "test-id"))
+	rr := httptest.NewRecorder()
+	h.GetSettings(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	settings := resp["settings"].([]interface{})
+	assert.Empty(t, settings)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsHandler_GetSettings_ReturnsSettings(t *testing.T) {
+	h, mock := newSettingsHandlerWithMock(t)
+	rows := sqlmock.NewRows(settingHandlerCols).
+		AddRow("scan.max_concurrent", "5", "Max concurrent scans", "int", time.Now().UTC()).
+		AddRow("notifications.scan_complete", "true", "Notify on scan completion", "bool", time.Now().UTC())
+	mock.ExpectQuery("SELECT key").WillReturnRows(rows)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/settings", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ContextKey("request_id"), "test-id"))
+	rr := httptest.NewRecorder()
+	h.GetSettings(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+	var resp struct {
+		Settings []db.Setting `json:"settings"`
+	}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(t, resp.Settings, 2)
+	assert.Equal(t, "scan.max_concurrent", resp.Settings[0].Key)
+	assert.Equal(t, "5", resp.Settings[0].Value)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsHandler_GetSettings_DBError(t *testing.T) {
+	h, mock := newSettingsHandlerWithMock(t)
+	mock.ExpectQuery("SELECT key").WillReturnError(fmt.Errorf("connection reset"))
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/settings", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ContextKey("request_id"), "test-id"))
+	rr := httptest.NewRecorder()
+	h.GetSettings(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── UpdateSettings ─────────────────────────────────────────────────────────────
+
+func TestSettingsHandler_UpdateSettings_Success(t *testing.T) {
+	h, mock := newSettingsHandlerWithMock(t)
+	mock.ExpectExec("UPDATE settings").
+		WithArgs("scan.max_concurrent", "10").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	body, _ := json.Marshal(map[string]string{"key": "scan.max_concurrent", "value": "10"})
+	req := httptest.NewRequest(http.MethodPut, "/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), ContextKey("request_id"), "test-id"))
+	rr := httptest.NewRecorder()
+	h.UpdateSettings(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, "scan.max_concurrent", resp["key"])
+	assert.Equal(t, true, resp["updated"])
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsHandler_UpdateSettings_BoolValue(t *testing.T) {
+	h, mock := newSettingsHandlerWithMock(t)
+	mock.ExpectExec("UPDATE settings").
+		WithArgs("notifications.scan_complete", "false").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	body, _ := json.Marshal(map[string]string{"key": "notifications.scan_complete", "value": "false"})
+	req := httptest.NewRequest(http.MethodPut, "/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), ContextKey("request_id"), "test-id"))
+	rr := httptest.NewRecorder()
+	h.UpdateSettings(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsHandler_UpdateSettings_MissingKey(t *testing.T) {
+	h, _ := newSettingsHandlerWithMock(t)
+
+	body, _ := json.Marshal(map[string]string{"value": "5"})
+	req := httptest.NewRequest(http.MethodPut, "/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), ContextKey("request_id"), "test-id"))
+	rr := httptest.NewRecorder()
+	h.UpdateSettings(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestSettingsHandler_UpdateSettings_InvalidJSON(t *testing.T) {
+	h, _ := newSettingsHandlerWithMock(t)
+
+	body, _ := json.Marshal(map[string]string{"key": "scan.max_concurrent", "value": "not-json-bool"})
+	req := httptest.NewRequest(http.MethodPut, "/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), ContextKey("request_id"), "test-id"))
+	rr := httptest.NewRecorder()
+	h.UpdateSettings(rr, req)
+
+	// "not-json-bool" is not valid JSON — it's not a number, bool, null, or quoted string
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestSettingsHandler_UpdateSettings_NotFound(t *testing.T) {
+	h, mock := newSettingsHandlerWithMock(t)
+	mock.ExpectExec("UPDATE settings").
+		WithArgs("unknown.key", "5").
+		WillReturnResult(sqlmock.NewResult(0, 0)) // 0 rows = key not found
+
+	body, _ := json.Marshal(map[string]string{"key": "unknown.key", "value": "5"})
+	req := httptest.NewRequest(http.MethodPut, "/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), ContextKey("request_id"), "test-id"))
+	rr := httptest.NewRecorder()
+	h.UpdateSettings(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsHandler_UpdateSettings_DBError(t *testing.T) {
+	h, mock := newSettingsHandlerWithMock(t)
+	mock.ExpectExec("UPDATE settings").
+		WillReturnError(fmt.Errorf("connection reset"))
+
+	body, _ := json.Marshal(map[string]string{"key": "scan.max_concurrent", "value": "5"})
+	req := httptest.NewRequest(http.MethodPut, "/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), ContextKey("request_id"), "test-id"))
+	rr := httptest.NewRecorder()
+	h.UpdateSettings(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsHandler_UpdateSettings_MalformedBody(t *testing.T) {
+	h, _ := newSettingsHandlerWithMock(t)
+
+	req := httptest.NewRequest(http.MethodPut, "/admin/settings", bytes.NewReader([]byte("not-json")))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), ContextKey("request_id"), "test-id"))
+	rr := httptest.NewRecorder()
+	h.UpdateSettings(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}

--- a/internal/api/handlers/stats.go
+++ b/internal/api/handlers/stats.go
@@ -1,0 +1,207 @@
+// Package handlers provides HTTP request handlers for the Scanorama API.
+// This file implements the StatsHandler for summary statistics endpoints.
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+const statsQueryTimeout = 5 * time.Second
+
+// StatsHandler handles statistics API endpoints.
+type StatsHandler struct {
+	db     *db.DB
+	logger *slog.Logger
+}
+
+// NewStatsHandler creates a new StatsHandler.
+func NewStatsHandler(database *db.DB, logger *slog.Logger) *StatsHandler {
+	return &StatsHandler{
+		db:     database,
+		logger: logger.With("handler", "stats"),
+	}
+}
+
+// StatsSummaryResponse holds the aggregated statistics summary.
+type StatsSummaryResponse struct {
+	HostsByStatus    map[string]int  `json:"hosts_by_status"`
+	HostsByOSFamily  []OSFamilyCount `json:"hosts_by_os_family"`
+	TopPorts         []PortCount     `json:"top_ports"`
+	StaleHostCount   int             `json:"stale_host_count"`
+	AvgScanDurationS float64         `json:"avg_scan_duration_s"`
+}
+
+// OSFamilyCount holds a count for a given OS family.
+type OSFamilyCount struct {
+	Family string `json:"family"`
+	Count  int    `json:"count"`
+}
+
+// PortCount holds a count for a given port.
+type PortCount struct {
+	Port  int `json:"port"`
+	Count int `json:"count"`
+}
+
+// GetStatsSummary handles GET /api/v1/stats/summary.
+func (h *StatsHandler) GetStatsSummary(w http.ResponseWriter, r *http.Request) {
+	response := StatsSummaryResponse{
+		HostsByStatus:   make(map[string]int),
+		HostsByOSFamily: []OSFamilyCount{},
+		TopPorts:        []PortCount{},
+	}
+
+	if err := h.fillHostsByStatus(r.Context(), response.HostsByStatus); err != nil {
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	osFamilies, err := h.queryOSFamilies(r.Context())
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	response.HostsByOSFamily = osFamilies
+
+	topPorts, err := h.queryTopPorts(r.Context())
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	response.TopPorts = topPorts
+
+	staleCount, err := h.queryStaleHostCount(r.Context())
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	response.StaleHostCount = staleCount
+
+	avgDuration, err := h.queryAvgScanDuration(r.Context())
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	response.AvgScanDurationS = avgDuration
+
+	writeJSON(w, r, http.StatusOK, response)
+}
+
+func (h *StatsHandler) fillHostsByStatus(ctx context.Context, out map[string]int) error {
+	ctx, cancel := context.WithTimeout(ctx, statsQueryTimeout)
+	defer cancel()
+
+	rows, err := h.db.QueryContext(ctx, `SELECT status, COUNT(*) FROM hosts GROUP BY status`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var status string
+		var count int
+		if err := rows.Scan(&status, &count); err != nil {
+			return err
+		}
+		out[status] = count
+	}
+	return rows.Err()
+}
+
+func (h *StatsHandler) queryOSFamilies(ctx context.Context) ([]OSFamilyCount, error) {
+	ctx, cancel := context.WithTimeout(ctx, statsQueryTimeout)
+	defer cancel()
+
+	rows, err := h.db.QueryContext(ctx,
+		`SELECT os_family, COUNT(*) as cnt FROM hosts
+		WHERE os_family IS NOT NULL AND os_family != ''
+		GROUP BY os_family ORDER BY cnt DESC LIMIT 10`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []OSFamilyCount
+	for rows.Next() {
+		var entry OSFamilyCount
+		if err := rows.Scan(&entry.Family, &entry.Count); err != nil {
+			return nil, err
+		}
+		result = append(result, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if result == nil {
+		result = []OSFamilyCount{}
+	}
+	return result, nil
+}
+
+func (h *StatsHandler) queryTopPorts(ctx context.Context) ([]PortCount, error) {
+	ctx, cancel := context.WithTimeout(ctx, statsQueryTimeout)
+	defer cancel()
+
+	rows, err := h.db.QueryContext(ctx,
+		`SELECT port, COUNT(*) as cnt FROM port_scans
+		WHERE state = 'open' GROUP BY port ORDER BY cnt DESC LIMIT 5`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []PortCount
+	for rows.Next() {
+		var entry PortCount
+		if err := rows.Scan(&entry.Port, &entry.Count); err != nil {
+			return nil, err
+		}
+		result = append(result, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if result == nil {
+		result = []PortCount{}
+	}
+	return result, nil
+}
+
+func (h *StatsHandler) queryStaleHostCount(ctx context.Context) (int, error) {
+	ctx, cancel := context.WithTimeout(ctx, statsQueryTimeout)
+	defer cancel()
+
+	var count int
+	row := h.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM hosts
+		WHERE last_seen < NOW() - INTERVAL '7 days' AND status != 'gone'`)
+	if err := row.Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (h *StatsHandler) queryAvgScanDuration(ctx context.Context) (float64, error) {
+	ctx, cancel := context.WithTimeout(ctx, statsQueryTimeout)
+	defer cancel()
+
+	var avg sql.NullFloat64
+	row := h.db.QueryRowContext(ctx,
+		`SELECT AVG(EXTRACT(EPOCH FROM (completed_at - started_at)))
+		FROM scan_jobs
+		WHERE status = 'completed'
+		AND completed_at IS NOT NULL AND started_at IS NOT NULL
+		AND completed_at > NOW() - INTERVAL '30 days'`)
+	if err := row.Scan(&avg); err != nil {
+		return 0, err
+	}
+	if avg.Valid {
+		return avg.Float64, nil
+	}
+	return 0, nil
+}

--- a/internal/api/handlers/stats_test.go
+++ b/internal/api/handlers/stats_test.go
@@ -1,0 +1,227 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+func newStatsHandlerWithMock(t *testing.T) (*StatsHandler, sqlmock.Sqlmock) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	database := &db.DB{DB: sqlx.NewDb(sqlDB, "sqlmock")}
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	return NewStatsHandler(database, logger), mock
+}
+
+func statsRequest(t *testing.T) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/stats/summary", nil)
+	return req.WithContext(context.WithValue(req.Context(), ContextKey("request_id"), "test-id"))
+}
+
+// expectAllStatsQueries registers all five stats queries in order with happy-path defaults.
+func expectAllStatsQueries(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("SELECT status, COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"status", "count"}).
+			AddRow("up", 10).
+			AddRow("down", 3))
+
+	mock.ExpectQuery("SELECT os_family").
+		WillReturnRows(sqlmock.NewRows([]string{"os_family", "cnt"}).
+			AddRow("Linux", 8).
+			AddRow("Windows", 5))
+
+	mock.ExpectQuery("SELECT port").
+		WillReturnRows(sqlmock.NewRows([]string{"port", "cnt"}).
+			AddRow(80, 12).
+			AddRow(443, 9).
+			AddRow(22, 6))
+
+	mock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+	mock.ExpectQuery("SELECT AVG").
+		WillReturnRows(sqlmock.NewRows([]string{"avg"}).AddRow(45.5))
+}
+
+// ── GetStatsSummary ────────────────────────────────────────────────────────────
+
+func TestStatsHandler_GetStatsSummary_Success(t *testing.T) {
+	h, mock := newStatsHandlerWithMock(t)
+	expectAllStatsQueries(mock)
+
+	rr := httptest.NewRecorder()
+	h.GetStatsSummary(rr, statsRequest(t))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+	var resp StatsSummaryResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+
+	assert.Equal(t, 10, resp.HostsByStatus["up"])
+	assert.Equal(t, 3, resp.HostsByStatus["down"])
+	require.Len(t, resp.HostsByOSFamily, 2)
+	assert.Equal(t, "Linux", resp.HostsByOSFamily[0].Family)
+	assert.Equal(t, 8, resp.HostsByOSFamily[0].Count)
+	require.Len(t, resp.TopPorts, 3)
+	assert.Equal(t, 80, resp.TopPorts[0].Port)
+	assert.Equal(t, 12, resp.TopPorts[0].Count)
+	assert.Equal(t, 2, resp.StaleHostCount)
+	assert.InDelta(t, 45.5, resp.AvgScanDurationS, 0.01)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStatsHandler_GetStatsSummary_EmptyDB(t *testing.T) {
+	h, mock := newStatsHandlerWithMock(t)
+
+	mock.ExpectQuery("SELECT status, COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"status", "count"}))
+	mock.ExpectQuery("SELECT os_family").
+		WillReturnRows(sqlmock.NewRows([]string{"os_family", "cnt"}))
+	mock.ExpectQuery("SELECT port").
+		WillReturnRows(sqlmock.NewRows([]string{"port", "cnt"}))
+	mock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery("SELECT AVG").
+		WillReturnRows(sqlmock.NewRows([]string{"avg"}).AddRow(nil)) // NULL avg
+
+	rr := httptest.NewRecorder()
+	h.GetStatsSummary(rr, statsRequest(t))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp StatsSummaryResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+
+	assert.Empty(t, resp.HostsByStatus)
+	assert.Empty(t, resp.HostsByOSFamily)
+	assert.Empty(t, resp.TopPorts)
+	assert.Equal(t, 0, resp.StaleHostCount)
+	assert.Equal(t, 0.0, resp.AvgScanDurationS)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStatsHandler_GetStatsSummary_StatusQueryError(t *testing.T) {
+	h, mock := newStatsHandlerWithMock(t)
+	mock.ExpectQuery("SELECT status, COUNT").WillReturnError(fmt.Errorf("db error"))
+
+	rr := httptest.NewRecorder()
+	h.GetStatsSummary(rr, statsRequest(t))
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStatsHandler_GetStatsSummary_OSFamilyQueryError(t *testing.T) {
+	h, mock := newStatsHandlerWithMock(t)
+	mock.ExpectQuery("SELECT status, COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"status", "count"}))
+	mock.ExpectQuery("SELECT os_family").WillReturnError(fmt.Errorf("db error"))
+
+	rr := httptest.NewRecorder()
+	h.GetStatsSummary(rr, statsRequest(t))
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStatsHandler_GetStatsSummary_TopPortsQueryError(t *testing.T) {
+	h, mock := newStatsHandlerWithMock(t)
+	mock.ExpectQuery("SELECT status, COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"status", "count"}))
+	mock.ExpectQuery("SELECT os_family").
+		WillReturnRows(sqlmock.NewRows([]string{"os_family", "cnt"}))
+	mock.ExpectQuery("SELECT port").WillReturnError(fmt.Errorf("db error"))
+
+	rr := httptest.NewRecorder()
+	h.GetStatsSummary(rr, statsRequest(t))
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStatsHandler_GetStatsSummary_StaleHostQueryError(t *testing.T) {
+	h, mock := newStatsHandlerWithMock(t)
+	mock.ExpectQuery("SELECT status, COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"status", "count"}))
+	mock.ExpectQuery("SELECT os_family").
+		WillReturnRows(sqlmock.NewRows([]string{"os_family", "cnt"}))
+	mock.ExpectQuery("SELECT port").
+		WillReturnRows(sqlmock.NewRows([]string{"port", "cnt"}))
+	mock.ExpectQuery("SELECT COUNT").WillReturnError(fmt.Errorf("db error"))
+
+	rr := httptest.NewRecorder()
+	h.GetStatsSummary(rr, statsRequest(t))
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStatsHandler_GetStatsSummary_AvgDurationQueryError(t *testing.T) {
+	h, mock := newStatsHandlerWithMock(t)
+	mock.ExpectQuery("SELECT status, COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"status", "count"}))
+	mock.ExpectQuery("SELECT os_family").
+		WillReturnRows(sqlmock.NewRows([]string{"os_family", "cnt"}))
+	mock.ExpectQuery("SELECT port").
+		WillReturnRows(sqlmock.NewRows([]string{"port", "cnt"}))
+	mock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery("SELECT AVG").WillReturnError(fmt.Errorf("db error"))
+
+	rr := httptest.NewRecorder()
+	h.GetStatsSummary(rr, statsRequest(t))
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStatsHandler_GetStatsSummary_ResponseShape(t *testing.T) {
+	h, mock := newStatsHandlerWithMock(t)
+	expectAllStatsQueries(mock)
+
+	rr := httptest.NewRecorder()
+	h.GetStatsSummary(rr, statsRequest(t))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Verify JSON field names match the documented API shape.
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&raw))
+	assert.Contains(t, raw, "hosts_by_status")
+	assert.Contains(t, raw, "hosts_by_os_family")
+	assert.Contains(t, raw, "top_ports")
+	assert.Contains(t, raw, "stale_host_count")
+	assert.Contains(t, raw, "avg_scan_duration_s")
+}
+
+// ── NewStatsHandler ────────────────────────────────────────────────────────────
+
+func TestNewStatsHandler(t *testing.T) {
+	sqlDB, _, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	database := &db.DB{DB: sqlx.NewDb(sqlDB, "sqlmock")}
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+
+	h := NewStatsHandler(database, logger)
+	require.NotNil(t, h)
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -62,6 +62,14 @@ func (s *Server) setupRoutes() {
 	api.HandleFunc("/admin/status", s.adminStatusHandler).Methods("GET")
 	api.HandleFunc("/admin/workers", handlerManager.GetWorkerStatus).Methods("GET")
 
+	statsHandler := apihandlers.NewStatsHandler(s.database, s.logger)
+	settingsHandler := apihandlers.NewSettingsHandler(
+		db.NewSettingsRepository(s.database), s.logger)
+
+	api.HandleFunc("/stats/summary", statsHandler.GetStatsSummary).Methods("GET")
+	api.HandleFunc("/admin/settings", settingsHandler.GetSettings).Methods("GET")
+	api.HandleFunc("/admin/settings", settingsHandler.UpdateSettings).Methods("PUT")
+
 	s.setupDocRoutes()
 	s.router.HandleFunc("/", s.redirectToAPI).Methods("GET")
 }

--- a/internal/db/009_settings.sql
+++ b/internal/db/009_settings.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS settings (
+    key         VARCHAR(100) PRIMARY KEY,
+    value       JSONB        NOT NULL,
+    description TEXT,
+    type        VARCHAR(20)  NOT NULL DEFAULT 'string',
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- Seed mutable settings with defaults
+INSERT INTO settings (key, value, type, description) VALUES
+    ('scan.default_timing',         '3',            'int',      'Default nmap timing template (0-5)'),
+    ('scan.max_concurrent',         '5',            'int',      'Maximum concurrent scans'),
+    ('discovery.ping_timeout_ms',   '1000',         'int',      'Ping timeout in milliseconds'),
+    ('discovery.methods',           '["icmp","arp"]','string[]', 'Discovery methods'),
+    ('retention.auto_purge_days',   '0',            'int',      'Auto-purge scan data older than N days (0=disabled)'),
+    ('retention.max_scan_history',  '0',            'int',      'Max scan history per host (0=unlimited)'),
+    ('notifications.scan_complete', 'true',         'bool',     'Notify on scan completion'),
+    ('notifications.host_down',     'true',         'bool',     'Notify when host goes down'),
+    ('notifications.new_host',      'true',         'bool',     'Notify on new host discovery')
+ON CONFLICT (key) DO NOTHING;

--- a/internal/db/repository_settings.go
+++ b/internal/db/repository_settings.go
@@ -1,0 +1,98 @@
+// Package db provides a typed repository for settings database operations.
+package db
+
+import (
+	"context"
+	"database/sql"
+	stderrors "errors"
+	"fmt"
+	"time"
+
+	"github.com/anstrom/scanorama/internal/errors"
+)
+
+// Setting represents a single application setting row.
+type Setting struct {
+	Key         string    `db:"key"         json:"key"`
+	Value       string    `db:"value"       json:"value"` // raw JSON string
+	Description string    `db:"description" json:"description"`
+	Type        string    `db:"type"        json:"type"`
+	UpdatedAt   time.Time `db:"updated_at"  json:"updated_at"`
+}
+
+// SettingsRepository handles settings database operations.
+type SettingsRepository struct {
+	db *DB
+}
+
+// NewSettingsRepository creates a new SettingsRepository.
+func NewSettingsRepository(db *DB) *SettingsRepository {
+	return &SettingsRepository{db: db}
+}
+
+// ListSettings returns all settings ordered by key.
+func (r *SettingsRepository) ListSettings(ctx context.Context) ([]Setting, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT key, value::text, COALESCE(description, ''), type, updated_at
+		FROM settings ORDER BY key`)
+	if err != nil {
+		return nil, sanitizeDBError("list settings", err)
+	}
+	defer func() {
+		if cerr := rows.Close(); cerr != nil {
+			_ = fmt.Errorf("list settings: close rows: %w", cerr)
+		}
+	}()
+
+	var settings []Setting
+	for rows.Next() {
+		var s Setting
+		if err := rows.Scan(&s.Key, &s.Value, &s.Description, &s.Type, &s.UpdatedAt); err != nil {
+			return nil, sanitizeDBError("scan setting row", err)
+		}
+		settings = append(settings, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, sanitizeDBError("iterate settings", err)
+	}
+	if settings == nil {
+		settings = []Setting{}
+	}
+	return settings, nil
+}
+
+// GetSetting returns a single setting by key, or ErrNotFound if missing.
+func (r *SettingsRepository) GetSetting(ctx context.Context, key string) (*Setting, error) {
+	var s Setting
+	row := r.db.QueryRowContext(ctx,
+		`SELECT key, value::text, COALESCE(description, ''), type, updated_at
+		FROM settings WHERE key = $1`, key)
+	err := row.Scan(&s.Key, &s.Value, &s.Description, &s.Type, &s.UpdatedAt)
+	if err != nil {
+		if stderrors.Is(err, sql.ErrNoRows) {
+			return nil, errors.ErrNotFound("setting")
+		}
+		return nil, sanitizeDBError("get setting", err)
+	}
+	return &s, nil
+}
+
+// SetSetting updates the value of an existing setting identified by key.
+// Returns an error if the key does not exist (unknown setting).
+func (r *SettingsRepository) SetSetting(ctx context.Context, key, valueJSON string) error {
+	result, err := r.db.ExecContext(ctx,
+		`UPDATE settings SET value = $2::jsonb, updated_at = NOW() WHERE key = $1`,
+		key, valueJSON)
+	if err != nil {
+		return sanitizeDBError("set setting", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return sanitizeDBError("set setting rows affected", err)
+	}
+	if rowsAffected == 0 {
+		return errors.ErrNotFound("setting")
+	}
+	return nil
+}

--- a/internal/db/repository_settings_unit_test.go
+++ b/internal/db/repository_settings_unit_test.go
@@ -1,0 +1,174 @@
+// Package db — unit tests for SettingsRepository using sqlmock.
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/errors"
+)
+
+var settingCols = []string{"key", "value", "description", "type", "updated_at"}
+
+func makeSettingRow(key, value, desc, typ string) *sqlmock.Rows {
+	return sqlmock.NewRows(settingCols).
+		AddRow(key, value, desc, typ, time.Now().UTC())
+}
+
+// ── NewSettingsRepository ──────────────────────────────────────────────────────
+
+func TestSettingsRepository_New(t *testing.T) {
+	db, _ := newMockDB(t)
+	repo := NewSettingsRepository(db)
+	require.NotNil(t, repo)
+}
+
+// ── ListSettings ───────────────────────────────────────────────────────────────
+
+func TestSettingsRepository_ListSettings_Empty(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WillReturnRows(sqlmock.NewRows(settingCols))
+
+	repo := NewSettingsRepository(db)
+	settings, err := repo.ListSettings(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, settings)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_ListSettings_Multiple(t *testing.T) {
+	db, mock := newMockDB(t)
+	rows := sqlmock.NewRows(settingCols).
+		AddRow("scan.max_concurrent", "5", "Max concurrent scans", "int", time.Now().UTC()).
+		AddRow("scan.default_timing", "3", "Default timing", "int", time.Now().UTC())
+	mock.ExpectQuery("SELECT key").WillReturnRows(rows)
+
+	repo := NewSettingsRepository(db)
+	settings, err := repo.ListSettings(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, settings, 2)
+	assert.Equal(t, "scan.max_concurrent", settings[0].Key)
+	assert.Equal(t, "5", settings[0].Value)
+	assert.Equal(t, "scan.default_timing", settings[1].Key)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_ListSettings_DBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").WillReturnError(fmt.Errorf("connection reset"))
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.ListSettings(context.Background())
+
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_ListSettings_ScanError(t *testing.T) {
+	db, mock := newMockDB(t)
+	// Return a row with wrong column count to trigger a scan error.
+	rows := sqlmock.NewRows([]string{"key"}).AddRow("only-key")
+	mock.ExpectQuery("SELECT key").WillReturnRows(rows)
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.ListSettings(context.Background())
+
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── GetSetting ─────────────────────────────────────────────────────────────────
+
+func TestSettingsRepository_GetSetting_Found(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("scan.max_concurrent").
+		WillReturnRows(makeSettingRow("scan.max_concurrent", "5", "Max concurrent scans", "int"))
+
+	repo := NewSettingsRepository(db)
+	s, err := repo.GetSetting(context.Background(), "scan.max_concurrent")
+
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	assert.Equal(t, "scan.max_concurrent", s.Key)
+	assert.Equal(t, "5", s.Value)
+	assert.Equal(t, "int", s.Type)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetSetting_NotFound(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("nonexistent").
+		WillReturnRows(sqlmock.NewRows(settingCols))
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.GetSetting(context.Background(), "nonexistent")
+
+	require.Error(t, err)
+	assert.True(t, errors.IsNotFound(err), "expected not-found error, got: %v", err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetSetting_DBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("scan.max_concurrent").
+		WillReturnError(fmt.Errorf("connection refused"))
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.GetSetting(context.Background(), "scan.max_concurrent")
+
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── SetSetting ─────────────────────────────────────────────────────────────────
+
+func TestSettingsRepository_SetSetting_Success(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectExec("UPDATE settings").
+		WithArgs("scan.max_concurrent", "10").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	repo := NewSettingsRepository(db)
+	err := repo.SetSetting(context.Background(), "scan.max_concurrent", "10")
+
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_SetSetting_NotFound(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectExec("UPDATE settings").
+		WithArgs("nonexistent", "true").
+		WillReturnResult(sqlmock.NewResult(0, 0)) // 0 rows affected
+
+	repo := NewSettingsRepository(db)
+	err := repo.SetSetting(context.Background(), "nonexistent", "true")
+
+	require.Error(t, err)
+	assert.True(t, errors.IsNotFound(err), "expected not-found error, got: %v", err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_SetSetting_DBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectExec("UPDATE settings").
+		WillReturnError(fmt.Errorf("connection reset"))
+
+	repo := NewSettingsRepository(db)
+	err := repo.SetSetting(context.Background(), "scan.max_concurrent", "5")
+
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
## Summary

- **`GET /api/v1/stats/summary`** — aggregates hosts by status, OS family distribution (top 10), top 5 open ports, stale host count (last seen > 7d), and avg scan duration (last 30d)
- **`GET/PUT /api/v1/admin/settings`** — DB-backed application settings stored as JSONB; migration 009 seeds scanning, discovery, retention, and notification defaults
- **Dashboard** — new `StatusBreakdown`, `OSDistribution`, `TopPorts`, `AvgDurationCard`, and `QuickActions` widgets using `useStatsSummary`; 2/3 + 1/3 layout with `ActivityFeed` alongside recent scans
- **ActivityFeed** — live WebSocket event stream (`useActivityFeed` hook) with deduplication, max-100 ring buffer, and auto-scroll; surfaces scan, discovery, and host-status events
- **Admin settings editor** — tabbed UI (`SettingsCard`) with per-setting inline save, dirty tracking, and type-aware inputs (bool → select, int → number, text → text)

## Test plan

- [ ] All 859 frontend tests pass, TypeScript clean, all Go packages pass
- [ ] Dashboard loads without errors; stat cards show `—` when API data is absent
- [ ] Activity feed shows "No recent activity" when no WS events received
- [ ] Admin → Configuration tab shows settings loaded from DB; editing and saving a value works
- [ ] `GET /api/v1/stats/summary` returns correct shape on fresh DB (all counts 0, avg 0)
- [ ] `PUT /api/v1/admin/settings` rejects unknown keys with 404, invalid JSON with 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)