### PR TITLE
fix(wave1): snmp_data always present; fork navigates to new profile

### DIFF
--- a/frontend/src/routes/profiles.tsx
+++ b/frontend/src/routes/profiles.tsx
@@ -99,11 +99,13 @@ function MetaRow({ label, value }: { label: string; value: React.ReactNode }) {
 interface ProfileDetailPanelProps {
   profile: ProfileResponse;
   onClose: () => void;
+  onForked?: (profile: ProfileResponse) => void;
 }
 
 function ProfileDetailPanel({
   profile: initialProfile,
   onClose,
+  onForked,
 }: ProfileDetailPanelProps) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -144,10 +146,11 @@ function ProfileDetailPanel({
     if (!trimmed) return;
     setActionError(null);
     try {
-      await cloneProfile({ id: p.id ?? "", name: trimmed });
-      toast.success("Profile cloned successfully");
+      const forked = await cloneProfile({ id: p.id ?? "", name: trimmed });
+      toast.success("Profile forked successfully");
       setShowCloneDialog(false);
       onClose();
+      if (forked && onForked) onForked(forked);
     } catch (err) {
       const apiErr = err as { message?: string; error?: string };
       const msg =
@@ -615,6 +618,7 @@ export function ProfilesPage() {
         <ProfileDetailPanel
           profile={selectedProfile}
           onClose={() => setSelectedProfile(null)}
+          onForked={(forked) => setSelectedProfile(forked)}
         />
       )}
 

--- a/internal/api/handlers/host.go
+++ b/internal/api/handlers/host.go
@@ -123,7 +123,7 @@ type HostResponse struct {
 	DNSRecords        []db.DNSRecord        `json:"dns_records,omitempty"`
 	Banners           []*db.PortBanner      `json:"banners"`
 	Certificates      []*db.Certificate     `json:"certificates"`
-	SNMPData          *db.HostSNMPData      `json:"snmp_data,omitempty"`
+	SNMPData          *db.HostSNMPData      `json:"snmp_data"`
 	KnowledgeScore    int                   `json:"knowledge_score"`
 }
 


### PR DESCRIPTION
## Summary

Two remaining gaps from issue #649 verification:

- **`snmp_data` absent when null**: `HostDetailResponse.SNMPData` had `omitempty`, so hosts without SNMP enrichment returned the field missing entirely instead of `"snmp_data": null`. The prior fix commit correctly fixed `banners` and `certificates` but missed this field.
- **Fork doesn't navigate**: After forking a profile, `handleClone` discarded the returned profile and just closed the panel. Now it passes the new profile to an `onForked` callback so the parent can immediately open the forked profile's detail panel.

## Test plan

- [ ] `GET /api/v1/hosts/{id}` for a host with no SNMP data returns `"snmp_data": null` (key present, value null)
- [ ] Fork a template profile → panel closes and reopens on the new profile

Closes #649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)