### PR TITLE
feat(scans): accept hostname/FQDN as scan targets

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: review-pr
+description: Run the full agent team review on a PR or current branch. Spawns code-quality-reviewer and integration-tester in parallel, then pr-quality-reviewer to consolidate.
+---
+
+Run the full agent team review on $ARGUMENTS.
+
+## Setup
+
+1. If `$ARGUMENTS` is empty or `--branch`, treat the **current branch** as the target. Resolve the PR number with `gh pr view --json number -q .number 2>/dev/null` (may not exist yet — that's OK, just review the local diff).
+2. If `$ARGUMENTS` looks like a number, treat it as the PR number. Run `gh pr checkout $ARGUMENTS` if you're not already on that branch.
+3. Identify the changed files and the base branch with `git diff --stat origin/main...HEAD` (or whatever the PR's base branch is).
+4. Identify the PR title, description, and current CI status if a PR exists: `gh pr view <num> --json title,body,statusCheckRollup`.
+5. Briefly summarize the scope to the user: branch, base, file count, lines changed, PR number (if any).
+
+## Pre-flight: swagger drift + test coverage audit (do this before Phase A)
+
+Before launching agents, run `git diff --stat origin/main...HEAD` to get the file list, then:
+
+### Swagger drift check
+Run `make docs` and then `git diff --exit-code docs/swagger/ frontend/src/api/types.ts`.
+- If the diff is non-empty: **blocker** — the swagger spec is out of sync. List the files that changed and instruct the author to commit the updated output.
+- This check is mandatory even if no handler files changed (swagger_docs.go may reference types from other packages).
+
+### Test coverage audit
+Read the PR test plan and the diff, then answer these questions:
+
+1. **Test plan vs. automation**: For each item in the PR test plan, decide whether it describes behaviour that *should* have a unit test or integration test (e.g. "endpoint X returns Y", "function Z handles edge case W"). If yes and no corresponding test exists in the diff, list it as a coverage gap — this is a blocker.
+2. **New code coverage** — apply these rules strictly:
+   - Every new exported function or method must have at least one test covering the happy path.
+   - Every non-trivial error path (error return, early return, branch that changes observable behaviour) must have a test that exercises it.
+   - Every new HTTP handler must have tests for: 200 success, 400 bad input, and the primary error path (404 or 500).
+   - Every new DB repository method must have at least one unit test or integration test.
+   - Absence of tests for non-trivial new code is a **blocker**, not a nice-to-have.
+   - Tautological tests (asserting language invariants or restating constants without exercising real logic) do not count as coverage.
+
+Summarise the coverage gaps before launching the agents, so the user sees them immediately regardless of how long the agent reviews take.
+
+## Phase A — Parallel reviews
+
+Launch **two agents in a single message** (parallel tool calls). Each gets a self-contained prompt — they cannot see each other's context.
+
+**Agent 1: `code-quality-reviewer`**
+- Task description: "Code quality review of <branch> vs <base>"
+- Prompt should include: base branch, PR number (if any), the file list from `git diff --stat`, the user's stated intent (from PR title/body or a 1-line note), and an explicit instruction to focus on the diff only (not the whole codebase). Tell it to write its report as the final message and not to commit anything.
+- Explicitly ask it to audit test coverage: for each new exported function/method/handler in the diff, check whether the diff contains tests covering the happy path and key error cases. Tautological tests (asserting language invariants or restating constants) do not count as coverage.
+
+**Agent 2: `integration-tester`**
+- Task description: "Integration test of <branch> against live dev env"
+- Prompt should include: base branch, PR number, the file list, which subsystems the diff touches (so it knows which CLI commands and API endpoints to prioritize), and an explicit instruction NOT to run `make dev-nuke` or destructive cleanup. Tell it to use the existing dev environment if one is already running.
+- **Cleanup requirement — include this verbatim in the prompt:** Before starting, record the current counts of scan jobs, profiles, and any other mutable resources that the tests will touch (e.g. `SELECT status, COUNT(*) FROM scan_jobs GROUP BY status`). After all tests complete, delete every resource the test session created: scan jobs queued during the session, profiles created during the session, discovery jobs, etc. Report the before/after counts to confirm cleanup. If a resource cannot be deleted via API (e.g. the DELETE endpoint doesn't exist), delete it directly via the database. Leaving test artifacts in the dev environment is a bug in the test run, not acceptable collateral.
+- **Scan failure reporting — include this verbatim in the prompt:** If scans fail, report the *specific error message* from the database (`error_message` column in `scan_jobs`), not just "expected without sudo". Distinguish between: (a) permission failures (raw socket / sudo required — acceptable in dev), (b) queue-full failures (means the test hammered the queue — flag as a test design issue), and (c) any other error. Never describe failures as "expected" without quoting the actual error and confirming it matches the known dev limitation.
+
+Run both in the foreground, in parallel, in the same tool-call message. Wait for both to return.
+
+## Phase B — Consolidation
+
+Once both reports are back, launch the third agent **sequentially** (it needs the outputs of the first two):
+
+**Agent 3: `pr-quality-reviewer`**
+- Task description: "Final PR review with cross-agent findings"
+- Prompt should include:
+  - Branch + base + PR number
+  - The full reports from `code-quality-reviewer` and `integration-tester`, clearly labeled
+  - The current CI status from `gh pr view ... --json statusCheckRollup` (if a PR exists)
+  - An instruction to **deduplicate** findings across the two upstream reports, **resolve conflicts** when the two agents disagree, and produce a **single prioritized merge-or-block decision**.
+
+## Phase C — Final report to the user
+
+Print a single consolidated summary in this exact shape:
+
+```
+## PR Review: <branch or #PR>
+
+**Scope**: <N files, +X/-Y lines, base: main>
+**CI status**: <pass/fail/pending or "no PR yet">
+
+### 🔴 Blockers (must fix before merge)
+- ...
+
+### 🟠 Should fix
+- ...
+
+### 🟡 Nice to have
+- ...
+
+### ✅ Verified
+- Unit tests: <pass/fail>
+- Lint/format: <pass/fail>
+- Live API smoke test: <pass/fail>
+- Cross-layer contract check: <pass/fail>
+
+### Recommendation
+<merge | merge after fixing blockers | block — reason>
+```
+
+Then print a one-line pointer to where the user can read each agent's full report if they want detail (or offer to print any of them in full).
+
+## Rules
+
+- **Never commit, push, force-push, or merge anything** as part of this command. Read-only.
+- **Don't modify config files** or run `make dev-nuke`.
+- If the dev environment isn't running and the user is on a feature branch, ask before running `make dev` (it requires sudo).
+- If `code-quality-reviewer` and `integration-tester` produce contradictory findings, surface the contradiction explicitly in the consolidation rather than picking one silently.
+- If there's no PR yet (just a local branch), still run the review — just note "no PR yet" in the CI status line.
+- **Check that every commit addresses exactly one concern.** If `git log origin/main..HEAD` reveals commits that bundle unrelated changes (e.g., two distinct bug fixes in one commit), flag it as a blocker — the branch must be split before merge.
+- **Check the PR test plan for CI-redundant items.** Items like "`go test ./...` passes" or "`golangci-lint` — 0 issues" are covered by CI and must not appear as manual checkboxes. Flag any such items as should-fix; test plans must only list live/manual verification steps that CI cannot perform.
+- **After making any code changes as part of the review process, update the PR title and body** using `gh pr edit` so they accurately reflect the current branch state. Summary, new endpoints, and test plan items must match what is actually in the branch.
+- **Test plan items that describe automatable behaviour must have tests.** If a test plan item says "endpoint X returns Y for input Z" or "function handles edge case W", that behaviour belongs in a unit or integration test — not just a manual checkbox. Flag any such item that has no corresponding test in the diff as a blocker.
+- **Swagger drift is a blocker.** Run `make docs` and `git diff --exit-code docs/swagger/ frontend/src/api/types.ts` — any diff means the spec is stale. The pre-push hook catches this locally; a CI failure here means the author skipped the hook.
+- **Thorough test coverage is required, not optional.** Low coverage is a blocker. Every new handler, service method, and repository method needs tests. "We'll add tests later" is not accepted.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -22,6 +22,19 @@ Run `make docs` and then `git diff --exit-code docs/swagger/ frontend/src/api/ty
 - If the diff is non-empty: **blocker** — the swagger spec is out of sync. List the files that changed and instruct the author to commit the updated output.
 - This check is mandatory even if no handler files changed (swagger_docs.go may reference types from other packages).
 
+### Codecov annotations (if a PR exists and CI has run)
+Run: `gh pr checks <PR number> --json name,conclusion,detailsUrl | jq '.[] | select(.name | test("codecov"; "i"))'`
+
+Then fetch the Codecov PR comment to read patch and project coverage:
+`gh api repos/anstrom/scanorama/issues/<PR number>/comments --jq '[.[] | select(.user.login == "codecov[bot]")] | last | .body' 2>/dev/null`
+
+From the comment, extract:
+- **Patch coverage** — the percentage of *new/changed lines* that are covered. Codecov threshold is ≥40% (informational — does not block CI, but flag if below).
+- **Project coverage** — total coverage delta vs base branch. Threshold is must not drop >2% (blocking — CI fails if it does). Flag if the project check shows a negative delta.
+- **File-level coverage table** — list any changed files where coverage dropped significantly (>5 percentage points) vs the base branch. These are should-fix items even if under threshold.
+- If CI is still running (no Codecov comment yet): note "Codecov pending" and skip this check — do not block on it.
+- If there is no PR yet: skip this check entirely.
+
 ### Test coverage audit
 Read the PR test plan and the diff, then answer these questions:
 
@@ -89,6 +102,7 @@ Print a single consolidated summary in this exact shape:
 - Lint/format: <pass/fail>
 - Live API smoke test: <pass/fail>
 - Cross-layer contract check: <pass/fail>
+- Codecov patch coverage: <X% / pending / no PR>
 
 ### Recommendation
 <merge | merge after fixing blockers | block — reason>

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -21,4 +21,20 @@ if ! (cd frontend && npx vitest run --reporter=dot 2>&1); then
     exit 1
 fi
 
+echo "  swagger drift..."
+if ! make docs > /dev/null 2>&1; then
+    echo "make docs failed — fix before pushing."
+    exit 1
+fi
+if ! git diff --exit-code docs/swagger/ frontend/src/api/types.ts > /dev/null 2>&1; then
+    echo ""
+    echo "Swagger spec is out of sync with code annotations."
+    echo "Run 'make docs' and commit the updated files before pushing:"
+    echo "  docs/swagger/swagger.json"
+    echo "  docs/swagger/swagger.yaml"
+    echo "  docs/swagger/docs.go"
+    echo "  frontend/src/api/types.ts"
+    exit 1
+fi
+
 echo "Pre-push checks passed."

--- a/Makefile
+++ b/Makefile
@@ -255,6 +255,27 @@ coverage: test-db-up ## Generate coverage report
 	@$(GO) tool cover -func=$(COVERAGE_FILE) | tail -1
 	@echo "✓ Report: $(COVERAGE_FILE).html"
 
+.PHONY: coverage-diff
+coverage-diff: coverage ## Show per-file coverage for Go files changed vs main (mirrors Codecov patch check)
+	@echo ""
+	@echo "Coverage for files changed vs main:"
+	@BASE=$$(git merge-base origin/main HEAD 2>/dev/null || echo "origin/main"); \
+	git diff --name-only $$BASE HEAD -- '*.go' \
+		| grep -v '_test\.go' | grep -v '/mocks/' \
+		| while read f; do \
+			$(GO) tool cover -func=$(COVERAGE_FILE) 2>/dev/null \
+				| grep "$$f" | tail -1; \
+		done | grep -v '^$$' || echo "  (no data — run make coverage first)"
+	@echo ""
+	@echo "Total project coverage:"
+	@$(GO) tool cover -func=$(COVERAGE_FILE) 2>/dev/null | tail -1 || echo "  (no data — run make coverage first)"
+	@echo ""
+	@echo "Codecov thresholds (.codecov.yml):"
+	@echo "  patch:   >=40% of new/changed lines covered (informational only)"
+	@echo "  project: must not drop >2% from base branch (blocking)"
+	@echo ""
+	@echo "Tip: open coverage.out.html for a line-by-line view — red = uncovered."
+
 
 
 # ─── Code Quality ────────────────────────────────────────────────────────────

--- a/frontend/src/components/run-scan-modal.tsx
+++ b/frontend/src/components/run-scan-modal.tsx
@@ -322,7 +322,7 @@ export function RunScanModal({
                     type="text"
                     value={target}
                     onChange={(e) => setTarget(e.target.value)}
-                    placeholder="192.168.1.1, 10.0.0.0/24…"
+                    placeholder="192.168.1.1, 10.0.0.0/24, myserver.local…"
                     autoFocus
                     className={cn(
                       "w-full px-3 py-1.5 text-xs rounded border border-border font-mono",
@@ -331,7 +331,7 @@ export function RunScanModal({
                     )}
                   />
                   <p className="text-xs text-text-muted">
-                    Comma-separated IPs, ranges, or CIDR blocks.
+                    Comma-separated IPs, CIDR ranges, or hostnames.
                   </p>
                 </div>
               )}

--- a/internal/api/handlers/coverage491_test.go
+++ b/internal/api/handlers/coverage491_test.go
@@ -376,7 +376,7 @@ func TestValidateScanRequest_NewRules(t *testing.T) {
 	})
 
 	t.Run("too many targets rejected", func(t *testing.T) {
-		targets := make([]string, maxTargetCount+1)
+		targets := make([]string, services.MaxTargetCount+1)
 		for i := range targets {
 			targets[i] = "10.0.0.1"
 		}
@@ -386,8 +386,8 @@ func TestValidateScanRequest_NewRules(t *testing.T) {
 		assert.Contains(t, err.Error(), "too many targets")
 	})
 
-	t.Run("exactly maxTargetCount targets accepted", func(t *testing.T) {
-		targets := make([]string, maxTargetCount)
+	t.Run("exactly services.MaxTargetCount targets accepted", func(t *testing.T) {
+		targets := make([]string, services.MaxTargetCount)
 		for i := range targets {
 			targets[i] = "10.0.0.1"
 		}

--- a/internal/api/handlers/scan.go
+++ b/internal/api/handlers/scan.go
@@ -11,7 +11,6 @@ import (
 	stderrors "errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"time"
 
@@ -22,13 +21,6 @@ import (
 	"github.com/anstrom/scanorama/internal/metrics"
 	"github.com/anstrom/scanorama/internal/scanning"
 	"github.com/anstrom/scanorama/internal/services"
-)
-
-// Scan validation constants.
-const (
-	maxScanNameLength = 255
-	maxTargetLength   = 255
-	maxTargetCount    = 100
 )
 
 // ScanHandler handles scan-related API endpoints.
@@ -566,10 +558,8 @@ func (h *ScanHandler) validateScanRequest(req *ScanRequest) error {
 		if len(target) > services.MaxTargetLength {
 			return fmt.Errorf("target %d too long (max %d characters)", i+1, services.MaxTargetLength)
 		}
-		if _, _, err := net.ParseCIDR(target); err != nil {
-			if net.ParseIP(target) == nil {
-				return fmt.Errorf("target %d: %q is not a valid IP address or CIDR range", i+1, target)
-			}
+		if !services.IsValidScanTarget(target) {
+			return fmt.Errorf("target %d: %q is not a valid IP address, CIDR range, or hostname", i+1, target)
 		}
 	}
 

--- a/internal/api/handlers/scan_test.go
+++ b/internal/api/handlers/scan_test.go
@@ -652,14 +652,24 @@ func TestScanHandler_EdgeCases(t *testing.T) {
 		err := handler.validateScanRequest(req)
 		assert.NoError(t, err)
 
-		// Hostname targets are not valid — must be IP or CIDR.
+		// Hostnames are valid targets; invalid strings (spaces, special chars) are not.
 		reqHostname := &ScanRequest{
 			Name:     "Test",
 			Targets:  []string{"192.168.1.1", "example.com"},
 			ScanType: "connect",
+			Ports:    "80",
 		}
 		err = handler.validateScanRequest(reqHostname)
-		assert.Error(t, err, "hostname targets should be rejected")
+		assert.NoError(t, err, "hostname targets should now be accepted")
+
+		reqInvalid := &ScanRequest{
+			Name:     "Test",
+			Targets:  []string{"192.168.1.1", "not valid!"},
+			ScanType: "connect",
+			Ports:    "80",
+		}
+		err = handler.validateScanRequest(reqInvalid)
+		assert.Error(t, err, "invalid target strings should be rejected")
 	})
 }
 
@@ -983,8 +993,8 @@ func TestValidateScanRequest_CIDRTarget(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "invalid CIDR and not plain IP",
-			targets:     []string{"not-a-cidr"},
+			name:        "invalid target — contains space",
+			targets:     []string{"not a target"},
 			expectError: true,
 		},
 	}

--- a/internal/db/repository_scan.go
+++ b/internal/db/repository_scan.go
@@ -25,15 +25,19 @@ const (
 )
 
 // isHostTarget reports whether target represents a single host: a bare IP
-// address or a /32 (IPv4) / /128 (IPv6) CIDR.  Such targets must not be
-// stored as rows in the networks table.
+// address, a /32 (IPv4) / /128 (IPv6) CIDR, or a DNS hostname.
+// Such targets must not be stored as rows in the networks table;
+// they are passed directly to the scan runner via execution_details.
 func isHostTarget(target string) bool {
 	if net.ParseIP(target) != nil {
 		return true // bare IP — always maps to /32 or /128
 	}
 	_, ipNet, err := net.ParseCIDR(target)
 	if err != nil {
-		return false
+		// Not an IP or CIDR — it must be a hostname (already validated by the
+		// service layer before reaching the DB).  Hostnames are host-scoped,
+		// not network-scoped, so we treat them like bare IPs.
+		return true
 	}
 	ones, bits := ipNet.Mask.Size()
 	return ones == bits // /32 for IPv4, /128 for IPv6

--- a/internal/db/scans_unit_test.go
+++ b/internal/db/scans_unit_test.go
@@ -326,16 +326,18 @@ func TestIsHostTarget(t *testing.T) {
 		input string
 		want  bool
 	}{
-		{"10.0.0.1", true},        // bare IPv4
-		{"192.168.1.100", true},   // bare IPv4
-		{"10.0.0.1/32", true},     // explicit /32
-		{"::1", true},             // bare IPv6 loopback
-		{"2001:db8::1/128", true}, // explicit /128
-		{"10.0.0.0/8", false},     // network CIDR /8
-		{"192.168.1.0/24", false}, // /24 network
-		{"172.16.0.0/12", false},  // /12 network
-		{"10.0.0.0/31", false},    // /31 point-to-point (two hosts, not one)
-		{"notanip", false},        // garbage — not a valid IP or CIDR
+		{"10.0.0.1", true},                 // bare IPv4
+		{"192.168.1.100", true},            // bare IPv4
+		{"10.0.0.1/32", true},              // explicit /32
+		{"::1", true},                      // bare IPv6 loopback
+		{"2001:db8::1/128", true},          // explicit /128
+		{"10.0.0.0/8", false},              // network CIDR /8
+		{"192.168.1.0/24", false},          // /24 network
+		{"172.16.0.0/12", false},           // /12 network
+		{"10.0.0.0/31", false},             // /31 point-to-point (two hosts, not one)
+		{"myserver", true},                 // bare hostname — host-scoped
+		{"api.internal.example.com", true}, // FQDN — host-scoped
+		{"my-server-01.prod.corp", true},   // FQDN with hyphens — host-scoped
 	}
 
 	for _, tc := range cases {

--- a/internal/services/scan.go
+++ b/internal/services/scan.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -27,6 +28,32 @@ const MaxTargetLength = 200
 
 // MaxTargetCount is the maximum number of targets allowed per scan.
 const MaxTargetCount = 100
+
+// hostnameLabel matches a single DNS label: 1–63 chars, alphanumeric plus
+// interior hyphens, not starting or ending with a hyphen (RFC 1123).
+var hostnameLabel = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$`)
+
+// IsValidScanTarget reports whether s is an acceptable scan target:
+// a plain IP address, a CIDR range, or an RFC 1123 hostname.
+func IsValidScanTarget(s string) bool {
+	if net.ParseIP(s) != nil {
+		return true
+	}
+	if _, _, err := net.ParseCIDR(s); err == nil {
+		return true
+	}
+	// Hostname: dot-separated labels, total length ≤ 253.
+	s = strings.TrimRight(s, ".") // strip optional trailing dot
+	if s == "" || len(s) > 253 {
+		return false
+	}
+	for _, label := range strings.Split(s, ".") {
+		if !hostnameLabel.MatchString(label) {
+			return false
+		}
+	}
+	return true
+}
 
 // validScanTypes lists the scan-type values accepted by the service layer.
 var validScanTypes = map[string]bool{
@@ -204,11 +231,9 @@ func validateScanInput(input db.CreateScanInput) error {
 			return errors.NewScanError(errors.CodeValidation,
 				fmt.Sprintf("target %d too long (max %d characters)", i+1, MaxTargetLength))
 		}
-		if _, _, err := net.ParseCIDR(target); err != nil {
-			if net.ParseIP(target) == nil {
-				return errors.NewScanError(errors.CodeValidation,
-					fmt.Sprintf("target %d: %q is not a valid IP address or CIDR range", i+1, target))
-			}
+		if !IsValidScanTarget(target) {
+			return errors.NewScanError(errors.CodeValidation,
+				fmt.Sprintf("target %d: %q is not a valid IP address, CIDR range, or hostname", i+1, target))
 		}
 	}
 

--- a/internal/services/scan_test.go
+++ b/internal/services/scan_test.go
@@ -846,19 +846,19 @@ func TestValidateScanInput(t *testing.T) {
 		assert.Contains(t, err.Error(), "too long")
 	})
 
-	t.Run("target at MaxTargetLength but invalid IP is rejected for format", func(t *testing.T) {
-		// Exactly MaxTargetLength chars: passes the length gate, fails IP check.
+	t.Run("target at MaxTargetLength but not a valid target is rejected", func(t *testing.T) {
+		// Exactly MaxTargetLength chars of underscores: not an IP, CIDR, or hostname.
 		in := validCreateInput()
-		in.Targets = []string{strings.Repeat("a", MaxTargetLength)}
+		in.Targets = []string{strings.Repeat("_", MaxTargetLength)}
 		err := validateScanInput(in)
 		require.Error(t, err)
 		assert.True(t, errors.IsCode(err, errors.CodeValidation))
 		assert.Contains(t, err.Error(), "not a valid IP")
 	})
 
-	t.Run("invalid target (hostname, not an IP or CIDR)", func(t *testing.T) {
+	t.Run("invalid target (bare invalid string)", func(t *testing.T) {
 		in := validCreateInput()
-		in.Targets = []string{"not-an-ip"}
+		in.Targets = []string{"not an ip!"}
 		err := validateScanInput(in)
 		require.Error(t, err)
 		assert.True(t, errors.IsCode(err, errors.CodeValidation))
@@ -887,6 +887,57 @@ func TestValidateScanInput(t *testing.T) {
 		in := validCreateInput()
 		in.Targets = []string{"2001:db8::/32"}
 		assert.NoError(t, validateScanInput(in))
+	})
+
+	t.Run("valid simple hostname", func(t *testing.T) {
+		in := validCreateInput()
+		in.Targets = []string{"myserver"}
+		assert.NoError(t, validateScanInput(in))
+	})
+
+	t.Run("valid FQDN", func(t *testing.T) {
+		in := validCreateInput()
+		in.Targets = []string{"api.internal.example.com"}
+		assert.NoError(t, validateScanInput(in))
+	})
+
+	t.Run("valid hostname with hyphens", func(t *testing.T) {
+		in := validCreateInput()
+		in.Targets = []string{"my-server-01.prod.example.com"}
+		assert.NoError(t, validateScanInput(in))
+	})
+
+	t.Run("valid hostname with trailing dot", func(t *testing.T) {
+		in := validCreateInput()
+		in.Targets = []string{"api.example.com."}
+		assert.NoError(t, validateScanInput(in))
+	})
+
+	t.Run("invalid hostname — label starts with hyphen", func(t *testing.T) {
+		in := validCreateInput()
+		in.Targets = []string{"-badhost.example.com"}
+		err := validateScanInput(in)
+		require.Error(t, err)
+		assert.True(t, errors.IsCode(err, errors.CodeValidation))
+		assert.Contains(t, err.Error(), "not a valid IP")
+	})
+
+	t.Run("invalid hostname — label ends with hyphen", func(t *testing.T) {
+		in := validCreateInput()
+		in.Targets = []string{"badhost-.example.com"}
+		err := validateScanInput(in)
+		require.Error(t, err)
+		assert.True(t, errors.IsCode(err, errors.CodeValidation))
+		assert.Contains(t, err.Error(), "not a valid IP")
+	})
+
+	t.Run("invalid hostname — contains underscore", func(t *testing.T) {
+		in := validCreateInput()
+		in.Targets = []string{"bad_host.example.com"}
+		err := validateScanInput(in)
+		require.Error(t, err)
+		assert.True(t, errors.IsCode(err, errors.CodeValidation))
+		assert.Contains(t, err.Error(), "not a valid IP")
 	})
 
 	// ── ScanType ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Relaxes per-target validation in the service and handler layers to accept RFC 1123 hostnames alongside IPs and CIDRs
- nmap resolves hostnames natively at scan time — no pre-resolution needed
- Updates the run-scan modal placeholder and help text
- Adds swagger drift check to pre-push hook (catches stale specs before CI)
- Strengthens review-pr skill with mandatory swagger and test coverage checks

Valid targets: `myserver`, `api.internal.example.com`, `my-host-01.prod.corp`, `192.168.1.0/24`
Invalid targets: labels starting/ending with hyphens, underscores, spaces, or special characters

Closes #682

## Test plan

- Open Run Scan modal — confirm placeholder shows a hostname example
- Enter `router.local` as a target and submit — scan should be created without a 400 error
- Enter `bad_host.example.com` — confirm the API returns a 400 validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)