### PR TITLE
fix: wave 1 followup fixes from bug hunt

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -3272,6 +3272,56 @@ const docTemplate = `{
                 }
             }
         },
+        "docs.CertificateResponse": {
+            "type": "object",
+            "properties": {
+                "host_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "issuer": {
+                    "type": "string",
+                    "example": "Let's Encrypt Authority X3"
+                },
+                "key_type": {
+                    "type": "string",
+                    "example": "RSA-2048"
+                },
+                "not_after": {
+                    "type": "string"
+                },
+                "not_before": {
+                    "type": "string"
+                },
+                "port": {
+                    "type": "integer",
+                    "example": 443
+                },
+                "sans": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "server01.local",
+                        "www.server01.local"
+                    ]
+                },
+                "scanned_at": {
+                    "type": "string"
+                },
+                "subject_cn": {
+                    "type": "string",
+                    "example": "server01.local"
+                },
+                "tls_version": {
+                    "type": "string",
+                    "example": "TLS 1.3"
+                }
+            }
+        },
         "docs.CreateDiscoveryJobRequest": {
             "type": "object",
             "properties": {
@@ -3477,6 +3527,41 @@ const docTemplate = `{
                 }
             }
         },
+        "docs.DNSRecordResponse": {
+            "type": "object",
+            "properties": {
+                "host_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "record_type": {
+                    "type": "string",
+                    "enum": [
+                        "A",
+                        "AAAA",
+                        "PTR",
+                        "CNAME",
+                        "MX",
+                        "TXT",
+                        "SRV"
+                    ],
+                    "example": "PTR"
+                },
+                "resolved_at": {
+                    "type": "string"
+                },
+                "ttl": {
+                    "type": "integer",
+                    "example": 300
+                },
+                "value": {
+                    "type": "string",
+                    "example": "server01.local"
+                }
+            }
+        },
         "docs.DiscoveryJobResponse": {
             "type": "object",
             "properties": {
@@ -3599,6 +3684,31 @@ const docTemplate = `{
         "docs.HostResponse": {
             "type": "object",
             "properties": {
+                "banners": {
+                    "description": "Banners are populated when banner grabbing has run for this host.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/docs.PortBannerResponse"
+                    }
+                },
+                "certificates": {
+                    "description": "Certificates are populated when TLS banner grabbing has run for this host.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/docs.CertificateResponse"
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Primary web server"
+                },
+                "dns_records": {
+                    "description": "DNSRecords are populated when DNS enrichment has run for this host.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/docs.DNSRecordResponse"
+                    }
+                },
                 "first_seen": {
                     "type": "string"
                 },
@@ -3621,6 +3731,10 @@ const docTemplate = `{
                     "type": "string",
                     "example": "00:1B:44:11:3A:B7"
                 },
+                "network_id": {
+                    "description": "NetworkID is the network this host belongs to, if any.",
+                    "type": "string"
+                },
                 "open_ports": {
                     "type": "array",
                     "items": {
@@ -3632,9 +3746,39 @@ const docTemplate = `{
                         443
                     ]
                 },
+                "os_family": {
+                    "description": "OSFamily is the broad OS family detected by nmap (e.g. \"Linux\", \"Windows\").",
+                    "type": "string",
+                    "example": "Linux"
+                },
+                "os_name": {
+                    "description": "OSName is the full OS name returned by nmap (e.g. \"Linux 5.15\").",
+                    "type": "string",
+                    "example": "Ubuntu 22.04"
+                },
+                "os_version": {
+                    "type": "string",
+                    "example": "22.04"
+                },
+                "response_time_avg_ms": {
+                    "type": "number",
+                    "example": 1.5
+                },
+                "response_time_ms": {
+                    "type": "number",
+                    "example": 1.23
+                },
                 "scan_count": {
                     "type": "integer",
                     "example": 5
+                },
+                "snmp_data": {
+                    "description": "SNMPData is populated when SNMP enrichment has run for this host.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/docs.SNMPDataResponse"
+                        }
+                    ]
                 },
                 "status": {
                     "type": "string",
@@ -3644,6 +3788,20 @@ const docTemplate = `{
                         "unknown"
                     ],
                     "example": "up"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "web",
+                        "production"
+                    ]
+                },
+                "vendor": {
+                    "type": "string",
+                    "example": "Dell Inc."
                 }
             }
         },
@@ -3907,6 +4065,44 @@ const docTemplate = `{
                 }
             }
         },
+        "docs.PortBannerResponse": {
+            "type": "object",
+            "properties": {
+                "host_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "port": {
+                    "type": "integer",
+                    "example": 80
+                },
+                "protocol": {
+                    "type": "string",
+                    "enum": [
+                        "tcp",
+                        "udp"
+                    ],
+                    "example": "tcp"
+                },
+                "raw_banner": {
+                    "type": "string",
+                    "example": "HTTP/1.1 200 OK"
+                },
+                "scanned_at": {
+                    "type": "string"
+                },
+                "service": {
+                    "type": "string",
+                    "example": "nginx"
+                },
+                "version": {
+                    "type": "string",
+                    "example": "1.24.0"
+                }
+            }
+        },
         "docs.ProfileResponse": {
             "type": "object",
             "properties": {
@@ -3958,6 +4154,78 @@ const docTemplate = `{
                 "new_name": {
                     "type": "string",
                     "example": "New Office Network"
+                }
+            }
+        },
+        "docs.SNMPDataResponse": {
+            "type": "object",
+            "properties": {
+                "collected_at": {
+                    "type": "string"
+                },
+                "if_count": {
+                    "type": "integer",
+                    "example": 4
+                },
+                "interfaces": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/docs.SNMPInterfaceResponse"
+                    }
+                },
+                "sys_contact": {
+                    "type": "string",
+                    "example": "admin@example.com"
+                },
+                "sys_descr": {
+                    "type": "string",
+                    "example": "Cisco IOS XE"
+                },
+                "sys_location": {
+                    "type": "string",
+                    "example": "Server Room A"
+                },
+                "sys_name": {
+                    "type": "string",
+                    "example": "router01"
+                },
+                "sys_uptime_cs": {
+                    "type": "integer",
+                    "example": 123456789
+                }
+            }
+        },
+        "docs.SNMPInterfaceResponse": {
+            "type": "object",
+            "properties": {
+                "index": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "ip": {
+                    "type": "string",
+                    "example": "192.168.1.1"
+                },
+                "mac": {
+                    "type": "string",
+                    "example": "00:1B:44:11:3A:B7"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "eth0"
+                },
+                "speed_mbps": {
+                    "type": "number",
+                    "example": 1000
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "up",
+                        "down",
+                        "unknown"
+                    ],
+                    "example": "up"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -3266,6 +3266,56 @@
                 }
             }
         },
+        "docs.CertificateResponse": {
+            "type": "object",
+            "properties": {
+                "host_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "issuer": {
+                    "type": "string",
+                    "example": "Let's Encrypt Authority X3"
+                },
+                "key_type": {
+                    "type": "string",
+                    "example": "RSA-2048"
+                },
+                "not_after": {
+                    "type": "string"
+                },
+                "not_before": {
+                    "type": "string"
+                },
+                "port": {
+                    "type": "integer",
+                    "example": 443
+                },
+                "sans": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "server01.local",
+                        "www.server01.local"
+                    ]
+                },
+                "scanned_at": {
+                    "type": "string"
+                },
+                "subject_cn": {
+                    "type": "string",
+                    "example": "server01.local"
+                },
+                "tls_version": {
+                    "type": "string",
+                    "example": "TLS 1.3"
+                }
+            }
+        },
         "docs.CreateDiscoveryJobRequest": {
             "type": "object",
             "properties": {
@@ -3471,6 +3521,41 @@
                 }
             }
         },
+        "docs.DNSRecordResponse": {
+            "type": "object",
+            "properties": {
+                "host_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "record_type": {
+                    "type": "string",
+                    "enum": [
+                        "A",
+                        "AAAA",
+                        "PTR",
+                        "CNAME",
+                        "MX",
+                        "TXT",
+                        "SRV"
+                    ],
+                    "example": "PTR"
+                },
+                "resolved_at": {
+                    "type": "string"
+                },
+                "ttl": {
+                    "type": "integer",
+                    "example": 300
+                },
+                "value": {
+                    "type": "string",
+                    "example": "server01.local"
+                }
+            }
+        },
         "docs.DiscoveryJobResponse": {
             "type": "object",
             "properties": {
@@ -3593,6 +3678,31 @@
         "docs.HostResponse": {
             "type": "object",
             "properties": {
+                "banners": {
+                    "description": "Banners are populated when banner grabbing has run for this host.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/docs.PortBannerResponse"
+                    }
+                },
+                "certificates": {
+                    "description": "Certificates are populated when TLS banner grabbing has run for this host.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/docs.CertificateResponse"
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Primary web server"
+                },
+                "dns_records": {
+                    "description": "DNSRecords are populated when DNS enrichment has run for this host.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/docs.DNSRecordResponse"
+                    }
+                },
                 "first_seen": {
                     "type": "string"
                 },
@@ -3615,6 +3725,10 @@
                     "type": "string",
                     "example": "00:1B:44:11:3A:B7"
                 },
+                "network_id": {
+                    "description": "NetworkID is the network this host belongs to, if any.",
+                    "type": "string"
+                },
                 "open_ports": {
                     "type": "array",
                     "items": {
@@ -3626,9 +3740,39 @@
                         443
                     ]
                 },
+                "os_family": {
+                    "description": "OSFamily is the broad OS family detected by nmap (e.g. \"Linux\", \"Windows\").",
+                    "type": "string",
+                    "example": "Linux"
+                },
+                "os_name": {
+                    "description": "OSName is the full OS name returned by nmap (e.g. \"Linux 5.15\").",
+                    "type": "string",
+                    "example": "Ubuntu 22.04"
+                },
+                "os_version": {
+                    "type": "string",
+                    "example": "22.04"
+                },
+                "response_time_avg_ms": {
+                    "type": "number",
+                    "example": 1.5
+                },
+                "response_time_ms": {
+                    "type": "number",
+                    "example": 1.23
+                },
                 "scan_count": {
                     "type": "integer",
                     "example": 5
+                },
+                "snmp_data": {
+                    "description": "SNMPData is populated when SNMP enrichment has run for this host.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/docs.SNMPDataResponse"
+                        }
+                    ]
                 },
                 "status": {
                     "type": "string",
@@ -3638,6 +3782,20 @@
                         "unknown"
                     ],
                     "example": "up"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "web",
+                        "production"
+                    ]
+                },
+                "vendor": {
+                    "type": "string",
+                    "example": "Dell Inc."
                 }
             }
         },
@@ -3901,6 +4059,44 @@
                 }
             }
         },
+        "docs.PortBannerResponse": {
+            "type": "object",
+            "properties": {
+                "host_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "port": {
+                    "type": "integer",
+                    "example": 80
+                },
+                "protocol": {
+                    "type": "string",
+                    "enum": [
+                        "tcp",
+                        "udp"
+                    ],
+                    "example": "tcp"
+                },
+                "raw_banner": {
+                    "type": "string",
+                    "example": "HTTP/1.1 200 OK"
+                },
+                "scanned_at": {
+                    "type": "string"
+                },
+                "service": {
+                    "type": "string",
+                    "example": "nginx"
+                },
+                "version": {
+                    "type": "string",
+                    "example": "1.24.0"
+                }
+            }
+        },
         "docs.ProfileResponse": {
             "type": "object",
             "properties": {
@@ -3952,6 +4148,78 @@
                 "new_name": {
                     "type": "string",
                     "example": "New Office Network"
+                }
+            }
+        },
+        "docs.SNMPDataResponse": {
+            "type": "object",
+            "properties": {
+                "collected_at": {
+                    "type": "string"
+                },
+                "if_count": {
+                    "type": "integer",
+                    "example": 4
+                },
+                "interfaces": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/docs.SNMPInterfaceResponse"
+                    }
+                },
+                "sys_contact": {
+                    "type": "string",
+                    "example": "admin@example.com"
+                },
+                "sys_descr": {
+                    "type": "string",
+                    "example": "Cisco IOS XE"
+                },
+                "sys_location": {
+                    "type": "string",
+                    "example": "Server Room A"
+                },
+                "sys_name": {
+                    "type": "string",
+                    "example": "router01"
+                },
+                "sys_uptime_cs": {
+                    "type": "integer",
+                    "example": 123456789
+                }
+            }
+        },
+        "docs.SNMPInterfaceResponse": {
+            "type": "object",
+            "properties": {
+                "index": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "ip": {
+                    "type": "string",
+                    "example": "192.168.1.1"
+                },
+                "mac": {
+                    "type": "string",
+                    "example": "00:1B:44:11:3A:B7"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "eth0"
+                },
+                "speed_mbps": {
+                    "type": "number",
+                    "example": 1000
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "up",
+                        "down",
+                        "unknown"
+                    ],
+                    "example": "up"
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -11,6 +11,41 @@ definitions:
       timestamp:
         type: string
     type: object
+  docs.CertificateResponse:
+    properties:
+      host_id:
+        type: string
+      id:
+        type: string
+      issuer:
+        example: Let's Encrypt Authority X3
+        type: string
+      key_type:
+        example: RSA-2048
+        type: string
+      not_after:
+        type: string
+      not_before:
+        type: string
+      port:
+        example: 443
+        type: integer
+      sans:
+        example:
+        - server01.local
+        - www.server01.local
+        items:
+          type: string
+        type: array
+      scanned_at:
+        type: string
+      subject_cn:
+        example: server01.local
+        type: string
+      tls_version:
+        example: TLS 1.3
+        type: string
+    type: object
   docs.CreateDiscoveryJobRequest:
     properties:
       description:
@@ -160,6 +195,32 @@ definitions:
         example: scan
         type: string
     type: object
+  docs.DNSRecordResponse:
+    properties:
+      host_id:
+        type: string
+      id:
+        type: string
+      record_type:
+        enum:
+        - A
+        - AAAA
+        - PTR
+        - CNAME
+        - MX
+        - TXT
+        - SRV
+        example: PTR
+        type: string
+      resolved_at:
+        type: string
+      ttl:
+        example: 300
+        type: integer
+      value:
+        example: server01.local
+        type: string
+    type: object
   docs.DiscoveryJobResponse:
     properties:
       completed_at:
@@ -246,6 +307,26 @@ definitions:
     type: object
   docs.HostResponse:
     properties:
+      banners:
+        description: Banners are populated when banner grabbing has run for this host.
+        items:
+          $ref: '#/definitions/docs.PortBannerResponse'
+        type: array
+      certificates:
+        description: Certificates are populated when TLS banner grabbing has run for
+          this host.
+        items:
+          $ref: '#/definitions/docs.CertificateResponse'
+        type: array
+      description:
+        example: Primary web server
+        type: string
+      dns_records:
+        description: DNSRecords are populated when DNS enrichment has run for this
+          host.
+        items:
+          $ref: '#/definitions/docs.DNSRecordResponse'
+        type: array
       first_seen:
         type: string
       hostname:
@@ -262,6 +343,9 @@ definitions:
       mac_address:
         example: 00:1B:44:11:3A:B7
         type: string
+      network_id:
+        description: NetworkID is the network this host belongs to, if any.
+        type: string
       open_ports:
         example:
         - 22
@@ -270,15 +354,47 @@ definitions:
         items:
           type: integer
         type: array
+      os_family:
+        description: OSFamily is the broad OS family detected by nmap (e.g. "Linux",
+          "Windows").
+        example: Linux
+        type: string
+      os_name:
+        description: OSName is the full OS name returned by nmap (e.g. "Linux 5.15").
+        example: Ubuntu 22.04
+        type: string
+      os_version:
+        example: "22.04"
+        type: string
+      response_time_avg_ms:
+        example: 1.5
+        type: number
+      response_time_ms:
+        example: 1.23
+        type: number
       scan_count:
         example: 5
         type: integer
+      snmp_data:
+        allOf:
+        - $ref: '#/definitions/docs.SNMPDataResponse'
+        description: SNMPData is populated when SNMP enrichment has run for this host.
       status:
         enum:
         - up
         - down
         - unknown
         example: up
+        type: string
+      tags:
+        example:
+        - web
+        - production
+        items:
+          type: string
+        type: array
+      vendor:
+        example: Dell Inc.
         type: string
     type: object
   docs.LivenessResponse:
@@ -463,6 +579,33 @@ definitions:
         example: 8
         type: integer
     type: object
+  docs.PortBannerResponse:
+    properties:
+      host_id:
+        type: string
+      id:
+        type: string
+      port:
+        example: 80
+        type: integer
+      protocol:
+        enum:
+        - tcp
+        - udp
+        example: tcp
+        type: string
+      raw_banner:
+        example: HTTP/1.1 200 OK
+        type: string
+      scanned_at:
+        type: string
+      service:
+        example: nginx
+        type: string
+      version:
+        example: 1.24.0
+        type: string
+    type: object
   docs.ProfileResponse:
     properties:
       created_at:
@@ -500,6 +643,58 @@ definitions:
     properties:
       new_name:
         example: New Office Network
+        type: string
+    type: object
+  docs.SNMPDataResponse:
+    properties:
+      collected_at:
+        type: string
+      if_count:
+        example: 4
+        type: integer
+      interfaces:
+        items:
+          $ref: '#/definitions/docs.SNMPInterfaceResponse'
+        type: array
+      sys_contact:
+        example: admin@example.com
+        type: string
+      sys_descr:
+        example: Cisco IOS XE
+        type: string
+      sys_location:
+        example: Server Room A
+        type: string
+      sys_name:
+        example: router01
+        type: string
+      sys_uptime_cs:
+        example: 123456789
+        type: integer
+    type: object
+  docs.SNMPInterfaceResponse:
+    properties:
+      index:
+        example: 1
+        type: integer
+      ip:
+        example: 192.168.1.1
+        type: string
+      mac:
+        example: 00:1B:44:11:3A:B7
+        type: string
+      name:
+        example: eth0
+        type: string
+      speed_mbps:
+        example: 1000
+        type: number
+      status:
+        enum:
+        - up
+        - down
+        - unknown
+        example: up
         type: string
     type: object
   docs.ScanResponse:

--- a/docs/swagger_docs.go
+++ b/docs/swagger_docs.go
@@ -205,13 +205,13 @@ type HostResponse struct {
 	OpenPorts []int    `json:"open_ports" example:"22,80,443"`
 	Tags      []string `json:"tags,omitempty" example:"web,production"`
 	// NetworkID is the network this host belongs to, if any.
-	NetworkID          *string   `json:"network_id,omitempty"`
-	Status             string    `json:"status" example:"up" enums:"up,down,unknown"`
-	ResponseTimeMs     *float64  `json:"response_time_ms,omitempty" example:"1.23"`
-	ResponseTimeAvgMs  *float64  `json:"response_time_avg_ms,omitempty" example:"1.5"`
-	LastSeen           time.Time `json:"last_seen"`
-	FirstSeen          time.Time `json:"first_seen"`
-	ScanCount          int       `json:"scan_count" example:"5"`
+	NetworkID         *string   `json:"network_id,omitempty"`
+	Status            string    `json:"status" example:"up" enums:"up,down,unknown"`
+	ResponseTimeMs    *float64  `json:"response_time_ms,omitempty" example:"1.23"`
+	ResponseTimeAvgMs *float64  `json:"response_time_avg_ms,omitempty" example:"1.5"`
+	LastSeen          time.Time `json:"last_seen"`
+	FirstSeen         time.Time `json:"first_seen"`
+	ScanCount         int       `json:"scan_count" example:"5"`
 	// DNSRecords are populated when DNS enrichment has run for this host.
 	DNSRecords []DNSRecordResponse `json:"dns_records,omitempty"`
 	// Banners are populated when banner grabbing has run for this host.

--- a/docs/swagger_docs.go
+++ b/docs/swagger_docs.go
@@ -130,17 +130,96 @@ type CreateScanRequest struct {
 	Tags        []string          `json:"tags,omitempty"`
 }
 
+// DNSRecordResponse represents a single DNS record for a host.
+type DNSRecordResponse struct {
+	ID         string    `json:"id"`
+	HostID     string    `json:"host_id"`
+	RecordType string    `json:"record_type" example:"PTR" enums:"A,AAAA,PTR,CNAME,MX,TXT,SRV"`
+	Value      string    `json:"value" example:"server01.local"`
+	TTL        *int      `json:"ttl,omitempty" example:"300"`
+	ResolvedAt time.Time `json:"resolved_at"`
+}
+
+// PortBannerResponse represents a service banner captured on a host port.
+type PortBannerResponse struct {
+	ID        string    `json:"id"`
+	HostID    string    `json:"host_id"`
+	Port      int       `json:"port" example:"80"`
+	Protocol  string    `json:"protocol" example:"tcp" enums:"tcp,udp"`
+	RawBanner *string   `json:"raw_banner,omitempty" example:"HTTP/1.1 200 OK"`
+	Service   *string   `json:"service,omitempty" example:"nginx"`
+	Version   *string   `json:"version,omitempty" example:"1.24.0"`
+	ScannedAt time.Time `json:"scanned_at"`
+}
+
+// CertificateResponse represents a TLS certificate captured from a host.
+type CertificateResponse struct {
+	ID        string    `json:"id"`
+	HostID    string    `json:"host_id"`
+	Port      int       `json:"port" example:"443"`
+	SubjectCN *string   `json:"subject_cn,omitempty" example:"server01.local"`
+	SANs      []string  `json:"sans,omitempty" example:"server01.local,www.server01.local"`
+	Issuer    *string   `json:"issuer,omitempty" example:"Let's Encrypt Authority X3"`
+	NotBefore *string   `json:"not_before,omitempty"`
+	NotAfter  *string   `json:"not_after,omitempty"`
+	KeyType   *string   `json:"key_type,omitempty" example:"RSA-2048"`
+	TLSVer    *string   `json:"tls_version,omitempty" example:"TLS 1.3"`
+	ScannedAt time.Time `json:"scanned_at"`
+}
+
+// SNMPInterfaceResponse represents a single network interface reported by SNMP.
+type SNMPInterfaceResponse struct {
+	Index     int     `json:"index" example:"1"`
+	Name      string  `json:"name" example:"eth0"`
+	Status    string  `json:"status" example:"up" enums:"up,down,unknown"`
+	SpeedMbps float64 `json:"speed_mbps" example:"1000"`
+	MAC       string  `json:"mac,omitempty" example:"00:1B:44:11:3A:B7"`
+	IP        string  `json:"ip,omitempty" example:"192.168.1.1"`
+}
+
+// SNMPDataResponse represents SNMP device information for a host.
+type SNMPDataResponse struct {
+	SysName     *string                 `json:"sys_name,omitempty" example:"router01"`
+	SysDescr    *string                 `json:"sys_descr,omitempty" example:"Cisco IOS XE"`
+	SysLocation *string                 `json:"sys_location,omitempty" example:"Server Room A"`
+	SysContact  *string                 `json:"sys_contact,omitempty" example:"admin@example.com"`
+	SysUptime   *int64                  `json:"sys_uptime_cs,omitempty" example:"123456789"`
+	IfCount     *int                    `json:"if_count,omitempty" example:"4"`
+	Interfaces  []SNMPInterfaceResponse `json:"interfaces,omitempty"`
+	CollectedAt time.Time               `json:"collected_at"`
+}
+
 // HostResponse represents a discovered host
 type HostResponse struct {
-	ID         string    `json:"id" example:"550e8400-e29b-41d4-a716-446655440002"`
-	IPAddress  string    `json:"ip_address" example:"192.168.1.100"`
-	Hostname   *string   `json:"hostname,omitempty" example:"server01.local"`
-	MACAddress *string   `json:"mac_address,omitempty" example:"00:1B:44:11:3A:B7"`
-	OpenPorts  []int     `json:"open_ports" example:"22,80,443"`
-	Status     string    `json:"status" example:"up" enums:"up,down,unknown"`
-	LastSeen   time.Time `json:"last_seen"`
-	FirstSeen  time.Time `json:"first_seen"`
-	ScanCount  int       `json:"scan_count" example:"5"`
+	ID          string  `json:"id" example:"550e8400-e29b-41d4-a716-446655440002"`
+	IPAddress   string  `json:"ip_address" example:"192.168.1.100"`
+	Hostname    *string `json:"hostname,omitempty" example:"server01.local"`
+	Description *string `json:"description,omitempty" example:"Primary web server"`
+	MACAddress  *string `json:"mac_address,omitempty" example:"00:1B:44:11:3A:B7"`
+	Vendor      *string `json:"vendor,omitempty" example:"Dell Inc."`
+	// OSFamily is the broad OS family detected by nmap (e.g. "Linux", "Windows").
+	OSFamily *string `json:"os_family,omitempty" example:"Linux"`
+	// OSName is the full OS name returned by nmap (e.g. "Linux 5.15").
+	OSName    *string  `json:"os_name,omitempty" example:"Ubuntu 22.04"`
+	OSVersion *string  `json:"os_version,omitempty" example:"22.04"`
+	OpenPorts []int    `json:"open_ports" example:"22,80,443"`
+	Tags      []string `json:"tags,omitempty" example:"web,production"`
+	// NetworkID is the network this host belongs to, if any.
+	NetworkID          *string   `json:"network_id,omitempty"`
+	Status             string    `json:"status" example:"up" enums:"up,down,unknown"`
+	ResponseTimeMs     *float64  `json:"response_time_ms,omitempty" example:"1.23"`
+	ResponseTimeAvgMs  *float64  `json:"response_time_avg_ms,omitempty" example:"1.5"`
+	LastSeen           time.Time `json:"last_seen"`
+	FirstSeen          time.Time `json:"first_seen"`
+	ScanCount          int       `json:"scan_count" example:"5"`
+	// DNSRecords are populated when DNS enrichment has run for this host.
+	DNSRecords []DNSRecordResponse `json:"dns_records,omitempty"`
+	// Banners are populated when banner grabbing has run for this host.
+	Banners []PortBannerResponse `json:"banners,omitempty"`
+	// Certificates are populated when TLS banner grabbing has run for this host.
+	Certificates []CertificateResponse `json:"certificates,omitempty"`
+	// SNMPData is populated when SNMP enrichment has run for this host.
+	SNMPData *SNMPDataResponse `json:"snmp_data,omitempty"`
 }
 
 // ProfileResponse represents a scan profile

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -4,4318 +4,4505 @@
  */
 
 export interface paths {
-  "/admin/status": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/admin/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Admin status
+         * @description Returns administrative status information
+         */
+        get: operations["getAdminStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Admin status
-     * @description Returns administrative status information
-     */
-    get: operations["getAdminStatus"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/discovery": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/discovery": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List discovery jobs
+         * @description Get paginated list of discovery jobs
+         */
+        get: operations["listDiscoveryJobs"];
+        put?: never;
+        /**
+         * Create discovery job
+         * @description Create a new network discovery job
+         */
+        post: operations["createDiscoveryJob"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * List discovery jobs
-     * @description Get paginated list of discovery jobs
-     */
-    get: operations["listDiscoveryJobs"];
-    put?: never;
-    /**
-     * Create discovery job
-     * @description Create a new network discovery job
-     */
-    post: operations["createDiscoveryJob"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/discovery/{discoveryId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/discovery/{discoveryId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get discovery job
+         * @description Get discovery job details by ID
+         */
+        get: operations["getDiscoveryJob"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get discovery job
-     * @description Get discovery job details by ID
-     */
-    get: operations["getDiscoveryJob"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/discovery/{discoveryId}/start": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/discovery/{discoveryId}/start": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Start discovery
+         * @description Start a discovery job
+         */
+        post: operations["startDiscovery"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Start discovery
-     * @description Start a discovery job
-     */
-    post: operations["startDiscovery"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/discovery/{discoveryId}/stop": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/discovery/{discoveryId}/stop": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Stop discovery
+         * @description Stop a running discovery job
+         */
+        post: operations["stopDiscovery"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Stop discovery
-     * @description Stop a running discovery job
-     */
-    post: operations["stopDiscovery"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/exclusions": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/exclusions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List global exclusions
+         * @description Get all global exclusion rules not tied to a specific network
+         */
+        get: operations["listGlobalExclusions"];
+        put?: never;
+        /**
+         * Create global exclusion
+         * @description Create a global exclusion rule that applies to all networks
+         */
+        post: operations["createGlobalExclusion"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * List global exclusions
-     * @description Get all global exclusion rules not tied to a specific network
-     */
-    get: operations["listGlobalExclusions"];
-    put?: never;
-    /**
-     * Create global exclusion
-     * @description Create a global exclusion rule that applies to all networks
-     */
-    post: operations["createGlobalExclusion"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/exclusions/{exclusionId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/exclusions/{exclusionId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete exclusion
+         * @description Delete an exclusion rule by ID
+         */
+        delete: operations["deleteExclusion"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /**
-     * Delete exclusion
-     * @description Delete an exclusion rule by ID
-     */
-    delete: operations["deleteExclusion"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/health": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Health check
+         * @description Returns service health status including database connectivity
+         */
+        get: operations["getHealth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Health check
-     * @description Returns service health status including database connectivity
-     */
-    get: operations["getHealth"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/hosts": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/hosts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List hosts
+         * @description Get paginated list of discovered hosts with optional filtering
+         */
+        get: operations["listHosts"];
+        put?: never;
+        /**
+         * Create host
+         * @description Manually add a host to the inventory
+         */
+        post: operations["createHost"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * List hosts
-     * @description Get paginated list of discovered hosts with optional filtering
-     */
-    get: operations["listHosts"];
-    put?: never;
-    /**
-     * Create host
-     * @description Manually add a host to the inventory
-     */
-    post: operations["createHost"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/hosts/{hostId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/hosts/{hostId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get host
+         * @description Get host details by ID
+         */
+        get: operations["getHost"];
+        /**
+         * Update host
+         * @description Update host information
+         */
+        put: operations["updateHost"];
+        post?: never;
+        /**
+         * Delete host
+         * @description Remove host from inventory
+         */
+        delete: operations["deleteHost"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get host
-     * @description Get host details by ID
-     */
-    get: operations["getHost"];
-    /**
-     * Update host
-     * @description Update host information
-     */
-    put: operations["updateHost"];
-    post?: never;
-    /**
-     * Delete host
-     * @description Remove host from inventory
-     */
-    delete: operations["deleteHost"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/hosts/{hostId}/scans": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/hosts/{hostId}/scans": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get host scans
+         * @description Get scans associated with a specific host
+         */
+        get: operations["getHostScans"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get host scans
-     * @description Get scans associated with a specific host
-     */
-    get: operations["getHostScans"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/liveness": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/liveness": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Liveness check
+         * @description Returns simple liveness status without dependency checks
+         */
+        get: operations["getLiveness"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Liveness check
-     * @description Returns simple liveness status without dependency checks
-     */
-    get: operations["getLiveness"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/metrics": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Application metrics
+         * @description Returns Prometheus metrics for monitoring
+         */
+        get: operations["getMetrics"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Application metrics
-     * @description Returns Prometheus metrics for monitoring
-     */
-    get: operations["getMetrics"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/networks": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/networks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List networks
+         * @description Get paginated list of networks with optional filtering
+         */
+        get: operations["listNetworks"];
+        put?: never;
+        /**
+         * Create network
+         * @description Create a new network for scanning and discovery
+         */
+        post: operations["createNetwork"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * List networks
-     * @description Get paginated list of networks with optional filtering
-     */
-    get: operations["listNetworks"];
-    put?: never;
-    /**
-     * Create network
-     * @description Create a new network for scanning and discovery
-     */
-    post: operations["createNetwork"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/networks/stats": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/networks/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get network statistics
+         * @description Returns aggregate statistics about networks, hosts, and exclusions
+         */
+        get: operations["getNetworkStats"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get network statistics
-     * @description Returns aggregate statistics about networks, hosts, and exclusions
-     */
-    get: operations["getNetworkStats"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/networks/{networkId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/networks/{networkId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get network
+         * @description Get network details by ID
+         */
+        get: operations["getNetwork"];
+        /**
+         * Update network
+         * @description Update network configuration
+         */
+        put: operations["updateNetwork"];
+        post?: never;
+        /**
+         * Delete network
+         * @description Delete a network and its associated exclusions
+         */
+        delete: operations["deleteNetwork"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get network
-     * @description Get network details by ID
-     */
-    get: operations["getNetwork"];
-    /**
-     * Update network
-     * @description Update network configuration
-     */
-    put: operations["updateNetwork"];
-    post?: never;
-    /**
-     * Delete network
-     * @description Delete a network and its associated exclusions
-     */
-    delete: operations["deleteNetwork"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/networks/{networkId}/disable": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/networks/{networkId}/disable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Disable network
+         * @description Disable a network from scanning and discovery
+         */
+        post: operations["disableNetwork"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Disable network
-     * @description Disable a network from scanning and discovery
-     */
-    post: operations["disableNetwork"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/networks/{networkId}/enable": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/networks/{networkId}/discover": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Start a discovery run for a network
+         * @description Creates a discovery job linked to the network, immediately transitions it to running, and returns the job. If a discovery engine is configured the actual nmap scan executes asynchronously.
+         */
+        post: operations["startNetworkDiscovery"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Enable network
-     * @description Enable a network for scanning and discovery
-     */
-    post: operations["enableNetwork"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/networks/{networkId}/exclusions": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/networks/{networkId}/discovery": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List discovery jobs for a network
+         * @description Returns paginated history of discovery runs linked to the network, ordered most-recent first.
+         */
+        get: operations["listNetworkDiscoveryJobs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * List network exclusions
-     * @description Get exclusion rules for a specific network
-     */
-    get: operations["listNetworkExclusions"];
-    put?: never;
-    /**
-     * Create network exclusion
-     * @description Add an exclusion rule to a specific network
-     */
-    post: operations["createNetworkExclusion"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/networks/{networkId}/rename": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/networks/{networkId}/enable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enable network
+         * @description Enable a network for scanning and discovery
+         */
+        post: operations["enableNetwork"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    /**
-     * Rename network
-     * @description Rename an existing network
-     */
-    put: operations["renameNetwork"];
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/networks/{networkId}/discover": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/networks/{networkId}/exclusions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List network exclusions
+         * @description Get exclusion rules for a specific network
+         */
+        get: operations["listNetworkExclusions"];
+        put?: never;
+        /**
+         * Create network exclusion
+         * @description Add an exclusion rule to a specific network
+         */
+        post: operations["createNetworkExclusion"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Start network discovery
-     * @description Trigger a discovery job for a network using its configured CIDR and method
-     */
-    post: operations["startNetworkDiscovery"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/profiles": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/networks/{networkId}/rename": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Rename network
+         * @description Rename an existing network
+         */
+        put: operations["renameNetwork"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * List profiles
-     * @description Get paginated list of scan profiles
-     */
-    get: operations["listProfiles"];
-    put?: never;
-    /**
-     * Create profile
-     * @description Create a new scan profile
-     */
-    post: operations["createProfile"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/profiles/{profileId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/profiles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List profiles
+         * @description Get paginated list of scan profiles
+         */
+        get: operations["listProfiles"];
+        put?: never;
+        /**
+         * Create profile
+         * @description Create a new scan profile
+         */
+        post: operations["createProfile"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get profile
-     * @description Get scan profile details by ID
-     */
-    get: operations["getProfile"];
-    /**
-     * Update profile
-     * @description Update scan profile configuration
-     */
-    put: operations["updateProfile"];
-    post?: never;
-    /**
-     * Delete profile
-     * @description Delete scan profile
-     */
-    delete: operations["deleteProfile"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/scans": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/profiles/{profileId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get profile
+         * @description Get scan profile details by ID
+         */
+        get: operations["getProfile"];
+        /**
+         * Update profile
+         * @description Update scan profile configuration
+         */
+        put: operations["updateProfile"];
+        post?: never;
+        /**
+         * Delete profile
+         * @description Delete scan profile
+         */
+        delete: operations["deleteProfile"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * List scans
-     * @description Get paginated list of scans with optional filtering
-     */
-    get: operations["listScans"];
-    put?: never;
-    /**
-     * Create scan
-     * @description Create a new network scan job
-     */
-    post: operations["createScan"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/scans/{scanId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/scans": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List scans
+         * @description Get paginated list of scans with optional filtering
+         */
+        get: operations["listScans"];
+        put?: never;
+        /**
+         * Create scan
+         * @description Create a new network scan job
+         */
+        post: operations["createScan"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get scan
-     * @description Get scan details by ID
-     */
-    get: operations["getScan"];
-    /**
-     * Update scan
-     * @description Update an existing scan configuration
-     */
-    put: operations["updateScan"];
-    post?: never;
-    /**
-     * Delete scan
-     * @description Cancel running scan or delete completed scan
-     */
-    delete: operations["deleteScan"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/scans/{scanId}/results": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/scans/{scanId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get scan
+         * @description Get scan details by ID
+         */
+        get: operations["getScan"];
+        /**
+         * Update scan
+         * @description Update an existing scan configuration
+         */
+        put: operations["updateScan"];
+        post?: never;
+        /**
+         * Delete scan
+         * @description Cancel running scan or delete completed scan
+         */
+        delete: operations["deleteScan"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get scan results
-     * @description Get detailed results from a completed scan
-     */
-    get: operations["getScanResults"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/scans/{scanId}/start": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/scans/{scanId}/results": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get scan results
+         * @description Get detailed results from a completed scan
+         */
+        get: operations["getScanResults"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Start scan
-     * @description Start a pending scan
-     */
-    post: operations["startScan"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/scans/{scanId}/stop": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/scans/{scanId}/start": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Start scan
+         * @description Start a pending scan
+         */
+        post: operations["startScan"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Stop scan
-     * @description Stop a running scan
-     */
-    post: operations["stopScan"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/schedules": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/scans/{scanId}/stop": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Stop scan
+         * @description Stop a running scan
+         */
+        post: operations["stopScan"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * List schedules
-     * @description Get paginated list of scheduled scans
-     */
-    get: operations["listSchedules"];
-    put?: never;
-    /**
-     * Create schedule
-     * @description Create a new scheduled scan
-     */
-    post: operations["createSchedule"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/schedules/{scheduleId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/schedules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List schedules
+         * @description Get paginated list of scheduled scans
+         */
+        get: operations["listSchedules"];
+        put?: never;
+        /**
+         * Create schedule
+         * @description Create a new scheduled scan
+         */
+        post: operations["createSchedule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get schedule
-     * @description Get schedule details by ID
-     */
-    get: operations["getSchedule"];
-    /**
-     * Update schedule
-     * @description Update schedule configuration
-     */
-    put: operations["updateSchedule"];
-    post?: never;
-    /**
-     * Delete schedule
-     * @description Delete scheduled scan
-     */
-    delete: operations["deleteSchedule"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/schedules/{scheduleId}/disable": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/schedules/{scheduleId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get schedule
+         * @description Get schedule details by ID
+         */
+        get: operations["getSchedule"];
+        /**
+         * Update schedule
+         * @description Update schedule configuration
+         */
+        put: operations["updateSchedule"];
+        post?: never;
+        /**
+         * Delete schedule
+         * @description Delete scheduled scan
+         */
+        delete: operations["deleteSchedule"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Disable schedule
-     * @description Disable a scheduled scan
-     */
-    post: operations["disableSchedule"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/schedules/{scheduleId}/enable": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/schedules/{scheduleId}/disable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Disable schedule
+         * @description Disable a scheduled scan
+         */
+        post: operations["disableSchedule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Enable schedule
-     * @description Enable a scheduled scan
-     */
-    post: operations["enableSchedule"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/status": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/schedules/{scheduleId}/enable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enable schedule
+         * @description Enable a scheduled scan
+         */
+        post: operations["enableSchedule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * System status
-     * @description Returns detailed system status information
-     */
-    get: operations["getStatus"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/version": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * System status
+         * @description Returns detailed system status information
+         */
+        get: operations["getStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Version information
-     * @description Returns version and build information
-     */
-    get: operations["getVersion"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
+    "/version": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Version information
+         * @description Returns version and build information
+         */
+        get: operations["getVersion"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    "docs.AdminStatusResponse": {
-      /** @example active */
-      admin_status?: string;
-      server_info?: {
-        [key: string]: unknown;
-      };
-      timestamp?: string;
+    schemas: {
+        "docs.AdminStatusResponse": {
+            /** @example active */
+            admin_status?: string;
+            server_info?: {
+                [key: string]: unknown;
+            };
+            timestamp?: string;
+        };
+        "docs.CertificateResponse": {
+            host_id?: string;
+            id?: string;
+            /** @example Let's Encrypt Authority X3 */
+            issuer?: string;
+            /** @example RSA-2048 */
+            key_type?: string;
+            not_after?: string;
+            not_before?: string;
+            /** @example 443 */
+            port?: number;
+            /**
+             * @example [
+             *       "server01.local",
+             *       "www.server01.local"
+             *     ]
+             */
+            sans?: string[];
+            scanned_at?: string;
+            /** @example server01.local */
+            subject_cn?: string;
+            /** @example TLS 1.3 */
+            tls_version?: string;
+        };
+        "docs.CreateDiscoveryJobRequest": {
+            description?: string;
+            /** @example true */
+            enabled?: boolean;
+            /**
+             * @example ping
+             * @enum {string}
+             */
+            method?: "ping" | "arp" | "icmp" | "tcp_connect";
+            /** @example Office Network Discovery */
+            name?: string;
+            /**
+             * @example [
+             *       "192.168.1.0/24"
+             *     ]
+             */
+            networks?: string[];
+        };
+        "docs.CreateExclusionRequest": {
+            /** @example 192.168.1.128/25 */
+            excluded_cidr?: string;
+            /** @example Reserved for printers */
+            reason?: string;
+        };
+        "docs.CreateNetworkRequest": {
+            /** @example 192.168.1.0/24 */
+            cidr?: string;
+            /** @example Main office network */
+            description?: string;
+            /**
+             * @example ping
+             * @enum {string}
+             */
+            discovery_method?: "ping" | "tcp" | "arp" | "icmp";
+            /** @example true */
+            is_active?: boolean;
+            /** @example Office Network */
+            name?: string;
+            /** @example true */
+            scan_enabled?: boolean;
+        };
+        "docs.CreateProfileRequest": {
+            /** @example Custom scan configuration */
+            description?: string;
+            /** @example Custom Scan Profile */
+            name?: string;
+            options?: {
+                [key: string]: string;
+            };
+            /** @example 22,80,443,8080 */
+            ports?: string;
+            /**
+             * @example connect
+             * @enum {string}
+             */
+            scan_type?: "connect" | "syn" | "ack" | "udp" | "aggressive" | "comprehensive";
+        };
+        "docs.CreateScanRequest": {
+            /** @example Regular security assessment */
+            description?: string;
+            /** @example Weekly security scan */
+            name?: string;
+            options?: {
+                [key: string]: string;
+            };
+            /** @example false */
+            os_detection?: boolean;
+            /** @example 22,80,443 */
+            ports?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440001 */
+            profile_id?: string;
+            /**
+             * @example connect
+             * @enum {string}
+             */
+            scan_type?: "connect" | "syn" | "ack" | "udp" | "aggressive" | "comprehensive";
+            tags?: string[];
+            /**
+             * @example [
+             *       "192.168.1.0/24"
+             *     ]
+             */
+            targets?: string[];
+        };
+        "docs.CreateScheduleRequest": {
+            /** @example 0 2 * * * */
+            cron_expr?: string;
+            /** @example true */
+            enabled?: boolean;
+            /** @example Daily Security Scan */
+            name?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440010 */
+            network_id?: string;
+            /**
+             * @example scan
+             * @enum {string}
+             */
+            type?: "scan" | "discovery";
+        };
+        "docs.DNSRecordResponse": {
+            host_id?: string;
+            id?: string;
+            /**
+             * @example PTR
+             * @enum {string}
+             */
+            record_type?: "A" | "AAAA" | "PTR" | "CNAME" | "MX" | "TXT" | "SRV";
+            resolved_at?: string;
+            /** @example 300 */
+            ttl?: number;
+            /** @example server01.local */
+            value?: string;
+        };
+        "docs.DiscoveryJobResponse": {
+            completed_at?: string;
+            created_at?: string;
+            created_by?: string;
+            description?: string;
+            /** @example true */
+            enabled?: boolean;
+            /** @example 12 */
+            hosts_found?: number;
+            /** @example 550e8400-e29b-41d4-a716-446655440004 */
+            id?: string;
+            last_error?: string;
+            last_run?: string;
+            /**
+             * @example ping
+             * @enum {string}
+             */
+            method?: "ping" | "arp" | "icmp" | "tcp_connect";
+            /** @example Network Discovery */
+            name?: string;
+            /**
+             * @example [
+             *       "192.168.1.0/24"
+             *     ]
+             */
+            networks?: string[];
+            next_run?: string;
+            /** @example 45.5 */
+            progress?: number;
+            started_at?: string;
+            /**
+             * @example running
+             * @enum {string}
+             */
+            status?: "pending" | "running" | "completed" | "failed";
+            updated_at?: string;
+        };
+        "docs.ErrorResponse": {
+            /** @example Invalid request */
+            error?: string;
+            /** @example req-123 */
+            request_id?: string;
+            timestamp?: string;
+        };
+        "docs.HealthResponse": {
+            checks?: {
+                [key: string]: string;
+            };
+            /** @example healthy */
+            status?: string;
+            timestamp?: string;
+            /** @example 2h30m45s */
+            uptime?: string;
+        };
+        "docs.HostResponse": {
+            /** @description Banners are populated when banner grabbing has run for this host. */
+            banners?: components["schemas"]["docs.PortBannerResponse"][];
+            /** @description Certificates are populated when TLS banner grabbing has run for this host. */
+            certificates?: components["schemas"]["docs.CertificateResponse"][];
+            /** @example Primary web server */
+            description?: string;
+            /** @description DNSRecords are populated when DNS enrichment has run for this host. */
+            dns_records?: components["schemas"]["docs.DNSRecordResponse"][];
+            first_seen?: string;
+            /** @example server01.local */
+            hostname?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440002 */
+            id?: string;
+            /** @example 192.168.1.100 */
+            ip_address?: string;
+            last_seen?: string;
+            /** @example 00:1B:44:11:3A:B7 */
+            mac_address?: string;
+            /** @description NetworkID is the network this host belongs to, if any. */
+            network_id?: string;
+            /**
+             * @example [
+             *       22,
+             *       80,
+             *       443
+             *     ]
+             */
+            open_ports?: number[];
+            /**
+             * @description OSFamily is the broad OS family detected by nmap (e.g. "Linux", "Windows").
+             * @example Linux
+             */
+            os_family?: string;
+            /**
+             * @description OSName is the full OS name returned by nmap (e.g. "Linux 5.15").
+             * @example Ubuntu 22.04
+             */
+            os_name?: string;
+            /** @example 22.04 */
+            os_version?: string;
+            /** @example 1.5 */
+            response_time_avg_ms?: number;
+            /** @example 1.23 */
+            response_time_ms?: number;
+            /** @example 5 */
+            scan_count?: number;
+            /** @description SNMPData is populated when SNMP enrichment has run for this host. */
+            snmp_data?: components["schemas"]["docs.SNMPDataResponse"];
+            /**
+             * @example up
+             * @enum {string}
+             */
+            status?: "up" | "down" | "unknown";
+            /**
+             * @example [
+             *       "web",
+             *       "production"
+             *     ]
+             */
+            tags?: string[];
+            /** @example Dell Inc. */
+            vendor?: string;
+        };
+        "docs.LivenessResponse": {
+            /** @example alive */
+            status?: string;
+            timestamp?: string;
+            /** @example 2h30m45s */
+            uptime?: string;
+        };
+        "docs.NetworkExclusionResponse": {
+            created_at?: string;
+            /** @example admin */
+            created_by?: string;
+            /** @example true */
+            enabled?: boolean;
+            /** @example 192.168.1.128/25 */
+            excluded_cidr?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440011 */
+            id?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440010 */
+            network_id?: string;
+            /** @example Reserved for printers */
+            reason?: string;
+            updated_at?: string;
+        };
+        "docs.NetworkResponse": {
+            /** @example 20 */
+            active_host_count?: number;
+            /** @example 192.168.1.0/24 */
+            cidr?: string;
+            created_at?: string;
+            /** @example admin */
+            created_by?: string;
+            /** @example Main office network */
+            description?: string;
+            /**
+             * @example ping
+             * @enum {string}
+             */
+            discovery_method?: "ping" | "tcp" | "arp" | "icmp";
+            /** @example 25 */
+            host_count?: number;
+            /** @example 550e8400-e29b-41d4-a716-446655440010 */
+            id?: string;
+            /** @example true */
+            is_active?: boolean;
+            last_discovery?: string;
+            last_scan?: string;
+            /** @example admin */
+            modified_by?: string;
+            /** @example Office Network */
+            name?: string;
+            /** @example true */
+            scan_enabled?: boolean;
+            /** @example 3600 */
+            scan_interval_seconds?: number;
+            /** @example 22,80,443,8080 */
+            scan_ports?: string;
+            /**
+             * @example connect
+             * @enum {string}
+             */
+            scan_type?: "connect" | "syn" | "ack" | "udp" | "aggressive" | "comprehensive";
+            updated_at?: string;
+        };
+        "docs.NetworkStatsResponse": {
+            exclusions?: {
+                [key: string]: unknown;
+            };
+            hosts?: {
+                [key: string]: unknown;
+            };
+            networks?: {
+                [key: string]: unknown;
+            };
+        };
+        "docs.PaginatedDiscoveryJobsResponse": {
+            data?: components["schemas"]["docs.DiscoveryJobResponse"][];
+            pagination?: components["schemas"]["docs.PaginationInfo"];
+        };
+        "docs.PaginatedHostsResponse": {
+            data?: components["schemas"]["docs.HostResponse"][];
+            pagination?: components["schemas"]["docs.PaginationInfo"];
+        };
+        "docs.PaginatedNetworksResponse": {
+            data?: components["schemas"]["docs.NetworkResponse"][];
+            pagination?: components["schemas"]["docs.PaginationInfo"];
+        };
+        "docs.PaginatedProfilesResponse": {
+            data?: components["schemas"]["docs.ProfileResponse"][];
+            pagination?: components["schemas"]["docs.PaginationInfo"];
+        };
+        "docs.PaginatedScansResponse": {
+            data?: components["schemas"]["docs.ScanResponse"][];
+            pagination?: components["schemas"]["docs.PaginationInfo"];
+        };
+        "docs.PaginatedSchedulesResponse": {
+            data?: components["schemas"]["docs.ScheduleResponse"][];
+            pagination?: components["schemas"]["docs.PaginationInfo"];
+        };
+        "docs.PaginationInfo": {
+            /** @example 1 */
+            page?: number;
+            /** @example 20 */
+            page_size?: number;
+            /** @example 150 */
+            total_items?: number;
+            /** @example 8 */
+            total_pages?: number;
+        };
+        "docs.PortBannerResponse": {
+            host_id?: string;
+            id?: string;
+            /** @example 80 */
+            port?: number;
+            /**
+             * @example tcp
+             * @enum {string}
+             */
+            protocol?: "tcp" | "udp";
+            /** @example HTTP/1.1 200 OK */
+            raw_banner?: string;
+            scanned_at?: string;
+            /** @example nginx */
+            service?: string;
+            /** @example 1.24.0 */
+            version?: string;
+        };
+        "docs.ProfileResponse": {
+            created_at?: string;
+            /** @example Fast TCP connect scan */
+            description?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440003 */
+            id?: string;
+            /** @example Quick Connect Scan */
+            name?: string;
+            options?: {
+                [key: string]: string;
+            };
+            /** @example 22,80,443 */
+            ports?: string;
+            /**
+             * @example connect
+             * @enum {string}
+             */
+            scan_type?: "connect" | "syn" | "ack" | "udp" | "aggressive" | "comprehensive";
+            updated_at?: string;
+        };
+        "docs.RenameNetworkRequest": {
+            /** @example New Office Network */
+            new_name?: string;
+        };
+        "docs.SNMPDataResponse": {
+            collected_at?: string;
+            /** @example 4 */
+            if_count?: number;
+            interfaces?: components["schemas"]["docs.SNMPInterfaceResponse"][];
+            /** @example admin@example.com */
+            sys_contact?: string;
+            /** @example Cisco IOS XE */
+            sys_descr?: string;
+            /** @example Server Room A */
+            sys_location?: string;
+            /** @example router01 */
+            sys_name?: string;
+            /** @example 123456789 */
+            sys_uptime_cs?: number;
+        };
+        "docs.SNMPInterfaceResponse": {
+            /** @example 1 */
+            index?: number;
+            /** @example 192.168.1.1 */
+            ip?: string;
+            /** @example 00:1B:44:11:3A:B7 */
+            mac?: string;
+            /** @example eth0 */
+            name?: string;
+            /** @example 1000 */
+            speed_mbps?: number;
+            /**
+             * @example up
+             * @enum {string}
+             */
+            status?: "up" | "down" | "unknown";
+        };
+        "docs.ScanResponse": {
+            completed_at?: string;
+            created_at?: string;
+            created_by?: string;
+            description?: string;
+            /** @example 14m30s */
+            duration?: string;
+            error_message?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440000 */
+            id?: string;
+            /** @example Ad-hoc scan: 192.168.1.0/24 */
+            name?: string;
+            options?: {
+                [key: string]: string;
+            };
+            /** @example 22,80,443 */
+            ports?: string;
+            /** @example 443 open / 1200 total */
+            ports_scanned?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440001 */
+            profile_id?: string;
+            /** @example 65.5 */
+            progress?: number;
+            /**
+             * @example connect
+             * @enum {string}
+             */
+            scan_type?: "connect" | "syn" | "ack" | "udp" | "aggressive" | "comprehensive";
+            started_at?: string;
+            /**
+             * @example running
+             * @enum {string}
+             */
+            status?: "pending" | "running" | "completed" | "failed";
+            tags?: string[];
+            /**
+             * @example [
+             *       "192.168.1.0/24"
+             *     ]
+             */
+            targets?: string[];
+            updated_at?: string;
+        };
+        "docs.ScheduleResponse": {
+            created_at?: string;
+            created_by?: string;
+            /** @example 0 2 * * 1 */
+            cron_expr?: string;
+            description?: string;
+            /** @example true */
+            enabled?: boolean;
+            /** @example 0 */
+            error_count?: number;
+            /** @example 550e8400-e29b-41d4-a716-446655440005 */
+            id?: string;
+            last_error?: string;
+            last_run?: string;
+            /** @example Weekly Security Scan */
+            name?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440010 */
+            network_id?: string;
+            /** @example Office Network */
+            network_name?: string;
+            next_run?: string;
+            /** @example 5 */
+            run_count?: number;
+            /** @example active */
+            status?: string;
+            /**
+             * @example scan
+             * @enum {string}
+             */
+            type?: "scan" | "discovery";
+            updated_at?: string;
+        };
+        "docs.StatusResponse": {
+            /** @example scanorama-api */
+            service?: string;
+            timestamp?: string;
+            /** @example 2h30m45s */
+            uptime?: string;
+            /** @example 0.7.0 */
+            version?: string;
+        };
+        "docs.UpdateNetworkRequest": {
+            /** @example 192.168.1.0/24 */
+            cidr?: string;
+            /** @example Main office network */
+            description?: string;
+            /**
+             * @example ping
+             * @enum {string}
+             */
+            discovery_method?: "ping" | "tcp" | "arp" | "icmp";
+            /** @example true */
+            is_active?: boolean;
+            /** @example Office Network */
+            name?: string;
+            /** @example true */
+            scan_enabled?: boolean;
+        };
+        "docs.UpdateScanRequest": {
+            /** @example Updated description */
+            description?: string;
+            /** @example Updated scan name */
+            name?: string;
+            options?: {
+                [key: string]: string;
+            };
+            /** @example false */
+            os_detection?: boolean;
+            /** @example 22,80,443 */
+            ports?: string;
+            profile_id?: string;
+            /**
+             * @example connect
+             * @enum {string}
+             */
+            scan_type?: "connect" | "syn" | "ack" | "udp" | "aggressive" | "comprehensive";
+            tags?: string[];
+            /**
+             * @example [
+             *       "192.168.1.0/24"
+             *     ]
+             */
+            targets?: string[];
+        };
+        "docs.VersionResponse": {
+            /** @example scanorama */
+            service?: string;
+            timestamp?: string;
+            /** @example 0.7.0 */
+            version?: string;
+        };
     };
-    "docs.CreateDiscoveryJobRequest": {
-      description?: string;
-      /** @example true */
-      enabled?: boolean;
-      /**
-       * @example ping
-       * @enum {string}
-       */
-      method?: "ping" | "arp" | "icmp" | "tcp_connect";
-      /** @example Office Network Discovery */
-      name?: string;
-      /**
-       * @example [
-       *       "192.168.1.0/24"
-       *     ]
-       */
-      networks?: string[];
+    responses: never;
+    parameters: never;
+    requestBodies: {
+        /** @description Exclusion configuration */
+        "docs.CreateExclusionRequest": {
+            content: {
+                "application/json": components["schemas"]["docs.CreateExclusionRequest"];
+            };
+        };
     };
-    "docs.CreateExclusionRequest": {
-      /** @example 192.168.1.128/25 */
-      excluded_cidr?: string;
-      /** @example Reserved for printers */
-      reason?: string;
-    };
-    "docs.CreateNetworkRequest": {
-      /** @example 192.168.1.0/24 */
-      cidr?: string;
-      /** @example Main office network */
-      description?: string;
-      /**
-       * @example ping
-       * @enum {string}
-       */
-      discovery_method?: "ping" | "tcp" | "arp" | "icmp";
-      /** @example true */
-      is_active?: boolean;
-      /** @example Office Network */
-      name?: string;
-      /** @example true */
-      scan_enabled?: boolean;
-    };
-    "docs.CreateProfileRequest": {
-      /** @example Custom scan configuration */
-      description?: string;
-      /** @example Custom Scan Profile */
-      name?: string;
-      options?: {
-        [key: string]: string;
-      };
-      /** @example 22,80,443,8080 */
-      ports?: string;
-      /**
-       * @example connect
-       * @enum {string}
-       */
-      scan_type?:
-        | "connect"
-        | "syn"
-        | "ack"
-        | "udp"
-        | "aggressive"
-        | "comprehensive";
-    };
-    "docs.CreateScanRequest": {
-      /** @example Regular security assessment */
-      description?: string;
-      /** @example Weekly security scan */
-      name?: string;
-      options?: {
-        [key: string]: string;
-      };
-      /** @example false */
-      os_detection?: boolean;
-      /** @example 22,80,443 */
-      ports?: string;
-      /** @example 550e8400-e29b-41d4-a716-446655440001 */
-      profile_id?: string;
-      /**
-       * @example connect
-       * @enum {string}
-       */
-      scan_type?:
-        | "connect"
-        | "syn"
-        | "ack"
-        | "udp"
-        | "aggressive"
-        | "comprehensive";
-      tags?: string[];
-      /**
-       * @example [
-       *       "192.168.1.0/24"
-       *     ]
-       */
-      targets?: string[];
-    };
-    "docs.CreateScheduleRequest": {
-      /** @example 0 2 * * * */
-      cron_expr?: string;
-      /** @example true */
-      enabled?: boolean;
-      /** @example Daily Security Scan */
-      name?: string;
-      /** @example 550e8400-e29b-41d4-a716-446655440010 */
-      network_id?: string;
-      /**
-       * @example scan
-       * @enum {string}
-       */
-      type?: "scan" | "discovery";
-    };
-    "docs.DiscoveryJobResponse": {
-      completed_at?: string;
-      created_at?: string;
-      created_by?: string;
-      description?: string;
-      /** @example true */
-      enabled?: boolean;
-      /** @example 12 */
-      hosts_found?: number;
-      /** @example 550e8400-e29b-41d4-a716-446655440004 */
-      id?: string;
-      last_error?: string;
-      last_run?: string;
-      /**
-       * @example ping
-       * @enum {string}
-       */
-      method?: "ping" | "arp" | "icmp" | "tcp_connect";
-      /** @example Network Discovery */
-      name?: string;
-      /**
-       * @example [
-       *       "192.168.1.0/24"
-       *     ]
-       */
-      networks?: string[];
-      next_run?: string;
-      /** @example 45.5 */
-      progress?: number;
-      started_at?: string;
-      /**
-       * @example running
-       * @enum {string}
-       */
-      status?: "pending" | "running" | "completed" | "failed";
-      updated_at?: string;
-    };
-    "docs.ErrorResponse": {
-      /** @example Invalid request */
-      error?: string;
-      /** @example req-123 */
-      request_id?: string;
-      timestamp?: string;
-    };
-    "docs.HealthResponse": {
-      checks?: {
-        [key: string]: string;
-      };
-      /** @example healthy */
-      status?: string;
-      timestamp?: string;
-      /** @example 2h30m45s */
-      uptime?: string;
-    };
-    "docs.HostResponse": {
-      first_seen?: string;
-      /** @example server01.local */
-      hostname?: string;
-      /** @example 550e8400-e29b-41d4-a716-446655440002 */
-      id?: string;
-      /** @example 192.168.1.100 */
-      ip_address?: string;
-      last_seen?: string;
-      /** @example 00:1B:44:11:3A:B7 */
-      mac_address?: string;
-      /**
-       * @example [
-       *       22,
-       *       80,
-       *       443
-       *     ]
-       */
-      open_ports?: number[];
-      /** @example 5 */
-      scan_count?: number;
-      /**
-       * @example up
-       * @enum {string}
-       */
-      status?: "up" | "down" | "unknown";
-    };
-    "docs.LivenessResponse": {
-      /** @example alive */
-      status?: string;
-      timestamp?: string;
-      /** @example 2h30m45s */
-      uptime?: string;
-    };
-    "docs.NetworkExclusionResponse": {
-      created_at?: string;
-      /** @example admin */
-      created_by?: string;
-      /** @example true */
-      enabled?: boolean;
-      /** @example 192.168.1.128/25 */
-      excluded_cidr?: string;
-      /** @example 550e8400-e29b-41d4-a716-446655440011 */
-      id?: string;
-      /** @example 550e8400-e29b-41d4-a716-446655440010 */
-      network_id?: string;
-      /** @example Reserved for printers */
-      reason?: string;
-      updated_at?: string;
-    };
-    "docs.NetworkResponse": {
-      /** @example 20 */
-      active_host_count?: number;
-      /** @example 192.168.1.0/24 */
-      cidr?: string;
-      created_at?: string;
-      /** @example admin */
-      created_by?: string;
-      /** @example Main office network */
-      description?: string;
-      /**
-       * @example ping
-       * @enum {string}
-       */
-      discovery_method?: "ping" | "tcp" | "arp" | "icmp";
-      /** @example 25 */
-      host_count?: number;
-      /** @example 550e8400-e29b-41d4-a716-446655440010 */
-      id?: string;
-      /** @example true */
-      is_active?: boolean;
-      last_discovery?: string;
-      last_scan?: string;
-      /** @example admin */
-      modified_by?: string;
-      /** @example Office Network */
-      name?: string;
-      /** @example true */
-      scan_enabled?: boolean;
-      /** @example 3600 */
-      scan_interval_seconds?: number;
-      /** @example 22,80,443,8080 */
-      scan_ports?: string;
-      /**
-       * @example connect
-       * @enum {string}
-       */
-      scan_type?:
-        | "connect"
-        | "syn"
-        | "ack"
-        | "udp"
-        | "aggressive"
-        | "comprehensive";
-      updated_at?: string;
-    };
-    "docs.NetworkStatsResponse": {
-      exclusions?: {
-        [key: string]: unknown;
-      };
-      hosts?: {
-        [key: string]: unknown;
-      };
-      networks?: {
-        [key: string]: unknown;
-      };
-    };
-    "docs.PaginatedDiscoveryJobsResponse": {
-      data?: components["schemas"]["docs.DiscoveryJobResponse"][];
-      pagination?: components["schemas"]["docs.PaginationInfo"];
-    };
-    "docs.PaginatedHostsResponse": {
-      data?: components["schemas"]["docs.HostResponse"][];
-      pagination?: components["schemas"]["docs.PaginationInfo"];
-    };
-    "docs.PaginatedNetworksResponse": {
-      data?: components["schemas"]["docs.NetworkResponse"][];
-      pagination?: components["schemas"]["docs.PaginationInfo"];
-    };
-    "docs.PaginatedProfilesResponse": {
-      data?: components["schemas"]["docs.ProfileResponse"][];
-      pagination?: components["schemas"]["docs.PaginationInfo"];
-    };
-    "docs.PaginatedScansResponse": {
-      data?: components["schemas"]["docs.ScanResponse"][];
-      pagination?: components["schemas"]["docs.PaginationInfo"];
-    };
-    "docs.PaginatedSchedulesResponse": {
-      data?: components["schemas"]["docs.ScheduleResponse"][];
-      pagination?: components["schemas"]["docs.PaginationInfo"];
-    };
-    "docs.PaginationInfo": {
-      /** @example 1 */
-      page?: number;
-      /** @example 20 */
-      page_size?: number;
-      /** @example 150 */
-      total_items?: number;
-      /** @example 8 */
-      total_pages?: number;
-    };
-    "docs.ProfileResponse": {
-      created_at?: string;
-      /** @example Fast TCP connect scan */
-      description?: string;
-      /** @example 550e8400-e29b-41d4-a716-446655440003 */
-      id?: string;
-      /** @example Quick Connect Scan */
-      name?: string;
-      options?: {
-        [key: string]: string;
-      };
-      /** @example 22,80,443 */
-      ports?: string;
-      /**
-       * @example connect
-       * @enum {string}
-       */
-      scan_type?:
-        | "connect"
-        | "syn"
-        | "ack"
-        | "udp"
-        | "aggressive"
-        | "comprehensive";
-      updated_at?: string;
-    };
-    "docs.RenameNetworkRequest": {
-      /** @example New Office Network */
-      new_name?: string;
-    };
-    "docs.ScanResponse": {
-      completed_at?: string;
-      created_at?: string;
-      created_by?: string;
-      description?: string;
-      /** @example 14m30s */
-      duration?: string;
-      error_message?: string;
-      /** @example 550e8400-e29b-41d4-a716-446655440000 */
-      id?: string;
-      /** @example Ad-hoc scan: 192.168.1.0/24 */
-      name?: string;
-      options?: {
-        [key: string]: string;
-      };
-      /** @example 22,80,443 */
-      ports?: string;
-      /** @example 443 open / 1200 total */
-      ports_scanned?: string;
-      /** @example 550e8400-e29b-41d4-a716-446655440001 */
-      profile_id?: string;
-      /** @example 65.5 */
-      progress?: number;
-      /**
-       * @example connect
-       * @enum {string}
-       */
-      scan_type?:
-        | "connect"
-        | "syn"
-        | "ack"
-        | "udp"
-        | "aggressive"
-        | "comprehensive";
-      started_at?: string;
-      /**
-       * @example running
-       * @enum {string}
-       */
-      status?: "pending" | "running" | "completed" | "failed";
-      tags?: string[];
-      /**
-       * @example [
-       *       "192.168.1.0/24"
-       *     ]
-       */
-      targets?: string[];
-      updated_at?: string;
-    };
-    "docs.ScheduleResponse": {
-      created_at?: string;
-      created_by?: string;
-      /** @example 0 2 * * 1 */
-      cron_expr?: string;
-      description?: string;
-      /** @example true */
-      enabled?: boolean;
-      /** @example 0 */
-      error_count?: number;
-      /** @example 550e8400-e29b-41d4-a716-446655440005 */
-      id?: string;
-      last_error?: string;
-      last_run?: string;
-      /** @example Weekly Security Scan */
-      name?: string;
-      /** @example 550e8400-e29b-41d4-a716-446655440010 */
-      network_id?: string;
-      /** @example Office Network */
-      network_name?: string;
-      next_run?: string;
-      /** @example 5 */
-      run_count?: number;
-      /** @example active */
-      status?: string;
-      /**
-       * @example scan
-       * @enum {string}
-       */
-      type?: "scan" | "discovery";
-      updated_at?: string;
-    };
-    "docs.StatusResponse": {
-      /** @example scanorama-api */
-      service?: string;
-      timestamp?: string;
-      /** @example 2h30m45s */
-      uptime?: string;
-      /** @example 0.7.0 */
-      version?: string;
-    };
-    "docs.UpdateNetworkRequest": {
-      /** @example 192.168.1.0/24 */
-      cidr?: string;
-      /** @example Main office network */
-      description?: string;
-      /**
-       * @example ping
-       * @enum {string}
-       */
-      discovery_method?: "ping" | "tcp" | "arp" | "icmp";
-      /** @example true */
-      is_active?: boolean;
-      /** @example Office Network */
-      name?: string;
-      /** @example true */
-      scan_enabled?: boolean;
-    };
-    "docs.UpdateScanRequest": {
-      /** @example Updated description */
-      description?: string;
-      /** @example Updated scan name */
-      name?: string;
-      options?: {
-        [key: string]: string;
-      };
-      /** @example false */
-      os_detection?: boolean;
-      /** @example 22,80,443 */
-      ports?: string;
-      profile_id?: string;
-      /**
-       * @example connect
-       * @enum {string}
-       */
-      scan_type?:
-        | "connect"
-        | "syn"
-        | "ack"
-        | "udp"
-        | "aggressive"
-        | "comprehensive";
-      tags?: string[];
-      /**
-       * @example [
-       *       "192.168.1.0/24"
-       *     ]
-       */
-      targets?: string[];
-    };
-    "docs.VersionResponse": {
-      /** @example scanorama */
-      service?: string;
-      timestamp?: string;
-      /** @example 0.7.0 */
-      version?: string;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: {
-    /** @description Exclusion configuration */
-    "docs.CreateExclusionRequest": {
-      content: {
-        "application/json": components["schemas"]["docs.CreateExclusionRequest"];
-      };
-    };
-  };
-  headers: never;
-  pathItems: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  getAdminStatus: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.AdminStatusResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  listDiscoveryJobs: {
-    parameters: {
-      query?: {
-        /** @description Page number */
-        page?: number;
-        /** @description Items per page */
-        page_size?: number;
-        /** @description Filter by status */
-        status?: "pending" | "running" | "completed" | "failed";
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.PaginatedDiscoveryJobsResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  createDiscoveryJob: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** @description Discovery job configuration */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["docs.CreateDiscoveryJobRequest"];
-      };
-    };
-    responses: {
-      /** @description Created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unprocessable Entity */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  getDiscoveryJob: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Discovery Job ID */
-        discoveryId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  startDiscovery: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Discovery Job ID */
-        discoveryId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Conflict */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  stopDiscovery: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Discovery Job ID */
-        discoveryId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Conflict */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  listGlobalExclusions: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.NetworkExclusionResponse"][];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  createGlobalExclusion: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: components["requestBodies"]["docs.CreateExclusionRequest"];
-    responses: {
-      /** @description Created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.NetworkExclusionResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unprocessable Entity */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  deleteExclusion: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Exclusion ID */
-        exclusionId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  getHealth: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.HealthResponse"];
-        };
-      };
-      /** @description Too Many Requests */
-      429: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Service Unavailable */
-      503: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.HealthResponse"];
-        };
-      };
-    };
-  };
-  listHosts: {
-    parameters: {
-      query?: {
-        /** @description Page number */
-        page?: number;
-        /** @description Items per page */
-        page_size?: number;
-        /** @description Filter by IP address */
-        ip_address?: string;
-        /** @description Filter by hostname */
-        hostname?: string;
-        /** @description Filter by status */
-        status?: "up" | "down" | "unknown";
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.PaginatedHostsResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  createHost: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** @description Host information */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["docs.HostResponse"];
-      };
-    };
-    responses: {
-      /** @description Created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.HostResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Conflict */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unprocessable Entity */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  getHost: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Host ID */
-        hostId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.HostResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  updateHost: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Host ID */
-        hostId: string;
-      };
-      cookie?: never;
-    };
-    /** @description Updated host information */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["docs.HostResponse"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.HostResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unprocessable Entity */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  deleteHost: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Host ID */
-        hostId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  getHostScans: {
-    parameters: {
-      query?: {
-        /** @description Page number */
-        page?: number;
-        /** @description Items per page */
-        page_size?: number;
-      };
-      header?: never;
-      path: {
-        /** @description Host ID */
-        hostId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.PaginatedScansResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  getLiveness: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.LivenessResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  getMetrics: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "text/plain": string;
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "text/plain": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "text/plain": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  listNetworks: {
-    parameters: {
-      query?: {
-        /** @description Page number */
-        page?: number;
-        /** @description Items per page */
-        page_size?: number;
-        /** @description Include inactive networks */
-        show_inactive?: boolean;
-        /** @description Filter by network name */
-        name?: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.PaginatedNetworksResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  createNetwork: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** @description Network configuration */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["docs.CreateNetworkRequest"];
-      };
-    };
-    responses: {
-      /** @description Created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.NetworkResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Conflict */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unprocessable Entity */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  getNetworkStats: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.NetworkStatsResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  getNetwork: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Network ID */
-        networkId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.NetworkResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  updateNetwork: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Network ID */
-        networkId: string;
-      };
-      cookie?: never;
-    };
-    /** @description Updated network configuration */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["docs.UpdateNetworkRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.NetworkResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unprocessable Entity */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  deleteNetwork: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Network ID */
-        networkId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  disableNetwork: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Network ID */
-        networkId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.NetworkResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  enableNetwork: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Network ID */
-        networkId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.NetworkResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  listNetworkExclusions: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Network ID */
-        networkId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.NetworkExclusionResponse"][];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  createNetworkExclusion: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Network ID */
-        networkId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: components["requestBodies"]["docs.CreateExclusionRequest"];
-    responses: {
-      /** @description Created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.NetworkExclusionResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unprocessable Entity */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  renameNetwork: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Network ID */
-        networkId: string;
-      };
-      cookie?: never;
-    };
-    /** @description New network name */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["docs.RenameNetworkRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.NetworkResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Conflict */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  listProfiles: {
-    parameters: {
-      query?: {
-        /** @description Page number */
-        page?: number;
-        /** @description Items per page */
-        page_size?: number;
-        /** @description Filter by scan type */
-        scan_type?: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.PaginatedProfilesResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  createProfile: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** @description Profile configuration */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["docs.CreateProfileRequest"];
-      };
-    };
-    responses: {
-      /** @description Created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ProfileResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Conflict */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unprocessable Entity */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  getProfile: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Profile ID */
-        profileId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ProfileResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  updateProfile: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Profile ID */
-        profileId: string;
-      };
-      cookie?: never;
-    };
-    /** @description Updated profile configuration */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["docs.CreateProfileRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ProfileResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unprocessable Entity */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  deleteProfile: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Profile ID */
-        profileId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Conflict */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  listScans: {
-    parameters: {
-      query?: {
-        /** @description Page number */
-        page?: number;
-        /** @description Items per page */
-        page_size?: number;
-        /** @description Filter by status */
-        status?: "pending" | "running" | "completed" | "failed" | "cancelled";
-        /** @description Filter by target */
-        target?: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.PaginatedScansResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  createScan: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** @description Scan configuration */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["docs.CreateScanRequest"];
-      };
-    };
-    responses: {
-      /** @description Created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ScanResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unprocessable Entity */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  getScan: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Scan ID */
-        scanId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ScanResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  updateScan: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Scan ID */
-        scanId: string;
-      };
-      cookie?: never;
-    };
-    /** @description Updated scan configuration */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["docs.UpdateScanRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ScanResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unprocessable Entity */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  deleteScan: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Scan ID */
-        scanId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Conflict */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  getScanResults: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Scan ID */
-        scanId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            [key: string]: unknown;
-          };
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  startScan: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Scan ID */
-        scanId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ScanResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Conflict */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  stopScan: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Scan ID */
-        scanId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ScanResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Conflict */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  listSchedules: {
-    parameters: {
-      query?: {
-        /** @description Page number */
-        page?: number;
-        /** @description Items per page */
-        page_size?: number;
-        /** @description Filter by enabled status */
-        enabled?: boolean;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.PaginatedSchedulesResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  createSchedule: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** @description Schedule configuration */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["docs.CreateScheduleRequest"];
-      };
-    };
-    responses: {
-      /** @description Created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ScheduleResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unprocessable Entity */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  getSchedule: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Schedule ID */
-        scheduleId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ScheduleResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  updateSchedule: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Schedule ID */
-        scheduleId: string;
-      };
-      cookie?: never;
-    };
-    /** @description Updated schedule configuration */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["docs.CreateScheduleRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ScheduleResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unprocessable Entity */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  deleteSchedule: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Schedule ID */
-        scheduleId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  disableSchedule: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Schedule ID */
-        scheduleId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ScheduleResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  enableSchedule: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Schedule ID */
-        scheduleId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ScheduleResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  getStatus: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.StatusResponse"];
-        };
-      };
-      /** @description Too Many Requests */
-      429: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  getVersion: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.VersionResponse"];
-        };
-      };
-      /** @description Too Many Requests */
-      429: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-    };
-  };
-  startNetworkDiscovery: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        networkId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Discovery job started */
-      202: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
-        };
-      };
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
-      503: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["docs.ErrorResponse"];
-        };
-      };
+    getAdminStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.AdminStatusResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    listDiscoveryJobs: {
+        parameters: {
+            query?: {
+                /** @description Page number */
+                page?: number;
+                /** @description Items per page */
+                page_size?: number;
+                /** @description Filter by status */
+                status?: "pending" | "running" | "completed" | "failed";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.PaginatedDiscoveryJobsResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    createDiscoveryJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Discovery job configuration */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.CreateDiscoveryJobRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getDiscoveryJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Discovery Job ID */
+                discoveryId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    startDiscovery: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Discovery Job ID */
+                discoveryId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    stopDiscovery: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Discovery Job ID */
+                discoveryId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    listGlobalExclusions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.NetworkExclusionResponse"][];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    createGlobalExclusion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: components["requestBodies"]["docs.CreateExclusionRequest"];
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.NetworkExclusionResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteExclusion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Exclusion ID */
+                exclusionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getHealth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.HealthResponse"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.HealthResponse"];
+                };
+            };
+        };
+    };
+    listHosts: {
+        parameters: {
+            query?: {
+                /** @description Page number */
+                page?: number;
+                /** @description Items per page */
+                page_size?: number;
+                /** @description Filter by IP address */
+                ip_address?: string;
+                /** @description Filter by hostname */
+                hostname?: string;
+                /** @description Filter by status */
+                status?: "up" | "down" | "unknown";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.PaginatedHostsResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    createHost: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Host information */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.HostResponse"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.HostResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getHost: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Host ID */
+                hostId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.HostResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateHost: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Host ID */
+                hostId: string;
+            };
+            cookie?: never;
+        };
+        /** @description Updated host information */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.HostResponse"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.HostResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteHost: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Host ID */
+                hostId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getHostScans: {
+        parameters: {
+            query?: {
+                /** @description Page number */
+                page?: number;
+                /** @description Items per page */
+                page_size?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Host ID */
+                hostId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.PaginatedScansResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getLiveness: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.LivenessResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getMetrics: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    listNetworks: {
+        parameters: {
+            query?: {
+                /** @description Page number */
+                page?: number;
+                /** @description Items per page */
+                page_size?: number;
+                /** @description Include inactive networks */
+                show_inactive?: boolean;
+                /** @description Filter by network name */
+                name?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.PaginatedNetworksResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    createNetwork: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Network configuration */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.CreateNetworkRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.NetworkResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getNetworkStats: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.NetworkStatsResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getNetwork: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Network ID */
+                networkId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.NetworkResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateNetwork: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Network ID */
+                networkId: string;
+            };
+            cookie?: never;
+        };
+        /** @description Updated network configuration */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.UpdateNetworkRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.NetworkResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteNetwork: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Network ID */
+                networkId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    disableNetwork: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Network ID */
+                networkId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.NetworkResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    startNetworkDiscovery: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Network ID */
+                networkId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.DiscoveryJobResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    listNetworkDiscoveryJobs: {
+        parameters: {
+            query?: {
+                /** @description Page number (default 1) */
+                page?: number;
+                /** @description Page size (default 50, max 100) */
+                page_size?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Network ID */
+                networkId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.PaginatedDiscoveryJobsResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    enableNetwork: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Network ID */
+                networkId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.NetworkResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    listNetworkExclusions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Network ID */
+                networkId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.NetworkExclusionResponse"][];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    createNetworkExclusion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Network ID */
+                networkId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: components["requestBodies"]["docs.CreateExclusionRequest"];
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.NetworkExclusionResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    renameNetwork: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Network ID */
+                networkId: string;
+            };
+            cookie?: never;
+        };
+        /** @description New network name */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.RenameNetworkRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.NetworkResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    listProfiles: {
+        parameters: {
+            query?: {
+                /** @description Page number */
+                page?: number;
+                /** @description Items per page */
+                page_size?: number;
+                /** @description Filter by scan type */
+                scan_type?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.PaginatedProfilesResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    createProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Profile configuration */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.CreateProfileRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ProfileResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Profile ID */
+                profileId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ProfileResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Profile ID */
+                profileId: string;
+            };
+            cookie?: never;
+        };
+        /** @description Updated profile configuration */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.CreateProfileRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ProfileResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Profile ID */
+                profileId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    listScans: {
+        parameters: {
+            query?: {
+                /** @description Page number */
+                page?: number;
+                /** @description Items per page */
+                page_size?: number;
+                /** @description Filter by status */
+                status?: "pending" | "running" | "completed" | "failed" | "cancelled";
+                /** @description Filter by target */
+                target?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.PaginatedScansResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    createScan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Scan configuration */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.CreateScanRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ScanResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getScan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Scan ID */
+                scanId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ScanResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateScan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Scan ID */
+                scanId: string;
+            };
+            cookie?: never;
+        };
+        /** @description Updated scan configuration */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.UpdateScanRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ScanResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteScan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Scan ID */
+                scanId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getScanResults: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Scan ID */
+                scanId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    startScan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Scan ID */
+                scanId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ScanResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    stopScan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Scan ID */
+                scanId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ScanResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    listSchedules: {
+        parameters: {
+            query?: {
+                /** @description Page number */
+                page?: number;
+                /** @description Items per page */
+                page_size?: number;
+                /** @description Filter by enabled status */
+                enabled?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.PaginatedSchedulesResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    createSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Schedule configuration */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.CreateScheduleRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ScheduleResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Schedule ID */
+                scheduleId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ScheduleResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Schedule ID */
+                scheduleId: string;
+            };
+            cookie?: never;
+        };
+        /** @description Updated schedule configuration */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.CreateScheduleRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ScheduleResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Schedule ID */
+                scheduleId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    disableSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Schedule ID */
+                scheduleId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ScheduleResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    enableSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Schedule ID */
+                scheduleId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ScheduleResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.StatusResponse"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getVersion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.VersionResponse"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
     };
-  };
 }

--- a/internal/db/013_certificates.sql
+++ b/internal/db/013_certificates.sql
@@ -1,4 +1,4 @@
--- Migration 010: TLS certificate records per host/port
+-- Migration 013: TLS certificate records per host/port
 -- Populated by banner enrichment after scans with open HTTPS ports.
 
 CREATE TABLE IF NOT EXISTS certificates (

--- a/internal/db/014_port_banners.sql
+++ b/internal/db/014_port_banners.sql
@@ -1,4 +1,4 @@
--- Migration 011: port banner and service version records per host/port
+-- Migration 014: port banner and service version records per host/port
 -- Populated by banner enrichment after scans with open ports.
 
 CREATE TABLE IF NOT EXISTS port_banners (

--- a/internal/db/015_snmp_data.sql
+++ b/internal/db/015_snmp_data.sql
@@ -1,4 +1,4 @@
--- Migration 010: SNMP data captured from network devices.
+-- Migration 015: SNMP data captured from network devices.
 -- Populated by SNMP enrichment when port 161 is open post-scan.
 
 CREATE TABLE IF NOT EXISTS host_snmp_data (

--- a/internal/db/repository_dns.go
+++ b/internal/db/repository_dns.go
@@ -36,16 +36,21 @@ func (r *DNSRepository) UpsertDNSRecords(ctx context.Context, hostID uuid.UUID, 
 
 	if len(records) > 0 {
 		// Batch insert all records in a single statement to avoid N+1 round-trips.
+		// Each row binds 5 args: id, host_id, record_type, value, ttl.
+		const argsPerRow = 5
 		placeholders := make([]string, 0, len(records))
-		args := make([]interface{}, 0, len(records)*5)
+		args := make([]interface{}, 0, len(records)*argsPerRow)
 		for i := range records {
 			records[i].HostID = hostID
 			if records[i].ID == uuid.Nil {
 				records[i].ID = uuid.New()
 			}
-			base := i * 5
-			placeholders = append(placeholders, fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,NOW())", base+1, base+2, base+3, base+4, base+5))
-			args = append(args, records[i].ID, records[i].HostID, records[i].RecordType, records[i].Value, records[i].TTL)
+			b := i * argsPerRow
+			placeholders = append(placeholders,
+				fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,NOW())", b+1, b+2, b+3, b+4, b+5))
+			args = append(args,
+				records[i].ID, records[i].HostID,
+				records[i].RecordType, records[i].Value, records[i].TTL)
 		}
 		query := `INSERT INTO host_dns_records (id, host_id, record_type, value, ttl, resolved_at) VALUES ` +
 			strings.Join(placeholders, ",")

--- a/internal/db/repository_dns.go
+++ b/internal/db/repository_dns.go
@@ -47,8 +47,8 @@ func (r *DNSRepository) UpsertDNSRecords(ctx context.Context, hostID uuid.UUID, 
 			}
 			b := i * argsPerRow
 			placeholders = append(placeholders,
-				fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,NOW())", //nolint:mnd
-					b+1, b+2, b+3, b+4, b+5))
+				fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,NOW())",
+					b+1, b+2, b+3, b+4, b+5)) //nolint:mnd
 			args = append(args,
 				records[i].ID, records[i].HostID,
 				records[i].RecordType, records[i].Value, records[i].TTL)

--- a/internal/db/repository_dns.go
+++ b/internal/db/repository_dns.go
@@ -47,7 +47,8 @@ func (r *DNSRepository) UpsertDNSRecords(ctx context.Context, hostID uuid.UUID, 
 			}
 			b := i * argsPerRow
 			placeholders = append(placeholders,
-				fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,NOW())", b+1, b+2, b+3, b+4, b+5))
+				fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,NOW())", //nolint:mnd
+					b+1, b+2, b+3, b+4, b+5))
 			args = append(args,
 				records[i].ID, records[i].HostID,
 				records[i].RecordType, records[i].Value, records[i].TTL)

--- a/internal/db/repository_dns.go
+++ b/internal/db/repository_dns.go
@@ -4,6 +4,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 )
@@ -33,18 +34,23 @@ func (r *DNSRepository) UpsertDNSRecords(ctx context.Context, hostID uuid.UUID, 
 		return fmt.Errorf("dns records: delete existing: %w", err)
 	}
 
-	for i := range records {
-		records[i].HostID = hostID
-		if records[i].ID == uuid.Nil {
-			records[i].ID = uuid.New()
+	if len(records) > 0 {
+		// Batch insert all records in a single statement to avoid N+1 round-trips.
+		placeholders := make([]string, 0, len(records))
+		args := make([]interface{}, 0, len(records)*5)
+		for i := range records {
+			records[i].HostID = hostID
+			if records[i].ID == uuid.Nil {
+				records[i].ID = uuid.New()
+			}
+			base := i * 5
+			placeholders = append(placeholders, fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,NOW())", base+1, base+2, base+3, base+4, base+5))
+			args = append(args, records[i].ID, records[i].HostID, records[i].RecordType, records[i].Value, records[i].TTL)
 		}
-		if _, err := tx.ExecContext(ctx,
-			`INSERT INTO host_dns_records (id, host_id, record_type, value, ttl, resolved_at)
-			VALUES ($1, $2, $3, $4, $5, NOW())`,
-			records[i].ID, records[i].HostID, records[i].RecordType,
-			records[i].Value, records[i].TTL,
-		); err != nil {
-			return fmt.Errorf("dns records: insert %s record: %w", records[i].RecordType, err)
+		query := `INSERT INTO host_dns_records (id, host_id, record_type, value, ttl, resolved_at) VALUES ` +
+			strings.Join(placeholders, ",")
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("dns records: batch insert: %w", err)
 		}
 	}
 

--- a/internal/db/repository_dns_unit_test.go
+++ b/internal/db/repository_dns_unit_test.go
@@ -51,16 +51,15 @@ func TestDNSRepository_UpsertDNSRecords_MultipleRecords(t *testing.T) {
 		{ID: uuid.New(), RecordType: "A", Value: "192.0.2.1"},
 	}
 
+	// Batch insert: all records in a single INSERT statement.
 	mock.ExpectBegin()
 	mock.ExpectExec("DELETE FROM host_dns_records").
 		WithArgs(hostID).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("INSERT INTO host_dns_records").
-		WithArgs(records[0].ID, hostID, "PTR", "host.example.com", (*int)(nil)).
-		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("INSERT INTO host_dns_records").
-		WithArgs(records[1].ID, hostID, "A", "192.0.2.1", (*int)(nil)).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+		WithArgs(records[0].ID, hostID, "PTR", "host.example.com", (*int)(nil),
+			records[1].ID, hostID, "A", "192.0.2.1", (*int)(nil)).
+		WillReturnResult(sqlmock.NewResult(2, 2))
 	mock.ExpectCommit()
 
 	err := NewDNSRepository(db).UpsertDNSRecords(context.Background(), hostID, records)

--- a/internal/enrichment/banner.go
+++ b/internal/enrichment/banner.go
@@ -146,6 +146,7 @@ func (g *BannerGrabber) grabTLS(ctx context.Context, t BannerTarget, port int, a
 		InsecureSkipVerify: true, //nolint:gosec // scanner needs certs from self-signed/expired endpoints
 		ServerName:         t.IP,
 	})
+	defer tlsConn.Close() //nolint:errcheck
 	if err := tlsConn.SetDeadline(time.Now().Add(bannerDialTimeout)); err != nil {
 		return
 	}


### PR DESCRIPTION
## Summary

Post-merge bug hunt on wave 1 (PRs #643–#647) found four issues:

- **Migration header comments** (013/014/015 all had wrong migration numbers in their `-- Migration N:` comment)
- **DNS records N+1 upsert**: `UpsertDNSRecords` looped over individual `INSERT` statements; replaced with a single multi-row batch `INSERT` (eliminates N+1 round-trips per enrichment run)
- **TLS connection cleanup**: `grabTLS` in `banner.go` deferred `rawConn.Close()` but did not explicitly close the `tls.Conn` wrapper; added `defer tlsConn.Close()`
- **Swagger/TypeScript types out of sync**: `docs.HostResponse` in `swagger_docs.go` was the old 9-field version; updated with all current fields (tags, os_family, os_name, os_version, vendor, description, response_time_ms, dns_records, banners, certificates, snmp_data); regenerated `swagger.json` and `frontend/src/api/types.ts`

## Test plan

- [x] `go test ./internal/db/` passes (DNS batch insert + updated unit test)
- [x] `go test ./internal/enrichment/` passes (banner grabber)
- [x] `go test ./internal/...` all 18 packages pass
- [x] `npx tsc --noEmit` passes (TypeScript types compatible with existing frontend code)
- [x] `docs.HostResponse` in regenerated swagger.json includes all enrichment fields
- [x] `types.ts` contains `dns_records`, `banners`, `certificates`, `snmp_data` on `HostResponse`

Fixes bugs found while working issue #649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)