### PR TITLE
fix(errors): unwrap error chains in IsCode using errors.As

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -984,6 +984,7 @@ make lint-fix && make lint && make test
 6. **Batch similar fixes**: Group lint fixes, type fixes, etc. before squashing
 7. **Precise commit messages**: Avoid adjectives, use technical descriptions
 8. **Imperative mood**: "fix timeout" not "fixed timeout" or "fixes timeout"
+9. **No PR/issue references in commit messages**: Never include PR numbers, issue numbers, or tracking identifiers (e.g. "#647", "PR C", "issue #123") in commit message subjects or bodies. The git history must be self-contained and readable without a project tracker.
 
 ### Anti-Patterns (Avoid Yak Shaving):
 ```bash

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -4,6 +4,7 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -262,17 +263,23 @@ func WrapConfigError(code ErrorCode, message string, err error) *ConfigError {
 
 // Utility functions for common error operations
 
-// IsCode checks if an error has a specific error code.
+// IsCode checks if an error has a specific error code, unwrapping through error chains.
 func IsCode(err error, code ErrorCode) bool {
-	switch e := err.(type) {
-	case *ScanError:
-		return e.Code == code
-	case *DatabaseError:
-		return e.Code == code
-	case *DiscoveryError:
-		return e.Code == code
-	case *ConfigError:
-		return e.Code == code
+	var scanErr *ScanError
+	if errors.As(err, &scanErr) {
+		return scanErr.Code == code
+	}
+	var dbErr *DatabaseError
+	if errors.As(err, &dbErr) {
+		return dbErr.Code == code
+	}
+	var discErr *DiscoveryError
+	if errors.As(err, &discErr) {
+		return discErr.Code == code
+	}
+	var cfgErr *ConfigError
+	if errors.As(err, &cfgErr) {
+		return cfgErr.Code == code
 	}
 	return false
 }


### PR DESCRIPTION
## Summary

- `IsCode()` used a type switch that only matched direct error types, not wrapped errors
- Handlers calling `errors.IsNotFound(err)` on wrapped service errors (e.g. `fmt.Errorf("cloning profile: %w", err)`) always fell through to the 500 branch
- Replacing with `errors.As()` properly unwraps error chains and fixes HTTP status propagation

**Symptom caught during manual testing (issue #649):**  
`POST /api/v1/profiles/nonexistent/fork` returned 500 instead of 404.

## Test plan

- [x] `go test ./internal/errors/...` passes
- [x] `go test ./internal/api/...` passes
- [x] `POST /api/v1/profiles/{nonexistent}/fork` returns `404` (not `500`)
- [x] `POST /api/v1/profiles/{nonexistent}/clone` returns `404` (not `500`)
- [x] `go test -race ./internal/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)