### PR TITLE
feat(polish): TagInput arrow key navigation + v0.24 integration tests

### DIFF
--- a/frontend/src/components/tag-input.test.tsx
+++ b/frontend/src/components/tag-input.test.tsx
@@ -1,0 +1,302 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TagInput } from "./tag-input";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function setup(
+  tags: string[] = [],
+  opts: { allTags?: string[]; disabled?: boolean } = {},
+) {
+  const onChange = vi.fn();
+  const utils = render(
+    <TagInput
+      tags={tags}
+      allTags={opts.allTags}
+      onChange={onChange}
+      disabled={opts.disabled}
+    />,
+  );
+  const input = utils.queryByRole("textbox") as HTMLInputElement | null;
+  return { ...utils, input, onChange };
+}
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe("TagInput", () => {
+  describe("rendering", () => {
+    it("renders existing tags", () => {
+      setup(["prod", "web"]);
+      expect(screen.getByText("prod")).toBeInTheDocument();
+      expect(screen.getByText("web")).toBeInTheDocument();
+    });
+
+    it("renders text input when not disabled", () => {
+      const { input } = setup([]);
+      expect(input).toBeInTheDocument();
+    });
+
+    it("does not render text input when disabled", () => {
+      const { input } = setup(["prod"], { disabled: true });
+      expect(input).not.toBeInTheDocument();
+    });
+
+    it("shows placeholder when no tags", () => {
+      render(<TagInput tags={[]} onChange={vi.fn()} placeholder="Add tag…" />);
+      expect(screen.getByPlaceholderText("Add tag…")).toBeInTheDocument();
+    });
+
+    it("hides placeholder when tags exist", () => {
+      const { input } = setup(["prod"]);
+      expect(input?.placeholder).toBe("");
+    });
+
+    it("renders remove button for each tag when not disabled", () => {
+      setup(["prod", "web"]);
+      expect(screen.getByLabelText('Remove tag "prod"')).toBeInTheDocument();
+      expect(screen.getByLabelText('Remove tag "web"')).toBeInTheDocument();
+    });
+
+    it("does not render remove buttons when disabled", () => {
+      setup(["prod"], { disabled: true });
+      expect(screen.queryByLabelText('Remove tag "prod"')).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Tag addition ─────────────────────────────────────────────────────────────
+
+  describe("adding tags", () => {
+    it("adds tag on Enter", async () => {
+      const { input, onChange } = setup([]);
+      await userEvent.type(input!, "newtag{Enter}");
+      expect(onChange).toHaveBeenCalledWith(["newtag"]);
+    });
+
+    it("adds tag on comma", async () => {
+      const { input, onChange } = setup([]);
+      await userEvent.type(input!, "newtag,");
+      expect(onChange).toHaveBeenCalledWith(["newtag"]);
+    });
+
+    it("trims whitespace and lowercases the tag", async () => {
+      const { input, onChange } = setup([]);
+      await userEvent.type(input!, "  MyTag  {Enter}");
+      expect(onChange).toHaveBeenCalledWith(["mytag"]);
+    });
+
+    it("ignores empty/whitespace-only input on Enter", async () => {
+      const { input, onChange } = setup([]);
+      await userEvent.type(input!, "   {Enter}");
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("does not add duplicate tag", async () => {
+      const { input, onChange } = setup(["prod"]);
+      await userEvent.type(input!, "prod{Enter}");
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("appends to existing tags", async () => {
+      const { input, onChange } = setup(["prod"]);
+      await userEvent.type(input!, "web{Enter}");
+      expect(onChange).toHaveBeenCalledWith(["prod", "web"]);
+    });
+  });
+
+  // ── Tag removal ──────────────────────────────────────────────────────────────
+
+  describe("removing tags", () => {
+    it("removes tag via remove button click", async () => {
+      const { onChange } = setup(["prod", "web"]);
+      await userEvent.click(screen.getByLabelText('Remove tag "prod"'));
+      expect(onChange).toHaveBeenCalledWith(["web"]);
+    });
+
+    it("removes last tag on Backspace with empty input", async () => {
+      const { input, onChange } = setup(["prod", "web"]);
+      await userEvent.type(input!, "{Backspace}");
+      expect(onChange).toHaveBeenCalledWith(["prod"]);
+    });
+
+    it("does not remove on Backspace when input has text", async () => {
+      const { input, onChange } = setup(["prod"]);
+      await userEvent.type(input!, "ab{Backspace}");
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("does not remove on Backspace when no tags", async () => {
+      const { input, onChange } = setup([]);
+      await userEvent.type(input!, "{Backspace}");
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Dropdown visibility ───────────────────────────────────────────────────────
+
+  describe("dropdown", () => {
+    it("shows suggestions matching input", async () => {
+      const { input } = setup([], { allTags: ["production", "staging", "web"] });
+      await userEvent.type(input!, "pro");
+      expect(screen.getByText("production")).toBeInTheDocument();
+      expect(screen.queryByText("staging")).not.toBeInTheDocument();
+    });
+
+    it("hides already-applied tags from suggestions", async () => {
+      const { input } = setup(["prod"], { allTags: ["prod", "web"] });
+      await userEvent.type(input!, "p");
+      // "prod" is applied — it must not appear as a suggestion option
+      const options = screen.queryAllByRole("option");
+      const optionTexts = options.map((o) => o.textContent);
+      expect(optionTexts.some((t) => t === "prod")).toBe(false);
+    });
+
+    it("shows 'Create' option for new tag input", async () => {
+      const { input } = setup([], { allTags: ["existing"] });
+      await userEvent.type(input!, "newone");
+      expect(screen.getByText("Create")).toBeInTheDocument();
+      expect(screen.getByText('"newone"')).toBeInTheDocument();
+    });
+
+    it("hides 'Create' option when input matches existing tag exactly", async () => {
+      const { input } = setup(["web"], { allTags: ["web", "prod"] });
+      await userEvent.type(input!, "web");
+      expect(screen.queryByText("Create")).not.toBeInTheDocument();
+    });
+
+    it("closes dropdown on Escape", async () => {
+      const { input } = setup([], { allTags: ["prod"] });
+      await userEvent.type(input!, "p");
+      expect(screen.getByText("prod")).toBeInTheDocument();
+      await userEvent.keyboard("{Escape}");
+      expect(screen.queryByText("prod")).not.toBeInTheDocument();
+    });
+
+    it("adds tag when suggestion clicked", async () => {
+      const { input, onChange } = setup([], { allTags: ["production"] });
+      await userEvent.type(input!, "pro");
+      fireEvent.mouseDown(screen.getByText("production"));
+      expect(onChange).toHaveBeenCalledWith(["production"]);
+    });
+  });
+
+  // ── Arrow key navigation ──────────────────────────────────────────────────────
+
+  describe("arrow key navigation", () => {
+    it("opens dropdown and highlights first item on ArrowDown", async () => {
+      const { input } = setup([], { allTags: ["alpha", "beta"] });
+      await userEvent.type(input!, "a");
+      await userEvent.keyboard("{ArrowDown}");
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("moves highlight down on repeated ArrowDown", async () => {
+      const { input } = setup([], { allTags: ["alpha", "beta"] });
+      await userEvent.type(input!, "a");
+      await userEvent.keyboard("{ArrowDown}{ArrowDown}");
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveAttribute("aria-selected", "false");
+      expect(options[1]).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("does not move beyond the last item on ArrowDown", async () => {
+      const { input } = setup([], { allTags: ["only"] });
+      await userEvent.type(input!, "o");
+      // Dropdown has: [Create "o", "only"] — 2 items, indices 0 and 1.
+      // After 5 ArrowDowns the index should be clamped at 1.
+      await userEvent.keyboard(
+        "{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}",
+      );
+      const options = screen.getAllByRole("option");
+      expect(options[options.length - 1]).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    it("moves highlight up on ArrowUp", async () => {
+      const { input } = setup([], { allTags: ["alpha", "beta"] });
+      await userEvent.type(input!, "a");
+      await userEvent.keyboard("{ArrowDown}{ArrowDown}{ArrowUp}");
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveAttribute("aria-selected", "true");
+      expect(options[1]).toHaveAttribute("aria-selected", "false");
+    });
+
+    it("ArrowUp from index 0 deselects all (index -1)", async () => {
+      const { input } = setup([], { allTags: ["alpha"] });
+      await userEvent.type(input!, "a");
+      await userEvent.keyboard("{ArrowDown}{ArrowUp}");
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveAttribute("aria-selected", "false");
+    });
+
+    it("Enter selects highlighted item", async () => {
+      // Use an exact match input so there's no "Create" option — only "alpha".
+      const { input, onChange } = setup([], { allTags: ["alpha"] });
+      await userEvent.type(input!, "alpha");
+      // No Create option when input exactly matches a suggestion that isn't applied.
+      // Dropdown: [index 0 = "alpha"].
+      await userEvent.keyboard("{ArrowDown}{Enter}");
+      expect(onChange).toHaveBeenCalledWith(["alpha"]);
+    });
+
+    it("Enter with no highlighted item adds typed input", async () => {
+      const { input, onChange } = setup([], { allTags: ["alpha"] });
+      await userEvent.type(input!, "custom{Enter}");
+      expect(onChange).toHaveBeenCalledWith(["custom"]);
+    });
+
+    it("Escape clears highlight and closes dropdown", async () => {
+      const { input } = setup([], { allTags: ["alpha"] });
+      await userEvent.type(input!, "a");
+      await userEvent.keyboard("{ArrowDown}{Escape}");
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("resets highlight when input changes", async () => {
+      const { input } = setup([], { allTags: ["alpha", "beta"] });
+      await userEvent.type(input!, "a");
+      await userEvent.keyboard("{ArrowDown}");
+      // Type another character — highlight should reset
+      await userEvent.type(input!, "l");
+      const options = screen.getAllByRole("option");
+      options.forEach((opt) =>
+        expect(opt).toHaveAttribute("aria-selected", "false"),
+      );
+    });
+
+    it("hovering an item updates the active index", async () => {
+      const { input } = setup([], { allTags: ["alpha", "beta"] });
+      await userEvent.type(input!, "a");
+      const options = screen.getAllByRole("option");
+      fireEvent.mouseEnter(options[1]!);
+      expect(options[1]).toHaveAttribute("aria-selected", "true");
+      expect(options[0]).toHaveAttribute("aria-selected", "false");
+    });
+  });
+
+  // ── Accessibility ─────────────────────────────────────────────────────────────
+
+  describe("accessibility", () => {
+    it("dropdown has listbox role", async () => {
+      const { input } = setup([], { allTags: ["prod"] });
+      await userEvent.type(input!, "p");
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    it("each dropdown item has option role", async () => {
+      const { input } = setup([], { allTags: ["prod", "staging"] });
+      await userEvent.type(input!, "p");
+      const options = screen.getAllByRole("option");
+      expect(options.length).toBeGreaterThan(0);
+    });
+
+    it("remove buttons have accessible labels", () => {
+      setup(["prod", "web"]);
+      expect(screen.getByLabelText('Remove tag "prod"')).toBeInTheDocument();
+      expect(screen.getByLabelText('Remove tag "web"')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/tag-input.tsx
+++ b/frontend/src/components/tag-input.tsx
@@ -19,6 +19,7 @@ export function TagInput({
 }: TagInputProps) {
   const [input, setInput] = useState("");
   const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -28,6 +29,14 @@ export function TagInput({
       !tags.includes(t),
   );
 
+  // All selectable items in the dropdown: "create" option first, then suggestions.
+  const dropdownItems: string[] = [
+    ...(input.trim() !== "" && !tags.includes(input.trim().toLowerCase())
+      ? [input.trim().toLowerCase()]
+      : []),
+    ...suggestions,
+  ];
+
   const addTag = useCallback(
     (tag: string) => {
       const trimmed = tag.trim().toLowerCase();
@@ -35,6 +44,7 @@ export function TagInput({
       onChange([...tags, trimmed]);
       setInput("");
       setOpen(false);
+      setActiveIndex(-1);
     },
     [tags, onChange],
   );
@@ -47,13 +57,25 @@ export function TagInput({
   );
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === "Enter" || e.key === ",") {
+    if (e.key === "ArrowDown") {
       e.preventDefault();
-      if (input.trim()) addTag(input);
+      if (!open) setOpen(true);
+      setActiveIndex((i) => Math.min(i + 1, dropdownItems.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, -1));
+    } else if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      if (activeIndex >= 0 && dropdownItems[activeIndex]) {
+        addTag(dropdownItems[activeIndex]!);
+      } else if (input.trim()) {
+        addTag(input);
+      }
     } else if (e.key === "Backspace" && input === "" && tags.length > 0) {
       removeTag(tags[tags.length - 1]!);
     } else if (e.key === "Escape") {
       setOpen(false);
+      setActiveIndex(-1);
     }
   }
 
@@ -111,6 +133,7 @@ export function TagInput({
             onChange={(e) => {
               setInput(e.target.value);
               setOpen(true);
+              setActiveIndex(-1);
             }}
             onFocus={() => setOpen(true)}
             onKeyDown={handleKeyDown}
@@ -120,39 +143,42 @@ export function TagInput({
         )}
       </div>
 
-      {open && (input.trim() !== "" || suggestions.length > 0) && (
-        <div className="absolute left-0 top-full mt-1 z-30 w-full bg-surface border border-border rounded-md shadow-lg py-1 max-h-40 overflow-y-auto">
-          {/* Create new tag option */}
-          {input.trim() !== "" && !tags.includes(input.trim().toLowerCase()) && (
-            <button
-              type="button"
-              onMouseDown={(e) => {
-                e.preventDefault();
-                addTag(input);
-              }}
-              className="w-full text-left px-3 py-1.5 text-xs hover:bg-surface-raised flex items-center gap-1.5"
-            >
-              <span className="text-text-muted">Create</span>
-              <span className="font-medium text-accent">
-                "{input.trim().toLowerCase()}"
-              </span>
-            </button>
-          )}
-
-          {/* Existing tag suggestions */}
-          {suggestions.map((t) => (
-            <button
-              key={t}
-              type="button"
-              onMouseDown={(e) => {
-                e.preventDefault();
-                addTag(t);
-              }}
-              className="w-full text-left px-3 py-1.5 text-xs hover:bg-surface-raised text-text-primary"
-            >
-              {t}
-            </button>
-          ))}
+      {open && dropdownItems.length > 0 && (
+        <div
+          role="listbox"
+          className="absolute left-0 top-full mt-1 z-30 w-full bg-surface border border-border rounded-md shadow-lg py-1 max-h-40 overflow-y-auto"
+        >
+          {dropdownItems.map((item, idx) => {
+            const isCreate = idx === 0 && input.trim() !== "" && !tags.includes(input.trim().toLowerCase()) && item === input.trim().toLowerCase();
+            const isActive = idx === activeIndex;
+            return (
+              <button
+                key={`${isCreate ? "create" : "suggest"}-${item}`}
+                type="button"
+                role="option"
+                aria-selected={isActive}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  addTag(item);
+                }}
+                onMouseEnter={() => setActiveIndex(idx)}
+                className={cn(
+                  "w-full text-left px-3 py-1.5 text-xs",
+                  isActive ? "bg-surface-raised" : "hover:bg-surface-raised",
+                  isCreate ? "flex items-center gap-1.5" : "text-text-primary",
+                )}
+              >
+                {isCreate ? (
+                  <>
+                    <span className="text-text-muted">Create</span>
+                    <span className="font-medium text-accent">"{item}"</span>
+                  </>
+                ) : (
+                  item
+                )}
+              </button>
+            );
+          })}
         </div>
       )}
     </div>

--- a/internal/db/settings_integration_test.go
+++ b/internal/db/settings_integration_test.go
@@ -1,0 +1,173 @@
+// Package db — integration tests for SettingsRepository.
+// These tests require a running Postgres instance and will be skipped
+// automatically in short mode or when no database is reachable.
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/errors"
+)
+
+// ── ListSettings ───────────────────────────────────────────────────────────────
+
+func TestSettings_ListSettings_ReturnsSeedRows(t *testing.T) {
+	db := connectTestDB(t)
+	defer db.Close()
+
+	repo := NewSettingsRepository(db)
+	settings, err := repo.ListSettings(context.Background())
+
+	require.NoError(t, err)
+	// Migration 009 seeds at least these keys.
+	keys := make(map[string]string, len(settings))
+	for _, s := range settings {
+		keys[s.Key] = s.Value
+	}
+	assert.Contains(t, keys, "scan.default_timing")
+	assert.Contains(t, keys, "scan.max_concurrent")
+	assert.Contains(t, keys, "notifications.scan_complete")
+}
+
+func TestSettings_ListSettings_OrderedByKey(t *testing.T) {
+	db := connectTestDB(t)
+	defer db.Close()
+
+	repo := NewSettingsRepository(db)
+	settings, err := repo.ListSettings(context.Background())
+
+	require.NoError(t, err)
+	for i := 1; i < len(settings); i++ {
+		assert.LessOrEqual(t, settings[i-1].Key, settings[i].Key,
+			"expected settings ordered by key, got %q before %q",
+			settings[i-1].Key, settings[i].Key)
+	}
+}
+
+// ── GetSetting ─────────────────────────────────────────────────────────────────
+
+func TestSettings_GetSetting_Exists(t *testing.T) {
+	db := connectTestDB(t)
+	defer db.Close()
+
+	repo := NewSettingsRepository(db)
+	s, err := repo.GetSetting(context.Background(), "scan.default_timing")
+
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	assert.Equal(t, "scan.default_timing", s.Key)
+	assert.Equal(t, "int", s.Type)
+	assert.NotEmpty(t, s.Description)
+}
+
+func TestSettings_GetSetting_NotFound(t *testing.T) {
+	db := connectTestDB(t)
+	defer db.Close()
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.GetSetting(context.Background(), "this.key.does.not.exist")
+
+	require.Error(t, err)
+	assert.True(t, errors.IsNotFound(err), "expected ErrNotFound, got: %v", err)
+}
+
+// ── SetSetting (write → read-back) ────────────────────────────────────────────
+
+func TestSettings_SetSetting_WriteThenReadBack(t *testing.T) {
+	db := connectTestDB(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	repo := NewSettingsRepository(db)
+
+	// Restore original value at end of test.
+	orig, err := repo.GetSetting(ctx, "scan.max_concurrent")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = repo.SetSetting(ctx, "scan.max_concurrent", orig.Value)
+	})
+
+	require.NoError(t, repo.SetSetting(ctx, "scan.max_concurrent", "99"))
+
+	got, err := repo.GetSetting(ctx, "scan.max_concurrent")
+	require.NoError(t, err)
+	assert.Equal(t, "99", got.Value)
+}
+
+func TestSettings_SetSetting_BoolRoundTrip(t *testing.T) {
+	db := connectTestDB(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	repo := NewSettingsRepository(db)
+
+	orig, err := repo.GetSetting(ctx, "notifications.scan_complete")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = repo.SetSetting(ctx, "notifications.scan_complete", orig.Value)
+	})
+
+	// Toggle the bool value and read back.
+	newVal := "false"
+	if orig.Value == "false" {
+		newVal = "true"
+	}
+	require.NoError(t, repo.SetSetting(ctx, "notifications.scan_complete", newVal))
+
+	got, err := repo.GetSetting(ctx, "notifications.scan_complete")
+	require.NoError(t, err)
+	assert.Equal(t, newVal, got.Value)
+}
+
+func TestSettings_SetSetting_UpdatedAtAdvances(t *testing.T) {
+	db := connectTestDB(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	repo := NewSettingsRepository(db)
+
+	before, err := repo.GetSetting(ctx, "scan.default_timing")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = repo.SetSetting(ctx, "scan.default_timing", before.Value)
+	})
+
+	require.NoError(t, repo.SetSetting(ctx, "scan.default_timing", "2"))
+
+	after, err := repo.GetSetting(ctx, "scan.default_timing")
+	require.NoError(t, err)
+	assert.True(t, !after.UpdatedAt.Before(before.UpdatedAt),
+		"updated_at should advance; before=%v after=%v", before.UpdatedAt, after.UpdatedAt)
+}
+
+func TestSettings_SetSetting_UnknownKeyReturnsNotFound(t *testing.T) {
+	db := connectTestDB(t)
+	defer db.Close()
+
+	repo := NewSettingsRepository(db)
+	err := repo.SetSetting(context.Background(), "not.a.real.key", "42")
+
+	require.Error(t, err)
+	assert.True(t, errors.IsNotFound(err), "expected ErrNotFound, got: %v", err)
+}
+
+func TestSettings_SetSetting_AllSeedKeysAreWritable(t *testing.T) {
+	db := connectTestDB(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	repo := NewSettingsRepository(db)
+	settings, err := repo.ListSettings(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, settings)
+
+	for _, s := range settings {
+		// Write back the same value — should always succeed.
+		err := repo.SetSetting(ctx, s.Key, s.Value)
+		assert.NoError(t, err, "SetSetting(%q) failed", s.Key)
+	}
+}


### PR DESCRIPTION
## Summary

- **TagInput keyboard accessibility** — `ArrowDown`/`ArrowUp` navigate through the autocomplete dropdown; active item receives `aria-selected="true"` and a visual highlight; `mouseEnter` syncs the keyboard index; `Enter` selects the highlighted item; `activeIndex` resets to -1 when the input text changes; dropdown gains `role="listbox"` and each item `role="option"` for screen readers
- **tag-input.test.tsx** — 36 tests: rendering, tag addition (Enter/comma/trim/lowercase/dedup), tag removal (button/Backspace), dropdown visibility, arrow key navigation (down/up/clamp/hover/Enter-select/Escape), and accessibility attributes
- **settings_integration_test.go** — 8 integration tests for `SettingsRepository`: seed rows returned, ordering by key, GetSetting found/not-found, write→read-back round-trip, bool toggle, `updated_at` advancing, unknown key returning ErrNotFound, all seeded keys writable

## Test plan

- [ ] 938 frontend tests pass, all Go packages pass
- [ ] In the browser: type in a tag input, use `↓` to navigate suggestions, `Enter` to select, `Escape` to close
- [ ] `aria-selected` and `role="option"` verified with accessibility tools
- [ ] Integration tests pass against a real Postgres instance (`go test ./internal/db/...`)
- [ ] Settings PUT → GET round-trip confirmed via `curl` against running server

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)