### PR TITLE
fix(wave1): address verification gaps from issue #649

### DIFF
--- a/config/environments/config.example.yaml
+++ b/config/environments/config.example.yaml
@@ -91,6 +91,9 @@ scanning:
     requests_per_second: 100
     burst_size: 200
 
+  # SNMPv2c community string used for post-scan SNMP enrichment
+  snmp_community: "public"
+
 # API Server Configuration
 api:
   # Enable REST API server

--- a/internal/api/handlers/host.go
+++ b/internal/api/handlers/host.go
@@ -121,8 +121,8 @@ type HostResponse struct {
 	ResponseTimeAvgMS *int                  `json:"response_time_avg_ms,omitempty"`
 	TimeoutCount      int                   `json:"timeout_count"`
 	DNSRecords        []db.DNSRecord        `json:"dns_records,omitempty"`
-	Banners           []*db.PortBanner      `json:"banners,omitempty"`
-	Certificates      []*db.Certificate     `json:"certificates,omitempty"`
+	Banners           []*db.PortBanner      `json:"banners"`
+	Certificates      []*db.Certificate     `json:"certificates"`
 	SNMPData          *db.HostSNMPData      `json:"snmp_data,omitempty"`
 }
 
@@ -228,11 +228,13 @@ func (h *HostHandler) GetHost(w http.ResponseWriter, r *http.Request) {
 					h.logger.Warn("failed to fetch DNS records", "host_id", hostID, "error", dnsErr)
 				}
 			}
+			resp.Banners = []*db.PortBanner{}
+			resp.Certificates = []*db.Certificate{}
 			if h.bannerRepo != nil {
-				if banners, bErr := h.bannerRepo.ListPortBanners(r.Context(), hostID); bErr == nil {
+				if banners, bErr := h.bannerRepo.ListPortBanners(r.Context(), hostID); bErr == nil && banners != nil {
 					resp.Banners = banners
 				}
-				if certs, cErr := h.bannerRepo.ListCertificates(r.Context(), hostID); cErr == nil {
+				if certs, cErr := h.bannerRepo.ListCertificates(r.Context(), hostID); cErr == nil && certs != nil {
 					resp.Certificates = certs
 				}
 			}

--- a/internal/api/handlers/ports.go
+++ b/internal/api/handlers/ports.go
@@ -58,6 +58,10 @@ func (h *PortHandler) ListPorts(w http.ResponseWriter, r *http.Request) {
 		SortBy:    q.Get("sort_by"),
 		SortOrder: q.Get("sort_order"),
 	}
+	if s := q.Get("is_standard"); s != "" {
+		v := s == "true"
+		filters.IsStandard = &v
+	}
 
 	ports, total, err := h.repo.ListPortDefinitions(r.Context(), filters, params.Offset, params.PageSize)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,6 +133,10 @@ type ScanningConfig struct {
 
 	// Rate limiting
 	RateLimit RateLimitConfig `yaml:"rate_limit" json:"rate_limit"`
+
+	// SNMPCommunity is the SNMPv2c community string used for post-scan SNMP
+	// enrichment. Defaults to "public".
+	SNMPCommunity string `yaml:"snmp_community" json:"snmp_community"`
 }
 
 // RetryConfig holds retry settings for failed scans.
@@ -373,6 +377,7 @@ func defaultScanningConfig() ScanningConfig {
 			RequestsPerSecond: defaultRequestsPerSecond,
 			BurstSize:         defaultBurstSize,
 		},
+		SNMPCommunity: "public",
 	}
 }
 

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -687,17 +687,18 @@ type PortDefinition struct {
 	Service     string   `db:"service"     json:"service"`
 	Description string   `db:"description" json:"description,omitempty"`
 	Category    string   `db:"category"    json:"category,omitempty"`
-	OSFamilies  []string `db:"os_families" json:"os_families,omitempty"`
+	OSFamilies  []string `db:"os_families" json:"os_families"`
 	IsStandard  bool     `db:"is_standard" json:"is_standard"`
 }
 
 // PortFilters holds query parameters for listing port definitions.
 type PortFilters struct {
-	Search    string
-	Category  string
-	Protocol  string
-	SortBy    string
-	SortOrder string
+	Search     string
+	Category   string
+	Protocol   string
+	IsStandard *bool
+	SortBy     string
+	SortOrder  string
 }
 
 // Certificate is a TLS certificate record captured from a host/port.

--- a/internal/db/repository_ports.go
+++ b/internal/db/repository_ports.go
@@ -63,12 +63,9 @@ func scanPortRow(rows *sql.Rows) (*PortDefinition, error) {
 	return p, nil
 }
 
-// ListPortDefinitions returns port definitions filtered by the given criteria.
-func (r *PortRepository) ListPortDefinitions(
-	ctx context.Context, filters PortFilters, offset, limit int,
-) ([]*PortDefinition, int64, error) {
+// buildPortFilterClause constructs the WHERE clause and args for port filters.
+func buildPortFilterClause(filters PortFilters) (whereClause string, args []interface{}) {
 	var where []string
-	var args []interface{}
 	argIdx := 1
 
 	if filters.Search != "" {
@@ -90,11 +87,22 @@ func (r *PortRepository) ListPortDefinitions(
 		args = append(args, filters.Protocol)
 		argIdx++
 	}
+	if filters.IsStandard != nil {
+		where = append(where, fmt.Sprintf("is_standard = $%d", argIdx))
+		args = append(args, *filters.IsStandard)
+	}
 
-	whereClause := ""
 	if len(where) > 0 {
 		whereClause = "WHERE " + strings.Join(where, " AND ")
 	}
+	return whereClause, args
+}
+
+// ListPortDefinitions returns port definitions filtered by the given criteria.
+func (r *PortRepository) ListPortDefinitions(
+	ctx context.Context, filters PortFilters, offset, limit int,
+) ([]*PortDefinition, int64, error) {
+	whereClause, args := buildPortFilterClause(filters)
 
 	var total int64
 	countQ := fmt.Sprintf("SELECT COUNT(*) FROM port_definitions %s", whereClause)
@@ -113,10 +121,11 @@ func (r *PortRepository) ListPortDefinitions(
 		}
 	}
 
+	limitIdx := len(args) + 1
 	listQ := fmt.Sprintf(
 		`SELECT port, protocol, service, description, category, os_families, is_standard
 		 FROM port_definitions %s %s LIMIT $%d OFFSET $%d`,
-		whereClause, orderBy, argIdx, argIdx+1)
+		whereClause, orderBy, limitIdx, limitIdx+1)
 	args = append(args, limit, offset)
 
 	rows, err := r.db.QueryContext(ctx, listQ, args...)

--- a/internal/enrichment/snmp.go
+++ b/internal/enrichment/snmp.go
@@ -44,6 +44,17 @@ const (
 	oidIfPhysAddr   = ".1.3.6.1.2.1.2.2.1.6"
 )
 
+// IF-MIB ifOperStatus values (RFC 2863).
+const (
+	ifOperStatusUp             = 1
+	ifOperStatusDown           = 2
+	ifOperStatusTesting        = 3
+	ifOperStatusUnknown        = 4
+	ifOperStatusDormant        = 5
+	ifOperStatusNotPresent     = 6
+	ifOperStatusLowerLayerDown = 7
+)
+
 var systemOIDs = []string{
 	oidSysDescr,
 	oidSysUptime,
@@ -222,10 +233,23 @@ func applyIfPDU(entry *ifData, v gosnmp.SnmpPDU) {
 			entry.name = s
 		}
 	case strings.HasPrefix(v.Name, oidIfOperStatus+"."):
-		if gosnmp.ToBigInt(v.Value).Int64() == 1 {
+		switch gosnmp.ToBigInt(v.Value).Int64() {
+		case ifOperStatusUp:
 			entry.status = "up"
-		} else {
+		case ifOperStatusDown:
 			entry.status = "down"
+		case ifOperStatusTesting:
+			entry.status = "testing"
+		case ifOperStatusUnknown:
+			entry.status = "unknown"
+		case ifOperStatusDormant:
+			entry.status = "dormant"
+		case ifOperStatusNotPresent:
+			entry.status = "notPresent"
+		case ifOperStatusLowerLayerDown:
+			entry.status = "lowerLayerDown"
+		default:
+			entry.status = "unknown"
 		}
 	case strings.HasPrefix(v.Name, oidIfSpeed+"."):
 		bps := gosnmp.ToBigInt(v.Value).Uint64()

--- a/internal/scanning/scan.go
+++ b/internal/scanning/scan.go
@@ -642,7 +642,7 @@ func storeScanResults(
 
 	// Launch banner enrichment in the background — best-effort, non-blocking.
 	go runBannerEnrichment(database, result.Hosts)
-	go runSNMPEnrichment(database, result.Hosts)
+	go runSNMPEnrichment(database, result.Hosts, config.SNMPCommunity)
 
 	return nil
 }
@@ -966,7 +966,7 @@ const (
 
 // runSNMPEnrichment probes hosts that had port 161 open during the scan.
 // Runs in a goroutine; errors are logged but not propagated.
-func runSNMPEnrichment(database *db.DB, hosts []Host) {
+func runSNMPEnrichment(database *db.DB, hosts []Host, community string) {
 	defer func() {
 		if r := recover(); r != nil {
 			logging.Error("panic in SNMP enrichment goroutine", "error", r)
@@ -991,8 +991,9 @@ func runSNMPEnrichment(database *db.DB, hosts []Host) {
 			continue
 		}
 		target := enrichment.SNMPTarget{
-			HostID: dbHost.ID,
-			IP:     h.Address,
+			HostID:    dbHost.ID,
+			IP:        h.Address,
+			Community: community,
 		}
 		if err := enricher.EnrichHost(ctx, target); err != nil {
 			slog.Default().Warn("snmp enrichment failed", "ip", h.Address, "err", err)

--- a/internal/scanning/types.go
+++ b/internal/scanning/types.go
@@ -62,6 +62,9 @@ type ScanConfig struct {
 	// linked to the same UUID exposed to the API client via GetScanResults.
 	// When nil a fresh UUID is generated (CLI / legacy path).
 	ScanID *uuid.UUID
+	// SNMPCommunity is the SNMPv2c community string used during post-scan SNMP
+	// enrichment. When empty the enricher falls back to "public".
+	SNMPCommunity string
 }
 
 // Validate checks if the scan configuration is valid.


### PR DESCRIPTION
## Summary

Fixes five issues found during code-level verification of the Wave 1 PR test plans (anstrom/scanorama#649):

- **`?is_standard=false` filter not implemented** — added `IsStandard *bool` to `PortFilters`, wired query parameter in the ports handler, and added `is_standard = $N` clause in `repository_ports.go`
- **`os_families` absent when null** — removed `omitempty` from `PortDefinition.OSFamilies`; DB-null rows now emit `null`, empty arrays emit `[]`
- **SNMP community string override not wired** — added `snmp_community` to `ScanningConfig`, wired it through `runSNMPEnrichment` → `SNMPTarget.Community`; default remains `"public"`
- **`ifOperStatus` mapping incomplete** — expanded switch to cover all 7 IF-MIB states (up/down/testing/unknown/dormant/notPresent/lowerLayerDown); default falls back to `"unknown"`
- **`banners`/`certificates` absent when empty** — removed `omitempty` from `HostResponse.Banners` and `HostResponse.Certificates`; pre-initialized to empty slices so fields are always present in JSON

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./...` — passes
- [x] `golangci-lint run` — 0 issues
- [ ] `GET /api/v1/ports?is_standard=false` returns only non-standard ports
- [ ] `GET /api/v1/ports?page_size=5` — entries with unknown families show `"os_families": null`, not absent
- [ ] `GET /api/v1/hosts/{id}` for a host with no banners — response includes `"banners": []` and `"certificates": []`
- [ ] SNMP enrichment uses configured community string when `snmp_community` is set to a non-default value in config

Closes items in anstrom/scanorama#649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)