### PR TITLE
feat(smart-scan): Smart Scan orchestrator with suggestions endpoint

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -88,6 +88,19 @@ jobs:
       - name: Generate API documentation
         run: make docs
 
+      - name: Check for swagger drift
+        run: |
+          if ! git diff --exit-code docs/swagger/ frontend/src/api/types.ts; then
+            echo ""
+            echo "❌ Swagger spec is out of sync with code annotations."
+            echo "Run 'make docs' locally and commit the updated files:"
+            echo "  docs/swagger/swagger.json"
+            echo "  docs/swagger/swagger.yaml"
+            echo "  docs/swagger/docs.go"
+            echo "  frontend/src/api/types.ts"
+            exit 1
+          fi
+
       - name: Build HTML documentation
         run: npm run docs:build
 

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -3188,6 +3188,233 @@ const docTemplate = `{
                 }
             }
         },
+        "/smart-scan/hosts/{id}/stage": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns the recommended next scan stage for the specified host.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Smart Scan"
+                ],
+                "summary": "Evaluate next scan stage for a host",
+                "operationId": "evaluateHostStage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Host UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ScanStageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/smart-scan/hosts/{id}/trigger": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Evaluates the host's knowledge gaps and queues the appropriate scan.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Smart Scan"
+                ],
+                "summary": "Trigger Smart Scan for a host",
+                "operationId": "triggerSmartScan",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Host UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No action needed",
+                        "schema": {
+                            "$ref": "#/definitions/docs.TriggerHostResponse"
+                        }
+                    },
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/docs.TriggerHostResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/smart-scan/suggestions": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns fleet-wide counts of hosts in each knowledge-gap category.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Smart Scan"
+                ],
+                "summary": "Get Smart Scan suggestions",
+                "operationId": "getSmartScanSuggestions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.SuggestionSummaryResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/smart-scan/trigger-batch": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Queues smart scans for all eligible hosts matching the filter.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Smart Scan"
+                ],
+                "summary": "Batch trigger Smart Scan",
+                "operationId": "triggerSmartScanBatch",
+                "parameters": [
+                    {
+                        "description": "Batch filter",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/docs.TriggerBatchRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/docs.BatchResultResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/status": {
             "get": {
                 "description": "Returns detailed system status information",
@@ -3269,6 +3496,46 @@ const docTemplate = `{
                 },
                 "timestamp": {
                     "type": "string"
+                }
+            }
+        },
+        "docs.BatchDetailEntryResponse": {
+            "type": "object",
+            "properties": {
+                "host_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "reason": {
+                    "type": "string",
+                    "example": "skip: host knowledge is sufficient"
+                },
+                "scan_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440001"
+                },
+                "stage": {
+                    "type": "string",
+                    "example": "os_detection"
+                }
+            }
+        },
+        "docs.BatchResultResponse": {
+            "type": "object",
+            "properties": {
+                "details": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/docs.BatchDetailEntryResponse"
+                    }
+                },
+                "queued": {
+                    "type": "integer",
+                    "example": 15
+                },
+                "skipped": {
+                    "type": "integer",
+                    "example": 51
                 }
             }
         },
@@ -4331,6 +4598,42 @@ const docTemplate = `{
                 }
             }
         },
+        "docs.ScanStageResponse": {
+            "type": "object",
+            "properties": {
+                "os_detection": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "ports": {
+                    "type": "string",
+                    "example": "1-1024"
+                },
+                "profile_id": {
+                    "type": "string",
+                    "example": "linux-common"
+                },
+                "reason": {
+                    "type": "string",
+                    "example": "no OS information recorded"
+                },
+                "scan_type": {
+                    "type": "string",
+                    "example": "syn"
+                },
+                "stage": {
+                    "type": "string",
+                    "enum": [
+                        "os_detection",
+                        "port_expansion",
+                        "service_scan",
+                        "refresh",
+                        "skip"
+                    ],
+                    "example": "os_detection"
+                }
+            }
+        },
         "docs.ScheduleResponse": {
             "type": "object",
             "properties": {
@@ -4418,6 +4721,100 @@ const docTemplate = `{
                 "version": {
                     "type": "string",
                     "example": "0.7.0"
+                }
+            }
+        },
+        "docs.SuggestionGroupResponse": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "example": "os_detection"
+                },
+                "count": {
+                    "type": "integer",
+                    "example": 12
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Hosts with no OS information"
+                }
+            }
+        },
+        "docs.SuggestionSummaryResponse": {
+            "type": "object",
+            "properties": {
+                "generated_at": {
+                    "type": "string"
+                },
+                "no_os_info": {
+                    "$ref": "#/definitions/docs.SuggestionGroupResponse"
+                },
+                "no_ports": {
+                    "$ref": "#/definitions/docs.SuggestionGroupResponse"
+                },
+                "no_services": {
+                    "$ref": "#/definitions/docs.SuggestionGroupResponse"
+                },
+                "stale": {
+                    "$ref": "#/definitions/docs.SuggestionGroupResponse"
+                },
+                "total_hosts": {
+                    "type": "integer",
+                    "example": 1082
+                },
+                "well_known": {
+                    "$ref": "#/definitions/docs.SuggestionGroupResponse"
+                }
+            }
+        },
+        "docs.TriggerBatchRequest": {
+            "type": "object",
+            "properties": {
+                "host_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "550e8400-e29b-41d4-a716-446655440000"
+                    ]
+                },
+                "limit": {
+                    "type": "integer",
+                    "example": 50
+                },
+                "stage": {
+                    "type": "string",
+                    "enum": [
+                        "os_detection",
+                        "port_expansion",
+                        "service_scan",
+                        "refresh",
+                        "skip"
+                    ],
+                    "example": "os_detection"
+                }
+            }
+        },
+        "docs.TriggerHostResponse": {
+            "type": "object",
+            "properties": {
+                "host_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "message": {
+                    "type": "string",
+                    "example": "no scan needed — host knowledge is sufficient"
+                },
+                "queued": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "scan_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440001"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -3182,6 +3182,233 @@
                 }
             }
         },
+        "/smart-scan/hosts/{id}/stage": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns the recommended next scan stage for the specified host.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Smart Scan"
+                ],
+                "summary": "Evaluate next scan stage for a host",
+                "operationId": "evaluateHostStage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Host UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ScanStageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/smart-scan/hosts/{id}/trigger": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Evaluates the host's knowledge gaps and queues the appropriate scan.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Smart Scan"
+                ],
+                "summary": "Trigger Smart Scan for a host",
+                "operationId": "triggerSmartScan",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Host UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No action needed",
+                        "schema": {
+                            "$ref": "#/definitions/docs.TriggerHostResponse"
+                        }
+                    },
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/docs.TriggerHostResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/smart-scan/suggestions": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns fleet-wide counts of hosts in each knowledge-gap category.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Smart Scan"
+                ],
+                "summary": "Get Smart Scan suggestions",
+                "operationId": "getSmartScanSuggestions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.SuggestionSummaryResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/smart-scan/trigger-batch": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Queues smart scans for all eligible hosts matching the filter.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Smart Scan"
+                ],
+                "summary": "Batch trigger Smart Scan",
+                "operationId": "triggerSmartScanBatch",
+                "parameters": [
+                    {
+                        "description": "Batch filter",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/docs.TriggerBatchRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/docs.BatchResultResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/status": {
             "get": {
                 "description": "Returns detailed system status information",
@@ -3263,6 +3490,46 @@
                 },
                 "timestamp": {
                     "type": "string"
+                }
+            }
+        },
+        "docs.BatchDetailEntryResponse": {
+            "type": "object",
+            "properties": {
+                "host_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "reason": {
+                    "type": "string",
+                    "example": "skip: host knowledge is sufficient"
+                },
+                "scan_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440001"
+                },
+                "stage": {
+                    "type": "string",
+                    "example": "os_detection"
+                }
+            }
+        },
+        "docs.BatchResultResponse": {
+            "type": "object",
+            "properties": {
+                "details": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/docs.BatchDetailEntryResponse"
+                    }
+                },
+                "queued": {
+                    "type": "integer",
+                    "example": 15
+                },
+                "skipped": {
+                    "type": "integer",
+                    "example": 51
                 }
             }
         },
@@ -4325,6 +4592,42 @@
                 }
             }
         },
+        "docs.ScanStageResponse": {
+            "type": "object",
+            "properties": {
+                "os_detection": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "ports": {
+                    "type": "string",
+                    "example": "1-1024"
+                },
+                "profile_id": {
+                    "type": "string",
+                    "example": "linux-common"
+                },
+                "reason": {
+                    "type": "string",
+                    "example": "no OS information recorded"
+                },
+                "scan_type": {
+                    "type": "string",
+                    "example": "syn"
+                },
+                "stage": {
+                    "type": "string",
+                    "enum": [
+                        "os_detection",
+                        "port_expansion",
+                        "service_scan",
+                        "refresh",
+                        "skip"
+                    ],
+                    "example": "os_detection"
+                }
+            }
+        },
         "docs.ScheduleResponse": {
             "type": "object",
             "properties": {
@@ -4412,6 +4715,100 @@
                 "version": {
                     "type": "string",
                     "example": "0.7.0"
+                }
+            }
+        },
+        "docs.SuggestionGroupResponse": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "example": "os_detection"
+                },
+                "count": {
+                    "type": "integer",
+                    "example": 12
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Hosts with no OS information"
+                }
+            }
+        },
+        "docs.SuggestionSummaryResponse": {
+            "type": "object",
+            "properties": {
+                "generated_at": {
+                    "type": "string"
+                },
+                "no_os_info": {
+                    "$ref": "#/definitions/docs.SuggestionGroupResponse"
+                },
+                "no_ports": {
+                    "$ref": "#/definitions/docs.SuggestionGroupResponse"
+                },
+                "no_services": {
+                    "$ref": "#/definitions/docs.SuggestionGroupResponse"
+                },
+                "stale": {
+                    "$ref": "#/definitions/docs.SuggestionGroupResponse"
+                },
+                "total_hosts": {
+                    "type": "integer",
+                    "example": 1082
+                },
+                "well_known": {
+                    "$ref": "#/definitions/docs.SuggestionGroupResponse"
+                }
+            }
+        },
+        "docs.TriggerBatchRequest": {
+            "type": "object",
+            "properties": {
+                "host_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "550e8400-e29b-41d4-a716-446655440000"
+                    ]
+                },
+                "limit": {
+                    "type": "integer",
+                    "example": 50
+                },
+                "stage": {
+                    "type": "string",
+                    "enum": [
+                        "os_detection",
+                        "port_expansion",
+                        "service_scan",
+                        "refresh",
+                        "skip"
+                    ],
+                    "example": "os_detection"
+                }
+            }
+        },
+        "docs.TriggerHostResponse": {
+            "type": "object",
+            "properties": {
+                "host_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "message": {
+                    "type": "string",
+                    "example": "no scan needed — host knowledge is sufficient"
+                },
+                "queued": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "scan_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440001"
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -11,6 +11,34 @@ definitions:
       timestamp:
         type: string
     type: object
+  docs.BatchDetailEntryResponse:
+    properties:
+      host_id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      reason:
+        example: 'skip: host knowledge is sufficient'
+        type: string
+      scan_id:
+        example: 550e8400-e29b-41d4-a716-446655440001
+        type: string
+      stage:
+        example: os_detection
+        type: string
+    type: object
+  docs.BatchResultResponse:
+    properties:
+      details:
+        items:
+          $ref: '#/definitions/docs.BatchDetailEntryResponse'
+        type: array
+      queued:
+        example: 15
+        type: integer
+      skipped:
+        example: 51
+        type: integer
+    type: object
   docs.CertificateResponse:
     properties:
       host_id:
@@ -772,6 +800,33 @@ definitions:
       updated_at:
         type: string
     type: object
+  docs.ScanStageResponse:
+    properties:
+      os_detection:
+        example: true
+        type: boolean
+      ports:
+        example: 1-1024
+        type: string
+      profile_id:
+        example: linux-common
+        type: string
+      reason:
+        example: no OS information recorded
+        type: string
+      scan_type:
+        example: syn
+        type: string
+      stage:
+        enum:
+        - os_detection
+        - port_expansion
+        - service_scan
+        - refresh
+        - skip
+        example: os_detection
+        type: string
+    type: object
   docs.ScheduleResponse:
     properties:
       created_at:
@@ -834,6 +889,72 @@ definitions:
         type: string
       version:
         example: 0.7.0
+        type: string
+    type: object
+  docs.SuggestionGroupResponse:
+    properties:
+      action:
+        example: os_detection
+        type: string
+      count:
+        example: 12
+        type: integer
+      description:
+        example: Hosts with no OS information
+        type: string
+    type: object
+  docs.SuggestionSummaryResponse:
+    properties:
+      generated_at:
+        type: string
+      no_os_info:
+        $ref: '#/definitions/docs.SuggestionGroupResponse'
+      no_ports:
+        $ref: '#/definitions/docs.SuggestionGroupResponse'
+      no_services:
+        $ref: '#/definitions/docs.SuggestionGroupResponse'
+      stale:
+        $ref: '#/definitions/docs.SuggestionGroupResponse'
+      total_hosts:
+        example: 1082
+        type: integer
+      well_known:
+        $ref: '#/definitions/docs.SuggestionGroupResponse'
+    type: object
+  docs.TriggerBatchRequest:
+    properties:
+      host_ids:
+        example:
+        - 550e8400-e29b-41d4-a716-446655440000
+        items:
+          type: string
+        type: array
+      limit:
+        example: 50
+        type: integer
+      stage:
+        enum:
+        - os_detection
+        - port_expansion
+        - service_scan
+        - refresh
+        - skip
+        example: os_detection
+        type: string
+    type: object
+  docs.TriggerHostResponse:
+    properties:
+      host_id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      message:
+        example: no scan needed — host knowledge is sufficient
+        type: string
+      queued:
+        example: true
+        type: boolean
+      scan_id:
+        example: 550e8400-e29b-41d4-a716-446655440001
         type: string
     type: object
   docs.UpdateNetworkRequest:
@@ -3017,6 +3138,153 @@ paths:
       summary: Enable schedule
       tags:
       - Schedules
+  /smart-scan/hosts/{id}/stage:
+    get:
+      description: Returns the recommended next scan stage for the specified host.
+      operationId: evaluateHostStage
+      parameters:
+      - description: Host UUID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/docs.ScanStageResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Evaluate next scan stage for a host
+      tags:
+      - Smart Scan
+  /smart-scan/hosts/{id}/trigger:
+    post:
+      description: Evaluates the host's knowledge gaps and queues the appropriate
+        scan.
+      operationId: triggerSmartScan
+      parameters:
+      - description: Host UUID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: No action needed
+          schema:
+            $ref: '#/definitions/docs.TriggerHostResponse'
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/docs.TriggerHostResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "429":
+          description: Too Many Requests
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Trigger Smart Scan for a host
+      tags:
+      - Smart Scan
+  /smart-scan/suggestions:
+    get:
+      description: Returns fleet-wide counts of hosts in each knowledge-gap category.
+      operationId: getSmartScanSuggestions
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/docs.SuggestionSummaryResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Get Smart Scan suggestions
+      tags:
+      - Smart Scan
+  /smart-scan/trigger-batch:
+    post:
+      consumes:
+      - application/json
+      description: Queues smart scans for all eligible hosts matching the filter.
+      operationId: triggerSmartScanBatch
+      parameters:
+      - description: Batch filter
+        in: body
+        name: body
+        schema:
+          $ref: '#/definitions/docs.TriggerBatchRequest'
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/docs.BatchResultResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Batch trigger Smart Scan
+      tags:
+      - Smart Scan
   /status:
     get:
       description: Returns detailed system status information

--- a/docs/swagger_docs.go
+++ b/docs/swagger_docs.go
@@ -1305,3 +1305,124 @@ func StartNetworkDiscovery(_ http.ResponseWriter, _ *http.Request) {}
 // @Router /networks/{networkId}/discovery [get]
 // @ID listNetworkDiscoveryJobs
 func ListNetworkDiscoveryJobs(_ http.ResponseWriter, _ *http.Request) {}
+
+// GetSmartScanSuggestions godoc
+// @Summary Get Smart Scan suggestions
+// @Description Returns fleet-wide counts of hosts in each knowledge-gap category.
+// @Tags Smart Scan
+// @Produce json
+// @Success 200 {object} SuggestionSummaryResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Security ApiKeyAuth
+// @Router /smart-scan/suggestions [get]
+// @ID getSmartScanSuggestions
+func GetSmartScanSuggestions(_ http.ResponseWriter, _ *http.Request) {}
+
+// EvaluateHostStage godoc
+// @Summary Evaluate next scan stage for a host
+// @Description Returns the recommended next scan stage for the specified host.
+// @Tags Smart Scan
+// @Produce json
+// @Param id path string true "Host UUID" format(uuid)
+// @Success 200 {object} ScanStageResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Security ApiKeyAuth
+// @Router /smart-scan/hosts/{id}/stage [get]
+// @ID evaluateHostStage
+func EvaluateHostStage(_ http.ResponseWriter, _ *http.Request) {}
+
+// TriggerSmartScan godoc
+// @Summary Trigger Smart Scan for a host
+// @Description Evaluates the host's knowledge gaps and queues the appropriate scan.
+// @Tags Smart Scan
+// @Produce json
+// @Param id path string true "Host UUID" format(uuid)
+// @Success 202 {object} TriggerHostResponse
+// @Success 200 {object} TriggerHostResponse "No action needed"
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 429 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Security ApiKeyAuth
+// @Router /smart-scan/hosts/{id}/trigger [post]
+// @ID triggerSmartScan
+func TriggerSmartScan(_ http.ResponseWriter, _ *http.Request) {}
+
+// TriggerSmartScanBatch godoc
+// @Summary Batch trigger Smart Scan
+// @Description Queues smart scans for all eligible hosts matching the filter.
+// @Tags Smart Scan
+// @Accept json
+// @Produce json
+// @Param body body TriggerBatchRequest false "Batch filter"
+// @Success 202 {object} BatchResultResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Security ApiKeyAuth
+// @Router /smart-scan/trigger-batch [post]
+// @ID triggerSmartScanBatch
+func TriggerSmartScanBatch(_ http.ResponseWriter, _ *http.Request) {}
+
+// ScanStageResponse is the response body for EvaluateHostStage.
+type ScanStageResponse struct {
+	Stage       string  `json:"stage" example:"os_detection" enums:"os_detection,port_expansion,service_scan,refresh,skip"`
+	ScanType    string  `json:"scan_type" example:"syn"`
+	Ports       string  `json:"ports" example:"1-1024"`
+	OSDetection bool    `json:"os_detection" example:"true"`
+	ProfileID   *string `json:"profile_id,omitempty" example:"linux-common"`
+	Reason      string  `json:"reason" example:"no OS information recorded"`
+}
+
+// SuggestionGroupResponse represents a count of hosts sharing a knowledge gap.
+type SuggestionGroupResponse struct {
+	Count       int    `json:"count" example:"12"`
+	Description string `json:"description" example:"Hosts with no OS information"`
+	Action      string `json:"action" example:"os_detection"`
+}
+
+// SuggestionSummaryResponse is the response body for GetSmartScanSuggestions.
+type SuggestionSummaryResponse struct {
+	NoOSInfo    SuggestionGroupResponse `json:"no_os_info"`
+	NoPorts     SuggestionGroupResponse `json:"no_ports"`
+	NoServices  SuggestionGroupResponse `json:"no_services"`
+	Stale       SuggestionGroupResponse `json:"stale"`
+	WellKnown   SuggestionGroupResponse `json:"well_known"`
+	TotalHosts  int                     `json:"total_hosts" example:"1082"`
+	GeneratedAt time.Time               `json:"generated_at"`
+}
+
+// TriggerHostResponse is the response body for TriggerSmartScan.
+type TriggerHostResponse struct {
+	HostID  string `json:"host_id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Queued  bool   `json:"queued" example:"true"`
+	ScanID  string `json:"scan_id,omitempty" example:"550e8400-e29b-41d4-a716-446655440001"`
+	Message string `json:"message,omitempty" example:"no scan needed — host knowledge is sufficient"`
+}
+
+// TriggerBatchRequest is the request body for TriggerSmartScanBatch.
+type TriggerBatchRequest struct {
+	Stage   string   `json:"stage,omitempty" example:"os_detection" enums:"os_detection,port_expansion,service_scan,refresh,skip"`
+	HostIDs []string `json:"host_ids,omitempty" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Limit   int      `json:"limit,omitempty" example:"50"`
+}
+
+// BatchDetailEntryResponse records the outcome for one host in a batch.
+type BatchDetailEntryResponse struct {
+	HostID string `json:"host_id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Stage  string `json:"stage" example:"os_detection"`
+	ScanID string `json:"scan_id,omitempty" example:"550e8400-e29b-41d4-a716-446655440001"`
+	Reason string `json:"reason,omitempty" example:"skip: host knowledge is sufficient"`
+}
+
+// BatchResultResponse is the response body for TriggerSmartScanBatch.
+type BatchResultResponse struct {
+	Queued  int                        `json:"queued" example:"15"`
+	Skipped int                        `json:"skipped" example:"51"`
+	Details []BatchDetailEntryResponse `json:"details"`
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6960,22 +6960,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yaml-ast-parser": {
       "version": "0.0.43",
       "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -736,6 +736,86 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/smart-scan/hosts/{id}/stage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Evaluate next scan stage for a host
+         * @description Returns the recommended next scan stage for the specified host.
+         */
+        get: operations["evaluateHostStage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/smart-scan/hosts/{id}/trigger": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger Smart Scan for a host
+         * @description Evaluates the host's knowledge gaps and queues the appropriate scan.
+         */
+        post: operations["triggerSmartScan"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/smart-scan/suggestions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Smart Scan suggestions
+         * @description Returns fleet-wide counts of hosts in each knowledge-gap category.
+         */
+        get: operations["getSmartScanSuggestions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/smart-scan/trigger-batch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Batch trigger Smart Scan
+         * @description Queues smart scans for all eligible hosts matching the filter.
+         */
+        post: operations["triggerSmartScanBatch"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/status": {
         parameters: {
             query?: never;
@@ -787,6 +867,23 @@ export interface components {
                 [key: string]: unknown;
             };
             timestamp?: string;
+        };
+        "docs.BatchDetailEntryResponse": {
+            /** @example 550e8400-e29b-41d4-a716-446655440000 */
+            host_id?: string;
+            /** @example skip: host knowledge is sufficient */
+            reason?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440001 */
+            scan_id?: string;
+            /** @example os_detection */
+            stage?: string;
+        };
+        "docs.BatchResultResponse": {
+            details?: components["schemas"]["docs.BatchDetailEntryResponse"][];
+            /** @example 15 */
+            queued?: number;
+            /** @example 51 */
+            skipped?: number;
         };
         "docs.CertificateResponse": {
             host_id?: string;
@@ -1274,6 +1371,23 @@ export interface components {
             targets?: string[];
             updated_at?: string;
         };
+        "docs.ScanStageResponse": {
+            /** @example true */
+            os_detection?: boolean;
+            /** @example 1-1024 */
+            ports?: string;
+            /** @example linux-common */
+            profile_id?: string;
+            /** @example no OS information recorded */
+            reason?: string;
+            /** @example syn */
+            scan_type?: string;
+            /**
+             * @example os_detection
+             * @enum {string}
+             */
+            stage?: "os_detection" | "port_expansion" | "service_scan" | "refresh" | "skip";
+        };
         "docs.ScheduleResponse": {
             created_at?: string;
             created_by?: string;
@@ -1314,6 +1428,49 @@ export interface components {
             uptime?: string;
             /** @example 0.7.0 */
             version?: string;
+        };
+        "docs.SuggestionGroupResponse": {
+            /** @example os_detection */
+            action?: string;
+            /** @example 12 */
+            count?: number;
+            /** @example Hosts with no OS information */
+            description?: string;
+        };
+        "docs.SuggestionSummaryResponse": {
+            generated_at?: string;
+            no_os_info?: components["schemas"]["docs.SuggestionGroupResponse"];
+            no_ports?: components["schemas"]["docs.SuggestionGroupResponse"];
+            no_services?: components["schemas"]["docs.SuggestionGroupResponse"];
+            stale?: components["schemas"]["docs.SuggestionGroupResponse"];
+            /** @example 1082 */
+            total_hosts?: number;
+            well_known?: components["schemas"]["docs.SuggestionGroupResponse"];
+        };
+        "docs.TriggerBatchRequest": {
+            /**
+             * @example [
+             *       "550e8400-e29b-41d4-a716-446655440000"
+             *     ]
+             */
+            host_ids?: string[];
+            /** @example 50 */
+            limit?: number;
+            /**
+             * @example os_detection
+             * @enum {string}
+             */
+            stage?: "os_detection" | "port_expansion" | "service_scan" | "refresh" | "skip";
+        };
+        "docs.TriggerHostResponse": {
+            /** @example 550e8400-e29b-41d4-a716-446655440000 */
+            host_id?: string;
+            /** @example no scan needed — host knowledge is sufficient */
+            message?: string;
+            /** @example true */
+            queued?: boolean;
+            /** @example 550e8400-e29b-41d4-a716-446655440001 */
+            scan_id?: string;
         };
         "docs.UpdateNetworkRequest": {
             /** @example 192.168.1.0/24 */
@@ -4416,6 +4573,232 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    evaluateHostStage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Host UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ScanStageResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    triggerSmartScan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Host UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No action needed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.TriggerHostResponse"];
+                };
+            };
+            /** @description Accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.TriggerHostResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getSmartScanSuggestions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.SuggestionSummaryResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    triggerSmartScanBatch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Batch filter */
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["docs.TriggerBatchRequest"];
+            };
+        };
+        responses: {
+            /** @description Accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.BatchResultResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/internal/api/handlers/smartscan.go
+++ b/internal/api/handlers/smartscan.go
@@ -1,0 +1,210 @@
+// Package handlers - Smart Scan HTTP adapter.
+// Thin HTTP layer over services.SmartScanService.
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+
+	"github.com/anstrom/scanorama/internal/errors"
+	"github.com/anstrom/scanorama/internal/scanning"
+	"github.com/anstrom/scanorama/internal/services"
+)
+
+// smartScanServicer is the service interface consumed by SmartScanHandler.
+type smartScanServicer interface {
+	GetSuggestions(ctx context.Context) (*services.SuggestionSummary, error)
+	EvaluateHostByID(ctx context.Context, hostID uuid.UUID) (*services.ScanStage, error)
+	QueueSmartScan(ctx context.Context, hostID uuid.UUID) (uuid.UUID, error)
+	QueueBatch(ctx context.Context, filter services.BatchFilter) (*services.BatchResult, error)
+}
+
+// SmartScanHandler handles Smart Scan API endpoints.
+type SmartScanHandler struct {
+	service smartScanServicer
+	logger  *slog.Logger
+}
+
+// NewSmartScanHandler creates a new SmartScanHandler.
+func NewSmartScanHandler(svc *services.SmartScanService, logger *slog.Logger) *SmartScanHandler {
+	return &SmartScanHandler{
+		service: svc,
+		logger:  logger.With("handler", "smart_scan"),
+	}
+}
+
+// GetSuggestions handles GET /api/v1/smart-scan/suggestions.
+//
+//	@Summary		Get Smart Scan suggestions
+//	@Description	Returns fleet-wide counts of hosts in each knowledge-gap category.
+//	@Tags			smart-scan
+//	@Produce		json
+//	@Success		200	{object}	services.SuggestionSummary
+//	@Failure		500	{object}	ErrorResponse
+//	@Router			/smart-scan/suggestions [get]
+func (h *SmartScanHandler) GetSuggestions(w http.ResponseWriter, r *http.Request) {
+	summary, err := h.service.GetSuggestions(r.Context())
+	if err != nil {
+		h.logger.Error("Failed to get smart scan suggestions", "error", err)
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, r, http.StatusOK, summary)
+}
+
+// EvaluateHost handles GET /api/v1/smart-scan/hosts/{id}/stage.
+//
+//	@Summary		Evaluate next scan stage for a host
+//	@Description	Returns the recommended next scan stage for the specified host.
+//	@Tags			smart-scan
+//	@Produce		json
+//	@Param			id	path		string	true	"Host UUID"
+//	@Success		200	{object}	services.ScanStage
+//	@Failure		400	{object}	ErrorResponse
+//	@Failure		404	{object}	ErrorResponse
+//	@Failure		500	{object}	ErrorResponse
+//	@Router			/smart-scan/hosts/{id}/stage [get]
+func (h *SmartScanHandler) EvaluateHost(w http.ResponseWriter, r *http.Request) {
+	hostID, err := parseHostID(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	// Load host so EvaluateHost can inspect its fields.
+	stage, err := h.service.EvaluateHostByID(r.Context(), hostID)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			writeError(w, r, http.StatusNotFound, err)
+			return
+		}
+		h.logger.Error("Failed to evaluate host stage", "host_id", hostID, "error", err)
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, r, http.StatusOK, stage)
+}
+
+// TriggerHost handles POST /api/v1/smart-scan/hosts/{id}/trigger.
+//
+//	@Summary		Trigger Smart Scan for a host
+//	@Description	Evaluates the host's knowledge gaps and queues the appropriate scan.
+//	@Tags			smart-scan
+//	@Produce		json
+//	@Param			id	path		string	true	"Host UUID"
+//	@Success		202	{object}	triggerHostResponse
+//	@Success		200	{object}	triggerHostResponse	"No action needed"
+//	@Failure		400	{object}	ErrorResponse
+//	@Failure		429	{object}	ErrorResponse
+//	@Failure		500	{object}	ErrorResponse
+//	@Router			/smart-scan/hosts/{id}/trigger [post]
+func (h *SmartScanHandler) TriggerHost(w http.ResponseWriter, r *http.Request) {
+	hostID, err := parseHostID(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	scanID, err := h.service.QueueSmartScan(r.Context(), hostID)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			writeError(w, r, http.StatusNotFound, err)
+			return
+		}
+		if stderrors.Is(err, scanning.ErrQueueFull) {
+			writeError(w, r, http.StatusTooManyRequests, err)
+			return
+		}
+		h.logger.Error("Failed to trigger smart scan", "host_id", hostID, "error", err)
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	resp := triggerHostResponse{HostID: hostID.String()}
+	if scanID == uuid.Nil {
+		resp.Queued = false
+		resp.Message = "no scan needed — host knowledge is sufficient"
+		writeJSON(w, r, http.StatusOK, resp)
+		return
+	}
+	resp.Queued = true
+	resp.ScanID = scanID.String()
+	writeJSON(w, r, http.StatusAccepted, resp)
+}
+
+type triggerHostResponse struct {
+	HostID  string `json:"host_id"`
+	Queued  bool   `json:"queued"`
+	ScanID  string `json:"scan_id,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// TriggerBatch handles POST /api/v1/smart-scan/trigger-batch.
+//
+//	@Summary		Batch trigger Smart Scan
+//	@Description	Queues smart scans for all eligible hosts matching the filter.
+//	@Tags			smart-scan
+//	@Accept			json
+//	@Produce		json
+//	@Param			body	body		triggerBatchRequest	false	"Batch filter"
+//	@Success		202	{object}	services.BatchResult
+//	@Failure		400	{object}	ErrorResponse
+//	@Failure		500	{object}	ErrorResponse
+//	@Router			/smart-scan/trigger-batch [post]
+func (h *SmartScanHandler) TriggerBatch(w http.ResponseWriter, r *http.Request) {
+	var req triggerBatchRequest
+	if r.ContentLength > 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, r, http.StatusBadRequest, err)
+			return
+		}
+	}
+
+	hostIDs := make([]uuid.UUID, 0, len(req.HostIDs))
+	for _, s := range req.HostIDs {
+		id, err := uuid.Parse(s)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, err)
+			return
+		}
+		hostIDs = append(hostIDs, id)
+	}
+
+	result, err := h.service.QueueBatch(r.Context(), services.BatchFilter{
+		Stage:   req.Stage,
+		HostIDs: hostIDs,
+		Limit:   req.Limit,
+	})
+	if err != nil {
+		h.logger.Error("Failed to queue batch smart scan", "error", err)
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, r, http.StatusAccepted, result)
+}
+
+type triggerBatchRequest struct {
+	Stage   string   `json:"stage"`
+	HostIDs []string `json:"host_ids"`
+	Limit   int      `json:"limit"`
+}
+
+// parseHostID extracts the host UUID from the path variable {id}.
+func parseHostID(r *http.Request) (uuid.UUID, error) {
+	vars := mux.Vars(r)
+	raw, ok := vars["id"]
+	if !ok || raw == "" {
+		return uuid.Nil, errors.NewScanError(errors.CodeValidation, "missing host id")
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.Nil, errors.NewScanError(errors.CodeValidation, "invalid host id")
+	}
+	return id, nil
+}

--- a/internal/api/handlers/smartscan_test.go
+++ b/internal/api/handlers/smartscan_test.go
@@ -135,10 +135,18 @@ func TestSmartScan_EvaluateHost_ReturnsValidStage(t *testing.T) {
 		"/api/v1/smart-scan/hosts/"+hostID.String()+"/stage", nil)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	var stage services.ScanStage
-	require.NoError(t, json.NewDecoder(w.Body).Decode(&stage))
-	assert.NotEmpty(t, stage.Stage)
-	assert.NotEmpty(t, stage.Reason)
+	// Decode into a raw map so we assert on the actual JSON key names, not Go
+	// field names. Decoding into services.ScanStage would mask missing json tags
+	// because Go's decoder maps PascalCase JSON keys to PascalCase fields.
+	var raw map[string]interface{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&raw))
+	assert.Equal(t, "os_detection", raw["stage"])
+	assert.Equal(t, "syn", raw["scan_type"])
+	assert.Equal(t, "22,80,443", raw["ports"])
+	assert.Equal(t, "no OS information", raw["reason"])
+	assert.NotContains(t, raw, "Stage", "response keys must be snake_case")
+	assert.NotContains(t, raw, "ScanType", "response keys must be snake_case")
+	assert.NotContains(t, raw, "OSDetection", "response keys must be snake_case")
 }
 
 func TestSmartScan_EvaluateHost_NotFound_Returns404(t *testing.T) {

--- a/internal/api/handlers/smartscan_test.go
+++ b/internal/api/handlers/smartscan_test.go
@@ -1,0 +1,258 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apierrors "github.com/anstrom/scanorama/internal/errors"
+	"github.com/anstrom/scanorama/internal/scanning"
+	"github.com/anstrom/scanorama/internal/services"
+)
+
+// ── mock ──────────────────────────────────────────────────────────────────────
+
+type mockSmartScanServicer struct {
+	getSuggestionsFn   func(ctx context.Context) (*services.SuggestionSummary, error)
+	evaluateHostByIDFn func(ctx context.Context, id uuid.UUID) (*services.ScanStage, error)
+	queueSmartScanFn   func(ctx context.Context, id uuid.UUID) (uuid.UUID, error)
+	queueBatchFn       func(ctx context.Context, f services.BatchFilter) (*services.BatchResult, error)
+}
+
+func (m *mockSmartScanServicer) GetSuggestions(ctx context.Context) (*services.SuggestionSummary, error) {
+	return m.getSuggestionsFn(ctx)
+}
+
+func (m *mockSmartScanServicer) EvaluateHostByID(ctx context.Context, id uuid.UUID) (*services.ScanStage, error) {
+	return m.evaluateHostByIDFn(ctx, id)
+}
+
+func (m *mockSmartScanServicer) QueueSmartScan(ctx context.Context, id uuid.UUID) (uuid.UUID, error) {
+	return m.queueSmartScanFn(ctx, id)
+}
+
+func (m *mockSmartScanServicer) QueueBatch(
+	ctx context.Context, f services.BatchFilter,
+) (*services.BatchResult, error) {
+	return m.queueBatchFn(ctx, f)
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func newSmartScanHandler(svc smartScanServicer) *SmartScanHandler {
+	return &SmartScanHandler{service: svc, logger: createTestLogger()}
+}
+
+// routeSmartScan wires the handler into a mux with the same path patterns
+// used in routes.go and returns a recorder for the given request.
+func routeSmartScan(h *SmartScanHandler, method, path string, body []byte) *httptest.ResponseRecorder {
+	r := mux.NewRouter()
+	r.HandleFunc("/api/v1/smart-scan/suggestions", h.GetSuggestions).Methods("GET")
+	r.HandleFunc("/api/v1/smart-scan/hosts/{id}/stage", h.EvaluateHost).Methods("GET")
+	r.HandleFunc("/api/v1/smart-scan/hosts/{id}/trigger", h.TriggerHost).Methods("POST")
+	r.HandleFunc("/api/v1/smart-scan/trigger-batch", h.TriggerBatch).Methods("POST")
+
+	var req *http.Request
+	if body != nil {
+		req = httptest.NewRequest(method, path, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.ContentLength = int64(len(body))
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// ── GetSuggestions ────────────────────────────────────────────────────────────
+
+func TestSmartScan_GetSuggestions_ReturnsNonNegativeCounts(t *testing.T) {
+	svc := &mockSmartScanServicer{
+		getSuggestionsFn: func(_ context.Context) (*services.SuggestionSummary, error) {
+			return &services.SuggestionSummary{
+				NoOSInfo:    services.SuggestionGroup{Count: 3, Action: "os_detection"},
+				NoPorts:     services.SuggestionGroup{Count: 1, Action: "port_expansion"},
+				NoServices:  services.SuggestionGroup{Count: 5, Action: "service_scan"},
+				Stale:       services.SuggestionGroup{Count: 2, Action: "refresh"},
+				WellKnown:   services.SuggestionGroup{Count: 10, Action: "skip"},
+				TotalHosts:  21,
+				GeneratedAt: time.Now(),
+			}, nil
+		},
+	}
+
+	w := routeSmartScan(newSmartScanHandler(svc), "GET", "/api/v1/smart-scan/suggestions", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body services.SuggestionSummary
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+	assert.GreaterOrEqual(t, body.NoOSInfo.Count, 0)
+	assert.GreaterOrEqual(t, body.NoPorts.Count, 0)
+	assert.GreaterOrEqual(t, body.NoServices.Count, 0)
+	assert.GreaterOrEqual(t, body.Stale.Count, 0)
+	assert.GreaterOrEqual(t, body.WellKnown.Count, 0)
+	assert.Equal(t, 21, body.TotalHosts)
+}
+
+func TestSmartScan_GetSuggestions_ServiceError_Returns500(t *testing.T) {
+	svc := &mockSmartScanServicer{
+		getSuggestionsFn: func(_ context.Context) (*services.SuggestionSummary, error) {
+			return nil, apierrors.NewScanError(apierrors.CodeUnknown, "db unavailable")
+		},
+	}
+
+	w := routeSmartScan(newSmartScanHandler(svc), "GET", "/api/v1/smart-scan/suggestions", nil)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ── EvaluateHost (GET /stage) ─────────────────────────────────────────────────
+
+func TestSmartScan_EvaluateHost_ReturnsValidStage(t *testing.T) {
+	hostID := uuid.New()
+	svc := &mockSmartScanServicer{
+		evaluateHostByIDFn: func(_ context.Context, id uuid.UUID) (*services.ScanStage, error) {
+			assert.Equal(t, hostID, id)
+			return &services.ScanStage{
+				Stage:    "os_detection",
+				ScanType: "syn",
+				Ports:    "22,80,443",
+				Reason:   "no OS information",
+			}, nil
+		},
+	}
+
+	w := routeSmartScan(newSmartScanHandler(svc), "GET",
+		"/api/v1/smart-scan/hosts/"+hostID.String()+"/stage", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var stage services.ScanStage
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&stage))
+	assert.NotEmpty(t, stage.Stage)
+	assert.NotEmpty(t, stage.Reason)
+}
+
+func TestSmartScan_EvaluateHost_NotFound_Returns404(t *testing.T) {
+	hostID := uuid.New()
+	svc := &mockSmartScanServicer{
+		evaluateHostByIDFn: func(_ context.Context, _ uuid.UUID) (*services.ScanStage, error) {
+			return nil, apierrors.NewScanError(apierrors.CodeNotFound, "host not found")
+		},
+	}
+
+	w := routeSmartScan(newSmartScanHandler(svc), "GET",
+		"/api/v1/smart-scan/hosts/"+hostID.String()+"/stage", nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestSmartScan_EvaluateHost_InvalidID_Returns400(t *testing.T) {
+	w := routeSmartScan(newSmartScanHandler(&mockSmartScanServicer{}),
+		"GET", "/api/v1/smart-scan/hosts/not-a-uuid/stage", nil)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── TriggerHost ───────────────────────────────────────────────────────────────
+
+func TestSmartScan_TriggerHost_NoOS_Returns202WithScanID(t *testing.T) {
+	hostID := uuid.New()
+	scanID := uuid.New()
+	svc := &mockSmartScanServicer{
+		queueSmartScanFn: func(_ context.Context, id uuid.UUID) (uuid.UUID, error) {
+			assert.Equal(t, hostID, id)
+			return scanID, nil // non-nil scan ID → queued
+		},
+	}
+
+	w := routeSmartScan(newSmartScanHandler(svc), "POST",
+		"/api/v1/smart-scan/hosts/"+hostID.String()+"/trigger", nil)
+	require.Equal(t, http.StatusAccepted, w.Code)
+
+	var resp triggerHostResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Queued)
+	assert.Equal(t, scanID.String(), resp.ScanID)
+}
+
+func TestSmartScan_TriggerHost_WellKnown_Returns200NotQueued(t *testing.T) {
+	hostID := uuid.New()
+	svc := &mockSmartScanServicer{
+		queueSmartScanFn: func(_ context.Context, _ uuid.UUID) (uuid.UUID, error) {
+			return uuid.Nil, nil // nil UUID → no scan needed
+		},
+	}
+
+	w := routeSmartScan(newSmartScanHandler(svc), "POST",
+		"/api/v1/smart-scan/hosts/"+hostID.String()+"/trigger", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp triggerHostResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.False(t, resp.Queued)
+	assert.Empty(t, resp.ScanID)
+}
+
+func TestSmartScan_TriggerHost_QueueFull_Returns429(t *testing.T) {
+	hostID := uuid.New()
+	svc := &mockSmartScanServicer{
+		queueSmartScanFn: func(_ context.Context, _ uuid.UUID) (uuid.UUID, error) {
+			return uuid.Nil, scanning.ErrQueueFull
+		},
+	}
+
+	w := routeSmartScan(newSmartScanHandler(svc), "POST",
+		"/api/v1/smart-scan/hosts/"+hostID.String()+"/trigger", nil)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+}
+
+// ── TriggerBatch ──────────────────────────────────────────────────────────────
+
+func TestSmartScan_TriggerBatch_QueuesUpToLimit(t *testing.T) {
+	svc := &mockSmartScanServicer{
+		queueBatchFn: func(_ context.Context, f services.BatchFilter) (*services.BatchResult, error) {
+			assert.Equal(t, 5, f.Limit)
+			return &services.BatchResult{
+				Queued:  5,
+				Skipped: 2,
+				Details: []services.BatchDetailEntry{},
+			}, nil
+		},
+	}
+
+	body, _ := json.Marshal(map[string]any{"limit": 5})
+	w := routeSmartScan(newSmartScanHandler(svc), "POST", "/api/v1/smart-scan/trigger-batch", body)
+	require.Equal(t, http.StatusAccepted, w.Code)
+
+	var result services.BatchResult
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&result))
+	assert.Equal(t, 5, result.Queued)
+	assert.LessOrEqual(t, result.Queued, 5)
+}
+
+func TestSmartScan_TriggerBatch_InvalidHostID_Returns400(t *testing.T) {
+	body, _ := json.Marshal(map[string]any{"host_ids": []string{"not-a-uuid"}})
+	w := routeSmartScan(newSmartScanHandler(&mockSmartScanServicer{}),
+		"POST", "/api/v1/smart-scan/trigger-batch", body)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSmartScan_TriggerBatch_EmptyBody_UsesDefaults(t *testing.T) {
+	svc := &mockSmartScanServicer{
+		queueBatchFn: func(_ context.Context, f services.BatchFilter) (*services.BatchResult, error) {
+			assert.Equal(t, 0, f.Limit, "empty body should pass limit=0 (service applies default)")
+			assert.Empty(t, f.Stage)
+			return &services.BatchResult{Details: []services.BatchDetailEntry{}}, nil
+		},
+	}
+
+	w := routeSmartScan(newSmartScanHandler(svc), "POST", "/api/v1/smart-scan/trigger-batch", nil)
+	assert.Equal(t, http.StatusAccepted, w.Code)
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -9,6 +9,8 @@ import (
 	_ "github.com/anstrom/scanorama/docs/swagger" // Import generated swagger docs
 	apihandlers "github.com/anstrom/scanorama/internal/api/handlers"
 	"github.com/anstrom/scanorama/internal/db"
+	"github.com/anstrom/scanorama/internal/profiles"
+	"github.com/anstrom/scanorama/internal/scanning"
 	"github.com/anstrom/scanorama/internal/services"
 )
 
@@ -41,6 +43,10 @@ func (s *Server) setupRoutes() {
 	groupHandler := apihandlers.NewGroupHandler(
 		services.NewGroupService(db.NewGroupRepository(s.database), s.logger), s.logger, s.metrics)
 	portHandler := apihandlers.NewPortHandler(db.NewPortRepository(s.database), s.logger, s.metrics)
+	profileManager := profiles.NewManager(s.database)
+	smartScanSvc := services.NewSmartScanService(s.database, profileManager, s.scanQueue, s.logger)
+	scanning.SetPostScanHook(smartScanSvc.ReEvaluateHosts)
+	smartScanHandler := apihandlers.NewSmartScanHandler(smartScanSvc, s.logger)
 	handlerManager := apihandlers.New(s.database, s.logger, s.metrics).
 		WithRingBuffer(s.ringBuffer)
 	if s.scanQueue != nil {
@@ -49,6 +55,7 @@ func (s *Server) setupRoutes() {
 		networkHandler = networkHandler.WithScanQueue(s.scanQueue)
 	}
 
+	s.setupSmartScanRoutes(api, smartScanHandler)
 	s.setupScanRoutes(api, scanHandler)
 	s.setupHostRoutes(api, hostHandler)
 	s.setupTagRoutes(api, hostHandler)
@@ -86,6 +93,14 @@ func (s *Server) setupSystemRoutes(api *mux.Router) {
 	api.HandleFunc("/version", s.versionHandler).Methods("GET")
 	api.HandleFunc("/metrics", s.metricsHandler).Methods("GET")
 	s.router.Handle("/metrics", promhttp.HandlerFor(s.prom.GetRegistry(), promhttp.HandlerOpts{})).Methods("GET")
+}
+
+// setupSmartScanRoutes registers Smart Scan evaluation and trigger endpoints.
+func (s *Server) setupSmartScanRoutes(api *mux.Router, h *apihandlers.SmartScanHandler) {
+	api.HandleFunc("/smart-scan/suggestions", h.GetSuggestions).Methods("GET")
+	api.HandleFunc("/smart-scan/hosts/{id}/stage", h.EvaluateHost).Methods("GET")
+	api.HandleFunc("/smart-scan/hosts/{id}/trigger", h.TriggerHost).Methods("POST")
+	api.HandleFunc("/smart-scan/trigger-batch", h.TriggerBatch).Methods("POST")
 }
 
 // setupScanRoutes registers scan CRUD and action endpoints.

--- a/internal/scanning/scan.go
+++ b/internal/scanning/scan.go
@@ -643,7 +643,13 @@ func storeScanResults(
 		for _, h := range storedHosts {
 			hostIDs = append(hostIDs, h.ID)
 		}
-		go runKnowledgeScoreUpdate(database, hostIDs)
+		// When a PostScanHook is registered it owns knowledge-score
+		// recalculation; otherwise fall back to the built-in updater.
+		if hasPostScanHook() {
+			go callPostScanHook(database, hostIDs)
+		} else {
+			go runKnowledgeScoreUpdate(database, hostIDs)
+		}
 	}
 
 	// Launch banner enrichment in the background — best-effort, non-blocking.

--- a/internal/scanning/smartscan_hook.go
+++ b/internal/scanning/smartscan_hook.go
@@ -1,0 +1,47 @@
+// Package scanning - post-scan hook for Smart Scan re-evaluation.
+package scanning
+
+import (
+	"sync"
+
+	"github.com/anstrom/scanorama/internal/db"
+	"github.com/google/uuid"
+)
+
+// postScanHookFn is the type for post-scan hook callbacks.
+type postScanHookFn func(database *db.DB, hostIDs []uuid.UUID)
+
+var (
+	postScanHookMu   sync.RWMutex
+	postScanHookFunc postScanHookFn
+)
+
+// SetPostScanHook registers a callback to be called after scan results are
+// stored and knowledge scores are queued for recalculation. Call once at
+// application startup. Pass nil to clear.
+func SetPostScanHook(fn postScanHookFn) {
+	postScanHookMu.Lock()
+	postScanHookFunc = fn
+	postScanHookMu.Unlock()
+}
+
+// callPostScanHook invokes the registered hook if one is set.
+// Safe for concurrent use from multiple goroutines.
+func callPostScanHook(database *db.DB, hostIDs []uuid.UUID) {
+	postScanHookMu.RLock()
+	fn := postScanHookFunc
+	postScanHookMu.RUnlock()
+	if fn != nil {
+		fn(database, hostIDs)
+	}
+}
+
+// hasPostScanHook reports whether a hook is currently registered.
+// Used by scan.go to decide whether to fall back to the built-in
+// knowledge-score update goroutine.
+func hasPostScanHook() bool {
+	postScanHookMu.RLock()
+	has := postScanHookFunc != nil
+	postScanHookMu.RUnlock()
+	return has
+}

--- a/internal/services/smartscan.go
+++ b/internal/services/smartscan.go
@@ -1,0 +1,531 @@
+// Package services - Smart Scan orchestration service.
+// Evaluates per-host knowledge gaps and queues the appropriate next scan stage.
+package services
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/anstrom/scanorama/internal/db"
+	"github.com/anstrom/scanorama/internal/profiles"
+	"github.com/anstrom/scanorama/internal/scanning"
+)
+
+// smartScanQueryTimeout caps suggestion-aggregation queries.
+const smartScanQueryTimeout = 5 * time.Second
+
+// staleThreshold is how old last_seen must be before a host is considered stale.
+const staleThreshold = 30 * 24 * time.Hour
+
+// hostHasServicesQueryTimeout caps per-host existence-check queries.
+const hostHasServicesQueryTimeout = 3 * time.Second
+
+// maxBatchHostsQuery is the maximum number of hosts fetched in a batch resolve.
+const maxBatchHostsQuery = 500
+
+// ScanStage describes what the Smart Scan orchestrator recommends doing next
+// for a specific host.
+type ScanStage struct {
+	Stage       string  `json:"stage"`                // os_detection, port_expansion, service_scan, refresh, skip
+	ScanType    string  `json:"scan_type"`            // nmap scan type to use
+	Ports       string  `json:"ports"`                // port specification
+	OSDetection bool    `json:"os_detection"`         // whether to enable OS fingerprinting
+	ProfileID   *string `json:"profile_id,omitempty"` // profile to attribute the scan to (may be nil)
+	Reason      string  `json:"reason"`               // human-readable explanation
+}
+
+// SuggestionGroup aggregates hosts that share the same knowledge gap.
+type SuggestionGroup struct {
+	Count       int    `json:"count"`
+	Description string `json:"description"`
+	Action      string `json:"action"` // matches ScanStage.Stage
+}
+
+// SuggestionSummary holds fleet-wide gap counts for the dashboard widget.
+type SuggestionSummary struct {
+	NoOSInfo    SuggestionGroup `json:"no_os_info"`
+	NoPorts     SuggestionGroup `json:"no_ports"`
+	NoServices  SuggestionGroup `json:"no_services"`
+	Stale       SuggestionGroup `json:"stale"`
+	WellKnown   SuggestionGroup `json:"well_known"`
+	TotalHosts  int             `json:"total_hosts"`
+	GeneratedAt time.Time       `json:"generated_at"`
+}
+
+// BatchFilter constrains which hosts to include in a batch smart-scan trigger.
+type BatchFilter struct {
+	Stage   string      // empty = all eligible stages; otherwise one of ScanStage.Stage values
+	HostIDs []uuid.UUID // non-empty = only these hosts; empty = all hosts
+	Limit   int         // max hosts to queue; 0 = use defaultBatchLimit
+}
+
+// BatchResult summarizes the outcome of a QueueBatch call.
+type BatchResult struct {
+	Queued  int                `json:"queued"`
+	Skipped int                `json:"skipped"`
+	Details []BatchDetailEntry `json:"details"`
+}
+
+// BatchDetailEntry records what happened for a single host in a batch.
+type BatchDetailEntry struct {
+	HostID string `json:"host_id"`
+	Stage  string `json:"stage"`
+	ScanID string `json:"scan_id,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+const defaultBatchLimit = 50
+
+// smartHostRepository is the subset of db.HostRepository used by SmartScanService.
+type smartHostRepository interface {
+	GetHost(ctx context.Context, id uuid.UUID) (*db.Host, error)
+	ListHosts(ctx context.Context, filters *db.HostFilters, offset, limit int) ([]*db.Host, int64, error)
+	RecalculateKnowledgeScore(ctx context.Context, hostID uuid.UUID) error
+}
+
+// SmartScanService evaluates host knowledge gaps and queues targeted scans.
+type SmartScanService struct {
+	database       *db.DB
+	hostRepo       smartHostRepository
+	profileManager *profiles.Manager
+	scanRepo       scanRepository
+	scanQueue      *scanning.ScanQueue
+	logger         *slog.Logger
+
+	// hasOpenPortsFn and hasServicesFn are called by EvaluateHost to check
+	// live host state. Replaced in tests to avoid a real database dependency.
+	hasOpenPortsFn func(ctx context.Context, hostID uuid.UUID) (bool, error)
+	hasServicesFn  func(ctx context.Context, hostID uuid.UUID) (bool, error)
+}
+
+// NewSmartScanService creates a new SmartScanService.
+func NewSmartScanService(
+	database *db.DB,
+	profileManager *profiles.Manager,
+	scanQueue *scanning.ScanQueue,
+	logger *slog.Logger,
+) *SmartScanService {
+	svc := &SmartScanService{
+		database:       database,
+		hostRepo:       db.NewHostRepository(database),
+		profileManager: profileManager,
+		scanRepo:       db.NewScanRepository(database),
+		scanQueue:      scanQueue,
+		logger:         logger.With("service", "smart_scan"),
+	}
+	svc.hasOpenPortsFn = svc.queryHasOpenPorts
+	svc.hasServicesFn = svc.queryHasServices
+	return svc
+}
+
+// GetSuggestions aggregates host gap counts fleet-wide. Results are computed
+// on-demand from the existing hosts table — no separate suggestions table needed.
+func (s *SmartScanService) GetSuggestions(ctx context.Context) (*SuggestionSummary, error) {
+	ctx, cancel := context.WithTimeout(ctx, smartScanQueryTimeout)
+	defer cancel()
+
+	staleTime := time.Now().Add(-staleThreshold)
+
+	row := s.database.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*) FILTER (WHERE status = 'up' AND (os_family IS NULL OR os_family = ''))           AS no_os_info,
+			COUNT(*) FILTER (WHERE os_family IS NOT NULL AND os_family != ''
+			                   AND NOT EXISTS (
+			                       SELECT 1 FROM port_scans ps
+			                       WHERE ps.host_id = h.id AND ps.state = 'open'))                    AS no_ports,
+			COUNT(*) FILTER (WHERE EXISTS (
+			                       SELECT 1 FROM port_scans ps
+			                       WHERE ps.host_id = h.id AND ps.state = 'open')
+			                   AND NOT EXISTS (
+			                       SELECT 1 FROM port_banners pb
+			                       WHERE pb.host_id = h.id
+			                         AND pb.service IS NOT NULL
+			                         AND pb.service != ''))                               AS no_services,
+			COUNT(*) FILTER (WHERE last_seen < $1 AND status <> 'gone')                              AS stale,
+			COUNT(*) FILTER (WHERE knowledge_score >= 80)                                            AS well_known,
+			COUNT(*)                                                                                  AS total
+		FROM hosts h
+	`, staleTime)
+
+	var noOS, noPorts, noServices, stale, wellKnown, total int
+	if err := row.Scan(&noOS, &noPorts, &noServices, &stale, &wellKnown, &total); err != nil {
+		return nil, fmt.Errorf("failed to query suggestion counts: %w", err)
+	}
+
+	return &SuggestionSummary{
+		NoOSInfo: SuggestionGroup{
+			Count:       noOS,
+			Description: "Hosts with no OS detection",
+			Action:      "os_detection",
+		},
+		NoPorts: SuggestionGroup{
+			Count:       noPorts,
+			Description: "Hosts with OS known but no open ports found",
+			Action:      "port_expansion",
+		},
+		NoServices: SuggestionGroup{
+			Count:       noServices,
+			Description: "Hosts with open ports but no service identification",
+			Action:      "service_scan",
+		},
+		Stale: SuggestionGroup{
+			Count:       stale,
+			Description: "Hosts not scanned in the last 30 days",
+			Action:      "refresh",
+		},
+		WellKnown: SuggestionGroup{
+			Count:       wellKnown,
+			Description: "Hosts with comprehensive knowledge (score ≥ 80)",
+			Action:      "skip",
+		},
+		TotalHosts:  total,
+		GeneratedAt: time.Now(),
+	}, nil
+}
+
+// EvaluateHostByID is a convenience wrapper that loads the host then calls EvaluateHost.
+func (s *SmartScanService) EvaluateHostByID(ctx context.Context, hostID uuid.UUID) (*ScanStage, error) {
+	host, err := s.hostRepo.GetHost(ctx, hostID)
+	if err != nil {
+		return nil, err
+	}
+	return s.EvaluateHost(ctx, host)
+}
+
+// EvaluateHost determines the next recommended scan stage for a single host.
+// Returns a ScanStage with Stage == "skip" when no action is recommended.
+func (s *SmartScanService) EvaluateHost(ctx context.Context, host *db.Host) (*ScanStage, error) {
+	// Hosts that are gone or explicitly excluded from scanning are always skipped.
+	if host.Status == "gone" || host.IgnoreScanning {
+		return &ScanStage{Stage: "skip", Reason: "host is gone or excluded from scanning"}, nil
+	}
+
+	hasOS := host.OSFamily != nil && *host.OSFamily != ""
+
+	hasOpenPorts, err := s.hasOpenPortsFn(ctx, host.ID)
+	if err != nil {
+		s.logger.Warn("Failed to check open ports", "host_id", host.ID, "error", err)
+		hasOpenPorts = false
+	}
+
+	hasServices, err := s.hasServicesFn(ctx, host.ID)
+	if err != nil {
+		s.logger.Warn("Failed to check service data", "host_id", host.ID, "error", err)
+		hasServices = false
+	}
+
+	isStale := time.Since(host.LastSeen) > staleThreshold
+
+	switch {
+	case !hasOS && host.Status == "up":
+		return s.stageOSDetection(), nil
+	case hasOS && !hasOpenPorts:
+		return s.stageWithProfile(ctx, host, "port_expansion"), nil
+	case hasOpenPorts && !hasServices:
+		return s.stageWithProfile(ctx, host, "service_scan"), nil
+	case isStale:
+		return &ScanStage{
+			Stage:    "refresh",
+			ScanType: "connect",
+			Ports:    "1-1024",
+			Reason:   fmt.Sprintf("last seen %s ago — refreshing scan", time.Since(host.LastSeen).Round(time.Hour)),
+		}, nil
+	default:
+		return &ScanStage{Stage: "skip", Reason: "host knowledge is sufficient"}, nil
+	}
+}
+
+// stageOSDetection returns a ScanStage configured for OS fingerprinting.
+// SYN scan is required because OS detection needs raw socket access (-O flag).
+func (s *SmartScanService) stageOSDetection() *ScanStage {
+	return &ScanStage{
+		Stage:       "os_detection",
+		ScanType:    "syn",
+		Ports:       "22,80,135,443,445,3389",
+		OSDetection: true,
+		Reason:      "no OS information — running OS fingerprint scan",
+	}
+}
+
+// stageWithProfile returns a ScanStage using the best matching profile,
+// falling back to a generic 1-1024 connect scan if none is found.
+func (s *SmartScanService) stageWithProfile(ctx context.Context, host *db.Host, stage string) *ScanStage {
+	fallbackReason := map[string]string{
+		"port_expansion": "OS known but no ports found — generic port scan",
+		"service_scan":   "open ports found but no service banners — generic service scan",
+	}
+	profileReason := map[string]string{
+		"port_expansion": fmt.Sprintf("OS known (%s) but no ports found — using profile", safeStr(host.OSFamily)),
+		"service_scan":   "open ports found but no service banners — service scan",
+	}
+
+	if s.profileManager != nil {
+		profile, err := s.profileManager.SelectBestProfile(ctx, host)
+		if err == nil && profile != nil {
+			profileID := profile.ID
+			return &ScanStage{
+				Stage:     stage,
+				ScanType:  profile.ScanType,
+				Ports:     profile.Ports,
+				ProfileID: &profileID,
+				Reason:    fmt.Sprintf("%s %q", profileReason[stage], profile.Name),
+			}
+		}
+	}
+	return &ScanStage{
+		Stage:    stage,
+		ScanType: "connect",
+		Ports:    "1-1024",
+		Reason:   fallbackReason[stage],
+	}
+}
+
+func safeStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// QueueSmartScan evaluates a single host and queues the recommended scan.
+// Returns the created scan UUID and an error. If the stage is "skip" a nil
+// UUID is returned with no error.
+func (s *SmartScanService) QueueSmartScan(ctx context.Context, hostID uuid.UUID) (uuid.UUID, error) {
+	host, err := s.hostRepo.GetHost(ctx, hostID)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("failed to load host: %w", err)
+	}
+
+	stage, err := s.EvaluateHost(ctx, host)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("failed to evaluate host: %w", err)
+	}
+	if stage.Stage == "skip" {
+		return uuid.Nil, nil
+	}
+
+	return s.createAndQueueScan(ctx, host, stage)
+}
+
+// QueueBatch queues smart scans for all eligible hosts matching the filter.
+func (s *SmartScanService) QueueBatch(ctx context.Context, filter BatchFilter) (*BatchResult, error) {
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = defaultBatchLimit
+	}
+
+	hosts, err := s.resolveHosts(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &BatchResult{Details: []BatchDetailEntry{}}
+
+	for _, host := range hosts {
+		if result.Queued >= limit {
+			break
+		}
+
+		stage, err := s.EvaluateHost(ctx, host)
+		if err != nil {
+			s.logger.Warn("Failed to evaluate host for batch smart scan",
+				"host_id", host.ID, "error", err)
+			result.Skipped++
+			continue
+		}
+		if stage.Stage == "skip" {
+			result.Skipped++
+			continue
+		}
+		if filter.Stage != "" && stage.Stage != filter.Stage {
+			result.Skipped++
+			continue
+		}
+
+		scanID, err := s.createAndQueueScan(ctx, host, stage)
+		if err != nil {
+			s.logger.Warn("Failed to queue smart scan for host",
+				"host_id", host.ID, "error", err)
+			result.Skipped++
+			result.Details = append(result.Details, BatchDetailEntry{
+				HostID: host.ID.String(),
+				Stage:  stage.Stage,
+				Reason: err.Error(),
+			})
+			continue
+		}
+
+		result.Queued++
+		result.Details = append(result.Details, BatchDetailEntry{
+			HostID: host.ID.String(),
+			Stage:  stage.Stage,
+			ScanID: scanID.String(),
+		})
+	}
+
+	return result, nil
+}
+
+// ReEvaluateHosts is the PostScanHook callback. It recalculates knowledge
+// scores for the given hosts, then evaluates their next scan stage and logs
+// the recommendation. It does not auto-queue further scans.
+func (s *SmartScanService) ReEvaluateHosts(_ *db.DB, hostIDs []uuid.UUID) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	for _, id := range hostIDs {
+		if err := s.hostRepo.RecalculateKnowledgeScore(ctx, id); err != nil {
+			s.logger.Warn("Post-scan knowledge score update failed", "host_id", id, "error", err)
+		}
+		host, err := s.hostRepo.GetHost(ctx, id)
+		if err != nil {
+			continue
+		}
+		stage, err := s.EvaluateHost(ctx, host)
+		if err != nil {
+			continue
+		}
+		s.logger.Debug("Post-scan stage evaluation", "host_id", id, "stage", stage.Stage, "reason", stage.Reason)
+	}
+}
+
+// ── internal helpers ──────────────────────────────────────────────────────────
+
+// queryHasOpenPorts returns true if the host has at least one open port in port_scans.
+func (s *SmartScanService) queryHasOpenPorts(ctx context.Context, hostID uuid.UUID) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, hostHasServicesQueryTimeout)
+	defer cancel()
+
+	var exists bool
+	err := s.database.QueryRowContext(ctx,
+		`SELECT EXISTS(
+			SELECT 1 FROM port_scans
+			WHERE host_id = $1 AND state = 'open'
+		)`, hostID,
+	).Scan(&exists)
+	return exists, err
+}
+
+// queryHasServices returns true if the host has at least one port_banners row
+// with a non-empty service name.
+func (s *SmartScanService) queryHasServices(ctx context.Context, hostID uuid.UUID) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, hostHasServicesQueryTimeout)
+	defer cancel()
+
+	var exists bool
+	err := s.database.QueryRowContext(ctx,
+		`SELECT EXISTS(
+			SELECT 1 FROM port_banners
+			WHERE host_id = $1 AND service IS NOT NULL AND service != ''
+		)`, hostID,
+	).Scan(&exists)
+	return exists, err
+}
+
+// resolveHosts returns the list of active hosts for a batch operation.
+// When filter.HostIDs is non-empty only those hosts are returned; otherwise
+// all up hosts are returned, capped at maxBatchHostsQuery.
+func (s *SmartScanService) resolveHosts(ctx context.Context, filter BatchFilter) ([]*db.Host, error) {
+	if len(filter.HostIDs) > 0 {
+		hosts := make([]*db.Host, 0, len(filter.HostIDs))
+		for _, id := range filter.HostIDs {
+			h, err := s.hostRepo.GetHost(ctx, id)
+			if err != nil {
+				s.logger.Warn("Host not found in batch", "host_id", id)
+				continue
+			}
+			hosts = append(hosts, h)
+		}
+		return hosts, nil
+	}
+
+	// Fetch only up hosts to avoid wasting the query budget on gone/ignored entries.
+	hosts, _, err := s.hostRepo.ListHosts(ctx, &db.HostFilters{Status: "up"}, 0, maxBatchHostsQuery)
+	return hosts, err
+}
+
+// createAndQueueScan builds a scan record from the stage recommendation and
+// submits it to the queue. Returns the new scan UUID.
+func (s *SmartScanService) createAndQueueScan(ctx context.Context, host *db.Host, stage *ScanStage) (uuid.UUID, error) {
+	ip := host.IPAddress.String()
+	scanName := fmt.Sprintf("Smart Scan: %s [%s]", ip, stage.Stage)
+
+	input := db.CreateScanInput{
+		Name:        scanName,
+		Targets:     []string{ip},
+		ScanType:    stage.ScanType,
+		Ports:       stage.Ports,
+		OSDetection: stage.OSDetection,
+		ProfileID:   stage.ProfileID,
+	}
+
+	scan, err := s.scanRepo.CreateScan(ctx, input)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("failed to create smart scan record: %w", err)
+	}
+
+	if err := s.scanRepo.StartScan(ctx, scan.ID); err != nil {
+		return uuid.Nil, fmt.Errorf("failed to start smart scan: %w", err)
+	}
+
+	scanID := scan.ID
+	scanConfig := &scanning.ScanConfig{
+		Targets:     scan.Targets,
+		Ports:       scan.Ports,
+		ScanType:    scan.ScanType,
+		TimeoutSec:  scanning.CalculateTimeout(scan.Ports, len(scan.Targets), scan.ScanType),
+		OSDetection: stage.OSDetection,
+		ScanID:      &scanID,
+	}
+
+	repo := s.scanRepo
+	logger := s.logger
+	database := s.database
+
+	job := scanning.NewScanJob(
+		scan.ID.String(),
+		scanConfig,
+		database,
+		scanning.ScanJobExecutor(scanning.RunScanWithContext),
+		func(_ *scanning.ScanResult, err error) {
+			bgCtx := context.Background()
+			if err != nil {
+				logger.Error("Smart scan execution failed", "scan_id", scanID, "error", err)
+				if stopErr := repo.StopScan(bgCtx, scanID, err.Error()); stopErr != nil {
+					logger.Error("Failed to mark smart scan as stopped", "scan_id", scanID, "error", stopErr)
+				}
+			} else {
+				logger.Info("Smart scan completed", "scan_id", scanID)
+				if completeErr := repo.CompleteScan(bgCtx, scanID); completeErr != nil {
+					logger.Error("Failed to mark smart scan as completed", "scan_id", scanID, "error", completeErr)
+				}
+			}
+		},
+	)
+
+	if s.scanQueue != nil {
+		if err := s.scanQueue.Submit(job); err != nil {
+			// Revert scan to stopped state — use a background context because the
+			// caller's context may already be cancelled at this point.
+			bgCtx := context.Background()
+			_ = s.scanRepo.StopScan(bgCtx, scan.ID, err.Error())
+			return uuid.Nil, fmt.Errorf("queue rejected smart scan: %w", err)
+		}
+	} else {
+		go func() {
+			bgCtx := context.Background()
+			if _, execErr := scanning.RunScanWithContext(bgCtx, scanConfig, database); execErr != nil {
+				logger.Error("Async smart scan failed", "scan_id", scanID, "error", execErr)
+				_ = repo.StopScan(bgCtx, scanID, execErr.Error())
+			} else {
+				_ = repo.CompleteScan(bgCtx, scanID)
+			}
+		}()
+	}
+
+	return scan.ID, nil
+}

--- a/internal/services/smartscan_test.go
+++ b/internal/services/smartscan_test.go
@@ -1,0 +1,345 @@
+// Package services - unit tests for SmartScanService.
+package services
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+}
+
+// ── mock implementations ──────────────────────────────────────────────────────
+
+type mockSmartHostRepo struct {
+	getHostFn   func(ctx context.Context, id uuid.UUID) (*db.Host, error)
+	listHostsFn func(ctx context.Context, filters *db.HostFilters, offset, limit int) ([]*db.Host, int64, error)
+}
+
+func (m *mockSmartHostRepo) GetHost(ctx context.Context, id uuid.UUID) (*db.Host, error) {
+	if m.getHostFn != nil {
+		return m.getHostFn(ctx, id)
+	}
+	return nil, errors.New("mockSmartHostRepo: GetHost not configured")
+}
+
+func (m *mockSmartHostRepo) ListHosts(
+	ctx context.Context, f *db.HostFilters, offset, limit int,
+) ([]*db.Host, int64, error) {
+	if m.listHostsFn != nil {
+		return m.listHostsFn(ctx, f, offset, limit)
+	}
+	return nil, 0, errors.New("mockSmartHostRepo: ListHosts not configured")
+}
+
+func (m *mockSmartHostRepo) RecalculateKnowledgeScore(_ context.Context, _ uuid.UUID) error {
+	return nil
+}
+
+type mockSmartScanRepo struct {
+	createScanFn func(ctx context.Context, input db.CreateScanInput) (*db.Scan, error)
+	startScanFn  func(ctx context.Context, id uuid.UUID) error
+	stopScanFn   func(ctx context.Context, id uuid.UUID, msg ...string) error
+}
+
+func (m *mockSmartScanRepo) CreateScan(ctx context.Context, input db.CreateScanInput) (*db.Scan, error) {
+	if m.createScanFn != nil {
+		return m.createScanFn(ctx, input)
+	}
+	return nil, errors.New("mockSmartScanRepo: CreateScan not configured")
+}
+
+func (m *mockSmartScanRepo) StartScan(ctx context.Context, id uuid.UUID) error {
+	if m.startScanFn != nil {
+		return m.startScanFn(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockSmartScanRepo) StopScan(ctx context.Context, id uuid.UUID, msg ...string) error {
+	if m.stopScanFn != nil {
+		return m.stopScanFn(ctx, id, msg...)
+	}
+	return nil
+}
+
+func (m *mockSmartScanRepo) CompleteScan(_ context.Context, _ uuid.UUID) error { return nil }
+func (m *mockSmartScanRepo) DeleteScan(_ context.Context, _ uuid.UUID) error   { return nil }
+func (m *mockSmartScanRepo) ListScans(_ context.Context, _ db.ScanFilters, _, _ int) ([]*db.Scan, int64, error) {
+	return nil, 0, nil
+}
+func (m *mockSmartScanRepo) GetScan(_ context.Context, _ uuid.UUID) (*db.Scan, error) {
+	return nil, nil
+}
+func (m *mockSmartScanRepo) UpdateScan(_ context.Context, _ uuid.UUID, _ db.UpdateScanInput) (*db.Scan, error) {
+	return nil, nil
+}
+func (m *mockSmartScanRepo) GetScanResults(_ context.Context, _ uuid.UUID, _, _ int) ([]*db.ScanResult, int64, error) {
+	return nil, 0, nil
+}
+func (m *mockSmartScanRepo) GetScanSummary(_ context.Context, _ uuid.UUID) (*db.ScanSummary, error) {
+	return nil, nil
+}
+func (m *mockSmartScanRepo) GetProfile(_ context.Context, _ string) (*db.ScanProfile, error) {
+	return nil, nil
+}
+
+// ── test helpers ──────────────────────────────────────────────────────────────
+
+// newTestService creates a SmartScanService with injected has-open-ports and
+// has-services functions so tests never touch a real database.
+func newTestService(hasOpenPorts, hasServices bool) *SmartScanService {
+	svc := &SmartScanService{
+		profileManager: nil,
+		logger:         discardLogger(),
+	}
+	svc.hasOpenPortsFn = func(_ context.Context, _ uuid.UUID) (bool, error) {
+		return hasOpenPorts, nil
+	}
+	svc.hasServicesFn = func(_ context.Context, _ uuid.UUID) (bool, error) {
+		return hasServices, nil
+	}
+	return svc
+}
+
+func strPtr(s string) *string { return &s }
+
+func mustParseIP(s string) db.IPAddr {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		panic("invalid IP: " + s)
+	}
+	return db.IPAddr{IP: ip}
+}
+
+// hostUp returns a minimal up host seen recently (not stale).
+func hostUp(ip string) *db.Host {
+	return &db.Host{
+		ID:        uuid.New(),
+		IPAddress: mustParseIP(ip),
+		Status:    "up",
+		LastSeen:  time.Now(),
+	}
+}
+
+// hostStale returns an up host whose last_seen is beyond the stale threshold.
+func hostStale(ip string) *db.Host {
+	h := hostUp(ip)
+	h.LastSeen = time.Now().Add(-40 * 24 * time.Hour)
+	return h
+}
+
+// ── EvaluateHost: skip conditions ────────────────────────────────────────────
+
+func TestEvaluateHost_SkipsGoneHost(t *testing.T) {
+	svc := newTestService(false, false)
+	host := hostUp("10.0.0.1")
+	host.Status = "gone"
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, "skip", stage.Stage)
+}
+
+func TestEvaluateHost_SkipsIgnoredHost(t *testing.T) {
+	svc := newTestService(false, false)
+	host := hostUp("10.0.0.1")
+	host.IgnoreScanning = true
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, "skip", stage.Stage)
+}
+
+// ── EvaluateHost: OS detection ────────────────────────────────────────────────
+
+func TestEvaluateHost_OSDetectionWhenNoOSAndUp(t *testing.T) {
+	svc := newTestService(false, false)
+	host := hostUp("10.0.0.2")
+	// OSFamily is nil — no OS known
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, "os_detection", stage.Stage)
+	assert.True(t, stage.OSDetection, "OS detection flag must be set")
+	assert.Equal(t, "syn", stage.ScanType, "OS detection requires SYN scan for raw-socket access")
+	assert.NotEmpty(t, stage.Ports)
+}
+
+func TestEvaluateHost_NoOSOnDownHostSkips(t *testing.T) {
+	svc := newTestService(false, false)
+	host := hostUp("10.0.0.3")
+	host.Status = "down"
+	// No OS, but host is down — os_detection case requires status=="up".
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, "skip", stage.Stage)
+}
+
+// ── EvaluateHost: port expansion ─────────────────────────────────────────────
+
+func TestEvaluateHost_PortExpansionWhenOSKnownButNoPorts(t *testing.T) {
+	svc := newTestService(false /*hasOpenPorts*/, false)
+	host := hostUp("10.0.0.4")
+	host.OSFamily = strPtr("linux")
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, "port_expansion", stage.Stage)
+	assert.NotEmpty(t, stage.Ports)
+}
+
+// ── EvaluateHost: service scan ────────────────────────────────────────────────
+
+func TestEvaluateHost_ServiceScanWhenPortsButNoServices(t *testing.T) {
+	svc := newTestService(true /*hasOpenPorts*/, false /*hasServices*/)
+	host := hostUp("10.0.0.5")
+	host.OSFamily = strPtr("linux")
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, "service_scan", stage.Stage)
+	assert.NotEmpty(t, stage.Ports)
+}
+
+// ── EvaluateHost: stale refresh ───────────────────────────────────────────────
+
+func TestEvaluateHost_RefreshWhenStale(t *testing.T) {
+	// A host with complete knowledge (OS + open ports + services) but last seen
+	// over 30 days ago should be refreshed, not skipped.
+	svc := newTestService(true /*hasOpenPorts*/, true /*hasServices*/)
+	host := hostStale("10.0.0.6")
+	host.OSFamily = strPtr("linux")
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, "refresh", stage.Stage)
+}
+
+func TestEvaluateHost_NotStaleWhenRecentlySeen(t *testing.T) {
+	svc := newTestService(true /*hasOpenPorts*/, true /*hasServices*/)
+	host := hostUp("10.0.0.6")
+	host.OSFamily = strPtr("linux")
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, "skip", stage.Stage)
+}
+
+// ── EvaluateHost: skip when complete ─────────────────────────────────────────
+
+func TestEvaluateHost_SkipWhenComplete(t *testing.T) {
+	svc := newTestService(true /*hasOpenPorts*/, true /*hasServices*/)
+	host := hostUp("10.0.0.7")
+	host.OSFamily = strPtr("linux")
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, "skip", stage.Stage)
+}
+
+// ── EvaluateHost: DB error tolerance ─────────────────────────────────────────
+
+func TestEvaluateHost_FallsBackOnOpenPortsError(t *testing.T) {
+	// If the open-ports query fails, hasOpenPorts is treated as false.
+	// A host with OS but a failing ports query should route to port_expansion.
+	svc := &SmartScanService{
+		logger: discardLogger(),
+		hasOpenPortsFn: func(_ context.Context, _ uuid.UUID) (bool, error) {
+			return false, errors.New("db error")
+		},
+		hasServicesFn: func(_ context.Context, _ uuid.UUID) (bool, error) {
+			return false, nil
+		},
+	}
+	host := hostUp("10.0.0.8")
+	host.OSFamily = strPtr("linux")
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, "port_expansion", stage.Stage)
+}
+
+// ── QueueBatch ────────────────────────────────────────────────────────────────
+
+func TestQueueBatch_RespectsLimit(t *testing.T) {
+	createCalls := 0
+	scanRepo := &mockSmartScanRepo{
+		createScanFn: func(_ context.Context, _ db.CreateScanInput) (*db.Scan, error) {
+			createCalls++
+			return &db.Scan{ID: uuid.New()}, nil
+		},
+	}
+
+	// 10 hosts, all needing os_detection (no OS, no ports).
+	hosts := make([]*db.Host, 10)
+	for i := range hosts {
+		hosts[i] = hostUp(fmt.Sprintf("10.0.0.%d", i+1))
+	}
+	hostRepo := &mockSmartHostRepo{
+		listHostsFn: func(_ context.Context, _ *db.HostFilters, _, _ int) ([]*db.Host, int64, error) {
+			return hosts, int64(len(hosts)), nil
+		},
+	}
+
+	svc := &SmartScanService{
+		hostRepo:       hostRepo,
+		scanRepo:       scanRepo,
+		logger:         discardLogger(),
+		hasOpenPortsFn: func(_ context.Context, _ uuid.UUID) (bool, error) { return false, nil },
+		hasServicesFn:  func(_ context.Context, _ uuid.UUID) (bool, error) { return false, nil },
+	}
+
+	result, err := svc.QueueBatch(context.Background(), BatchFilter{Limit: 3})
+	require.NoError(t, err)
+	assert.Equal(t, 3, result.Queued, "should stop queuing after limit")
+	assert.Equal(t, 3, createCalls, "CreateScan should not be called beyond the limit")
+}
+
+func TestQueueBatch_StageFilter(t *testing.T) {
+	scanRepo := &mockSmartScanRepo{
+		createScanFn: func(_ context.Context, _ db.CreateScanInput) (*db.Scan, error) {
+			return &db.Scan{ID: uuid.New()}, nil
+		},
+	}
+
+	// Two hosts: one needing os_detection, one needing port_expansion.
+	noOSHost := hostUp("10.0.0.1")
+	hasOSHost := hostUp("10.0.0.2")
+	hasOSHost.OSFamily = strPtr("linux")
+
+	hostRepo := &mockSmartHostRepo{
+		listHostsFn: func(_ context.Context, _ *db.HostFilters, _, _ int) ([]*db.Host, int64, error) {
+			return []*db.Host{noOSHost, hasOSHost}, 2, nil
+		},
+	}
+
+	svc := &SmartScanService{
+		hostRepo:       hostRepo,
+		scanRepo:       scanRepo,
+		logger:         discardLogger(),
+		hasOpenPortsFn: func(_ context.Context, _ uuid.UUID) (bool, error) { return false, nil },
+		hasServicesFn:  func(_ context.Context, _ uuid.UUID) (bool, error) { return false, nil },
+	}
+
+	result, err := svc.QueueBatch(context.Background(), BatchFilter{Stage: "port_expansion", Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Queued, "only the host needing port_expansion should be queued")
+	assert.Equal(t, 1, result.Skipped, "the os_detection host should be skipped by stage filter")
+	require.Len(t, result.Details, 1)
+	assert.Equal(t, "port_expansion", result.Details[0].Stage)
+}


### PR DESCRIPTION
## Summary

- Adds \`SmartScanService\` that evaluates per-host knowledge gaps and selects the appropriate next scan stage (os_detection → port_expansion → service_scan → refresh → skip)
- Profile manager selects OS-aware profiles for port expansion and service scans; falls back to generic 1–1024 connect scan when no profile matches
- \`GetSuggestions\` aggregates fleet-wide gap counts in a single SQL query — no new table, computed on-demand from \`hosts\`, \`port_scans\`, and \`port_banners\`
- \`SetPostScanHook\` in the \`scanning\` package (mutex-protected) triggers host re-evaluation after each scan without a circular import; falls back to the built-in knowledge-score updater when not wired
- \`SmartScanService\` exposes \`hasOpenPortsFn\`/\`hasServicesFn\` seams so all decision logic is unit-testable without a live database
- Handler tests cover all 4 endpoints including happy path, not-found, queue-full (429), and invalid input; service tests cover all \`EvaluateHost\` branches, DB-error fallback, and \`QueueBatch\` limit/stage-filter behaviour
- \`ScanStage\` response fields serialise as snake_case (\`stage\`, \`scan_type\`, \`os_detection\`, \`profile_id\`, \`reason\`) to match the API convention
- Swagger spec regenerated: all 4 endpoints and their request/response types are now visible in Swagger UI and the generated TypeScript client
- \`EvaluateHost\` handler test decodes the response into \`map[string]interface{}\` and asserts on exact JSON key names, so missing json struct tags on any response type will fail the test
- CI drift check added: \`Generate Documentation\` job now fails if \`make docs\` produces changes not committed to the branch

## New endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | \`/api/v1/smart-scan/suggestions\` | Fleet-wide gap counts for dashboard widget |
| GET | \`/api/v1/smart-scan/hosts/{id}/stage\` | Recommended next scan stage for one host |
| POST | \`/api/v1/smart-scan/hosts/{id}/trigger\` | Queue a smart scan for one host |
| POST | \`/api/v1/smart-scan/trigger-batch\` | Bulk queue by stage and/or host list |

## Test plan

- [ ] \`GET /api/v1/smart-scan/suggestions\` returns 200 with counts for each gap category and a non-zero \`total_hosts\`
- [ ] \`GET /api/v1/smart-scan/hosts/{id}/stage\` returns snake_case JSON (\`stage\`, \`scan_type\`, \`os_detection\`) for a known host
- [ ] \`GET /api/v1/smart-scan/hosts/{id}/stage\` returns 404 for a non-existent UUID
- [ ] \`POST /api/v1/smart-scan/hosts/{id}/trigger\` returns 202 with a \`scan_id\` for a host that needs scanning
- [ ] \`POST /api/v1/smart-scan/trigger-batch\` with \`{"stage":"os_detection","limit":2}\` queues exactly 2 hosts
- [ ] Swagger UI at \`/swagger/index.html\` shows the four smart-scan endpoints with correct request/response schemas

Closes #659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)