### PR TITLE
feat(smart-scan): trigger button and scan strategy preview

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -5266,6 +5266,10 @@ const docTemplate = `{
                     "type": "integer",
                     "example": 50
                 },
+                "network_cidr": {
+                    "type": "string",
+                    "example": "192.168.1.0/24"
+                },
                 "stage": {
                     "type": "string",
                     "enum": [

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -5260,6 +5260,10 @@
                     "type": "integer",
                     "example": 50
                 },
+                "network_cidr": {
+                    "type": "string",
+                    "example": "192.168.1.0/24"
+                },
                 "stage": {
                     "type": "string",
                     "enum": [

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1056,6 +1056,9 @@ definitions:
       limit:
         example: 50
         type: integer
+      network_cidr:
+        example: 192.168.1.0/24
+        type: string
       stage:
         enum:
         - os_detection

--- a/docs/swagger_docs.go
+++ b/docs/swagger_docs.go
@@ -1432,9 +1432,10 @@ type TriggerHostResponse struct {
 
 // TriggerBatchRequest is the request body for TriggerSmartScanBatch.
 type TriggerBatchRequest struct {
-	Stage   string   `json:"stage,omitempty" example:"os_detection" enums:"os_detection,port_expansion,service_scan,refresh,skip"`
-	HostIDs []string `json:"host_ids,omitempty" example:"550e8400-e29b-41d4-a716-446655440000"`
-	Limit   int      `json:"limit,omitempty" example:"50"`
+	Stage       string   `json:"stage,omitempty" example:"os_detection" enums:"os_detection,port_expansion,service_scan,refresh,skip"`
+	HostIDs     []string `json:"host_ids,omitempty" example:"550e8400-e29b-41d4-a716-446655440000"`
+	NetworkCIDR string   `json:"network_cidr,omitempty" example:"192.168.1.0/24"`
+	Limit       int      `json:"limit,omitempty" example:"50"`
 }
 
 // BatchDetailEntryResponse records the outcome for one host in a batch.

--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -74,4 +74,9 @@ export {
   useTriggerSmartScan,
   useTriggerSmartScanBatch,
 } from "./use-smart-scan";
-export type { ScanStage, SuggestionSummary, BatchResult } from "./use-smart-scan";
+export type {
+  ScanStage,
+  SuggestionSummary,
+  BatchResult,
+  TriggerHostResponse,
+} from "./use-smart-scan";

--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -68,3 +68,10 @@ export type {
   ExpiringCertificate,
   ExpiringCertificatesResponse,
 } from "./use-expiring-certs";
+export {
+  useSmartScanStage,
+  useSmartScanSuggestions,
+  useTriggerSmartScan,
+  useTriggerSmartScanBatch,
+} from "./use-smart-scan";
+export type { ScanStage, SuggestionSummary, BatchResult } from "./use-smart-scan";

--- a/frontend/src/api/hooks/use-smart-scan.ts
+++ b/frontend/src/api/hooks/use-smart-scan.ts
@@ -1,0 +1,81 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../client";
+import { ApiError } from "../errors";
+import type { components } from "../types";
+
+export type ScanStage = components["schemas"]["docs.ScanStageResponse"];
+export type SuggestionSummary =
+  components["schemas"]["docs.SuggestionSummaryResponse"];
+export type BatchResult = components["schemas"]["docs.BatchResultResponse"];
+
+export function useSmartScanStage(hostId: string) {
+  return useQuery({
+    queryKey: ["smart-scan", "stage", hostId],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        "/smart-scan/hosts/{id}/stage",
+        { params: { path: { id: hostId } } },
+      );
+      if (error) throw new ApiError(response.status, error);
+      return data as ScanStage;
+    },
+    enabled: !!hostId,
+    staleTime: 30_000,
+  });
+}
+
+export function useSmartScanSuggestions(enabled = true) {
+  return useQuery({
+    queryKey: ["smart-scan", "suggestions"],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        "/smart-scan/suggestions",
+      );
+      if (error) throw new ApiError(response.status, error);
+      return data as SuggestionSummary;
+    },
+    enabled,
+    staleTime: 60_000,
+  });
+}
+
+export function useTriggerSmartScan() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (hostId: string) => {
+      const { data, error, response } = await api.POST(
+        "/smart-scan/hosts/{id}/trigger",
+        { params: { path: { id: hostId } } },
+      );
+      if (error) throw new ApiError(response.status, error);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["scans"] });
+      queryClient.invalidateQueries({ queryKey: ["smart-scan"] });
+    },
+  });
+}
+
+export function useTriggerSmartScanBatch() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: {
+      stage?: string;
+      host_ids?: string[];
+      limit?: number;
+    }) => {
+      const { data, error, response } = await api.POST(
+        "/smart-scan/trigger-batch",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { body: body as any },
+      );
+      if (error) throw new ApiError(response.status, error);
+      return data as BatchResult;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["scans"] });
+      queryClient.invalidateQueries({ queryKey: ["smart-scan"] });
+    },
+  });
+}

--- a/frontend/src/api/hooks/use-smart-scan.ts
+++ b/frontend/src/api/hooks/use-smart-scan.ts
@@ -39,6 +39,13 @@ export function useSmartScanSuggestions(enabled = true) {
   });
 }
 
+export type TriggerHostResponse = {
+  host_id?: string;
+  queued?: boolean;
+  scan_id?: string;
+  message?: string;
+};
+
 export function useTriggerSmartScan() {
   const queryClient = useQueryClient();
   return useMutation({
@@ -48,7 +55,7 @@ export function useTriggerSmartScan() {
         { params: { path: { id: hostId } } },
       );
       if (error) throw new ApiError(response.status, error);
-      return data;
+      return data as TriggerHostResponse;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["scans"] });
@@ -60,15 +67,12 @@ export function useTriggerSmartScan() {
 export function useTriggerSmartScanBatch() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (body: {
-      stage?: string;
-      host_ids?: string[];
-      limit?: number;
-    }) => {
+    mutationFn: async (
+      body: components["schemas"]["docs.TriggerBatchRequest"],
+    ) => {
       const { data, error, response } = await api.POST(
         "/smart-scan/trigger-batch",
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        { body: body as any },
+        { body },
       );
       if (error) throw new ApiError(response.status, error);
       return data as BatchResult;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1664,6 +1664,8 @@ export interface components {
             host_ids?: string[];
             /** @example 50 */
             limit?: number;
+            /** @example 192.168.1.0/24 */
+            network_cidr?: string;
             /**
              * @example os_detection
              * @enum {string}

--- a/frontend/src/components/smart-scan-preview-modal.tsx
+++ b/frontend/src/components/smart-scan-preview-modal.tsx
@@ -1,0 +1,256 @@
+import { X, Zap, Loader2 } from "lucide-react";
+import { Button } from "./button";
+import { cn } from "../lib/utils";
+import type { ScanStage, SuggestionSummary } from "../api/hooks/use-smart-scan";
+
+// ── Host-level preview ────────────────────────────────────────────────────────
+
+const STAGE_LABELS: Record<string, string> = {
+  os_detection: "OS Detection",
+  port_expansion: "Port Expansion",
+  service_scan: "Service Scan",
+  refresh: "Refresh",
+  skip: "No action needed",
+};
+
+interface HostSmartScanPreviewProps {
+  hostIp: string;
+  stage: ScanStage;
+  isPending: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export function HostSmartScanPreviewModal({
+  hostIp,
+  stage,
+  isPending,
+  onConfirm,
+  onClose,
+}: HostSmartScanPreviewProps) {
+  const isSkip = stage.stage === "skip";
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Smart Scan preview"
+    >
+      <div
+        className="fixed inset-0 bg-black/50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div className="relative z-10 w-full max-w-sm bg-surface border border-border rounded-lg shadow-xl flex flex-col gap-4 p-5">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-text-primary flex items-center gap-2">
+            <Zap className="h-4 w-4 text-accent" />
+            Smart Scan Preview
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="text-xs text-text-muted font-mono">{hostIp}</div>
+
+        <div
+          className={cn(
+            "rounded-md border px-4 py-3 space-y-2",
+            isSkip
+              ? "border-border bg-surface-raised"
+              : "border-accent/30 bg-accent/5",
+          )}
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium text-text-primary">
+              {STAGE_LABELS[stage.stage ?? ""] ?? stage.stage}
+            </span>
+            {!isSkip && stage.scan_type && (
+              <span className="text-[11px] text-text-muted font-mono bg-surface-raised px-1.5 py-0.5 rounded">
+                {stage.scan_type}
+              </span>
+            )}
+          </div>
+          {stage.reason && (
+            <p className="text-xs text-text-secondary">{stage.reason}</p>
+          )}
+          {!isSkip && stage.ports && (
+            <div className="flex gap-2 text-xs">
+              <span className="text-text-muted w-16 shrink-0">Ports</span>
+              <span className="font-mono text-text-secondary">{stage.ports}</span>
+            </div>
+          )}
+          {!isSkip && stage.os_detection && (
+            <div className="flex gap-2 text-xs">
+              <span className="text-text-muted w-16 shrink-0">OS detect</span>
+              <span className="text-text-secondary">enabled</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex gap-2 justify-end">
+          <Button variant="secondary" onClick={onClose} className="text-xs h-7 px-3">
+            Cancel
+          </Button>
+          {!isSkip && (
+            <Button
+              onClick={onConfirm}
+              disabled={isPending}
+              className="text-xs h-7 px-3"
+            >
+              {isPending ? (
+                <>
+                  <Loader2 className="h-3 w-3 mr-1.5 animate-spin" />
+                  Queuing…
+                </>
+              ) : (
+                <>
+                  <Zap className="h-3 w-3 mr-1.5" />
+                  Run Smart Scan
+                </>
+              )}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Batch (network) preview ───────────────────────────────────────────────────
+
+interface BatchSmartScanPreviewProps {
+  networkName: string;
+  summary: SuggestionSummary;
+  isPending: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+interface SuggestionRowProps {
+  label: string;
+  count: number | undefined;
+  action: string | undefined;
+}
+
+function SuggestionRow({ label, count, action }: SuggestionRowProps) {
+  if (!count) return null;
+  return (
+    <div className="flex items-center justify-between text-xs py-1">
+      <span className="text-text-secondary">{label}</span>
+      <div className="flex items-center gap-3">
+        <span className="font-mono text-text-primary tabular-nums">{count}</span>
+        <span className="text-[11px] text-text-muted font-mono bg-surface-raised px-1.5 py-0.5 rounded w-24 text-center">
+          {action}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function BatchSmartScanPreviewModal({
+  networkName,
+  summary,
+  isPending,
+  onConfirm,
+  onClose,
+}: BatchSmartScanPreviewProps) {
+  const groups = [
+    { label: "No OS info", ...summary.no_os_info },
+    { label: "No open ports", ...summary.no_ports },
+    { label: "No service banners", ...summary.no_services },
+    { label: "Stale (>30 days)", ...summary.stale },
+  ];
+  const eligibleCount = groups.reduce((n, g) => n + (g.count ?? 0), 0);
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Smart Scan batch preview"
+    >
+      <div
+        className="fixed inset-0 bg-black/50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div className="relative z-10 w-full max-w-sm bg-surface border border-border rounded-lg shadow-xl flex flex-col gap-4 p-5">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-text-primary flex items-center gap-2">
+            <Zap className="h-4 w-4 text-accent" />
+            Smart Scan Preview
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="text-xs text-text-muted">{networkName}</div>
+
+        <div className="rounded-md border border-border bg-surface-raised divide-y divide-border/50">
+          {groups.map((g) => (
+            <div key={g.label} className={cn("px-3", !g.count && "opacity-40")}>
+              <SuggestionRow
+                label={g.label}
+                count={g.count}
+                action={g.action}
+              />
+            </div>
+          ))}
+        </div>
+
+        {eligibleCount === 0 ? (
+          <p className="text-xs text-text-muted text-center">
+            All hosts are well-known — no Smart Scan needed.
+          </p>
+        ) : (
+          <p className="text-xs text-text-secondary">
+            Up to{" "}
+            <span className="font-semibold text-text-primary">
+              {eligibleCount}
+            </span>{" "}
+            hosts will be queued for scanning (max 50 per batch).
+          </p>
+        )}
+
+        <div className="flex gap-2 justify-end">
+          <Button variant="secondary" onClick={onClose} className="text-xs h-7 px-3">
+            Cancel
+          </Button>
+          {eligibleCount > 0 && (
+            <Button
+              onClick={onConfirm}
+              disabled={isPending}
+              className="text-xs h-7 px-3"
+            >
+              {isPending ? (
+                <>
+                  <Loader2 className="h-3 w-3 mr-1.5 animate-spin" />
+                  Queuing…
+                </>
+              ) : (
+                <>
+                  <Zap className="h-3 w-3 mr-1.5" />
+                  Run Smart Scan
+                </>
+              )}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/smart-scan-preview-modal.tsx
+++ b/frontend/src/components/smart-scan-preview-modal.tsx
@@ -136,12 +136,11 @@ interface BatchSmartScanPreviewProps {
 
 interface SuggestionRowProps {
   label: string;
-  count: number | undefined;
+  count: number;
   action: string | undefined;
 }
 
 function SuggestionRow({ label, count, action }: SuggestionRowProps) {
-  if (!count) return null;
   return (
     <div className="flex items-center justify-between text-xs py-1">
       <span className="text-text-secondary">{label}</span>
@@ -202,12 +201,14 @@ export function BatchSmartScanPreviewModal({
 
         <div className="rounded-md border border-border bg-surface-raised divide-y divide-border/50">
           {groups.map((g) => (
-            <div key={g.label} className={cn("px-3", !g.count && "opacity-40")}>
-              <SuggestionRow
-                label={g.label}
-                count={g.count}
-                action={g.action}
-              />
+            <div key={g.label} className="px-3">
+              <div className={cn(!g.count && "opacity-40")}>
+                <SuggestionRow
+                  label={g.label}
+                  count={g.count ?? 0}
+                  action={g.action}
+                />
+              </div>
             </div>
           ))}
         </div>

--- a/frontend/src/routes/hosts.test.tsx
+++ b/frontend/src/routes/hosts.test.tsx
@@ -22,6 +22,15 @@ vi.mock("../api/hooks/use-groups", () => ({
   useAddHostsToGroup: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
 }));
 
+vi.mock("../api/hooks/use-smart-scan", () => ({
+  useSmartScanStage: vi.fn(() => ({ data: undefined, isLoading: false })),
+  useTriggerSmartScan: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+}));
+
+vi.mock("../components/smart-scan-preview-modal", () => ({
+  HostSmartScanPreviewModal: () => null,
+}));
+
 import {
   useHosts,
   useHost,
@@ -1003,10 +1012,10 @@ describe("HostsPage", () => {
 
     // ── Scan this host button ─────────────────────────────────────
 
-    it("opens the scan modal when 'Scan this host' is clicked", async () => {
+    it("opens the scan modal when 'Scan' is clicked", async () => {
       await openPanel();
       await userEvent.click(
-        screen.getByRole("button", { name: /scan this host/i }),
+        screen.getByRole("button", { name: /^scan$/i }),
       );
       expect(screen.getByTestId("run-scan-modal")).toBeInTheDocument();
     });

--- a/frontend/src/routes/hosts.test.tsx
+++ b/frontend/src/routes/hosts.test.tsx
@@ -27,8 +27,28 @@ vi.mock("../api/hooks/use-smart-scan", () => ({
   useTriggerSmartScan: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
 }));
 
+const mockOnSmartScanConfirm = vi.fn();
+const mockOnSmartScanClose = vi.fn();
 vi.mock("../components/smart-scan-preview-modal", () => ({
-  HostSmartScanPreviewModal: () => null,
+  HostSmartScanPreviewModal: ({
+    onConfirm,
+    onClose,
+  }: {
+    hostIp: string;
+    stage: unknown;
+    isPending: boolean;
+    onConfirm: () => void;
+    onClose: () => void;
+  }) => {
+    mockOnSmartScanConfirm.mockImplementation(onConfirm);
+    mockOnSmartScanClose.mockImplementation(onClose);
+    return (
+      <div data-testid="smart-scan-preview-modal">
+        <button onClick={onConfirm}>Run Smart Scan</button>
+        <button onClick={onClose}>Cancel</button>
+      </div>
+    );
+  },
 }));
 
 import {
@@ -39,6 +59,14 @@ import {
   useDeleteHost,
   useBulkDeleteHosts,
 } from "../api/hooks/use-hosts";
+
+import {
+  useSmartScanStage,
+  useTriggerSmartScan,
+} from "../api/hooks/use-smart-scan";
+
+const mockUseSmartScanStage = vi.mocked(useSmartScanStage);
+const mockUseTriggerSmartScan = vi.mocked(useTriggerSmartScan);
 
 const mockUseHosts = vi.mocked(useHosts);
 const mockUseHost = vi.mocked(useHost);
@@ -1018,6 +1046,72 @@ describe("HostsPage", () => {
         screen.getByRole("button", { name: /^scan$/i }),
       );
       expect(screen.getByTestId("run-scan-modal")).toBeInTheDocument();
+    });
+
+    // ── Smart Scan button ──────────────────────────────────────────
+
+    it("renders a Smart Scan button in the panel footer", async () => {
+      await openPanel();
+      expect(
+        screen.getByRole("button", { name: /smart scan/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("opens the preview modal when Smart Scan is clicked and stage data is available", async () => {
+      mockUseSmartScanStage.mockReturnValue({
+        data: {
+          stage: "os_detection",
+          scan_type: "syn",
+          ports: "22,80,443",
+          os_detection: true,
+          reason: "no OS information",
+        },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useSmartScanStage>);
+
+      await openPanel();
+      await userEvent.click(
+        screen.getByRole("button", { name: /smart scan/i }),
+      );
+      expect(screen.getByTestId("smart-scan-preview-modal")).toBeInTheDocument();
+    });
+
+    it("disables the Smart Scan button when a scan is already pending", async () => {
+      mockUseHostScans.mockReturnValue({
+        data: {
+          data: [{ id: "s1", status: "pending" }],
+          total: 1,
+          page: 1,
+          page_size: 5,
+          total_pages: 1,
+        },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useHostScans>);
+
+      await openPanel();
+      const btn = screen.getByRole("button", { name: /smart scan/i });
+      expect(btn).toBeDisabled();
+    });
+
+    it("calls triggerSmartScan when the preview modal confirm button is clicked", async () => {
+      const mockTrigger = vi.fn().mockResolvedValue({ queued: true, scan_id: "scan-123" });
+      mockUseTriggerSmartScan.mockReturnValue({
+        mutateAsync: mockTrigger,
+        isPending: false,
+      } as unknown as ReturnType<typeof useTriggerSmartScan>);
+      mockUseSmartScanStage.mockReturnValue({
+        data: { stage: "port_expansion", scan_type: "connect", ports: "1-1024", reason: "no ports" },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useSmartScanStage>);
+
+      await openPanel();
+      await userEvent.click(
+        screen.getByRole("button", { name: /smart scan/i }),
+      );
+      await userEvent.click(
+        screen.getByRole("button", { name: /run smart scan/i }),
+      );
+      expect(mockTrigger).toHaveBeenCalledWith("host-1");
     });
   });
 

--- a/frontend/src/routes/hosts.tsx
+++ b/frontend/src/routes/hosts.tsx
@@ -17,6 +17,7 @@ import {
   ChevronDown,
   ChevronRight,
   ShieldCheck,
+  Zap,
 } from "lucide-react";
 import { SortHeader } from "../components/sort-header";
 import type { SortOrder } from "../components/sort-header";
@@ -48,6 +49,11 @@ import type { FilterGroup } from "../lib/filter-expr";
 import { deserializeFilter, serializeFilter } from "../lib/filter-expr";
 import { useTags, useUpdateHostTags } from "../api/hooks/use-tags";
 import { useGroups, useAddHostsToGroup } from "../api/hooks/use-groups";
+import {
+  useSmartScanStage,
+  useTriggerSmartScan,
+} from "../api/hooks/use-smart-scan";
+import { HostSmartScanPreviewModal } from "../components/smart-scan-preview-modal";
 
 type HostResponse = components["schemas"]["docs.HostResponse"];
 
@@ -264,6 +270,33 @@ function HostDetailPanel({
     host.id ?? "",
     { page: scanHistoryPage, page_size: SCAN_HISTORY_PAGE_SIZE },
   );
+
+  // Smart Scan
+  const [showSmartScanPreview, setShowSmartScanPreview] = useState(false);
+  const { data: smartScanStage, isLoading: smartScanStageLoading } =
+    useSmartScanStage(showSmartScanPreview ? (h.id ?? "") : "");
+  const { mutateAsync: triggerSmartScan, isPending: isSmartScanPending } =
+    useTriggerSmartScan();
+
+  const hasPendingScan = (hostScansData?.data ?? []).some(
+    (s) => s.status === "pending" || s.status === "running",
+  );
+
+  async function handleSmartScanConfirm() {
+    try {
+      const result = await triggerSmartScan(h.id ?? "");
+      setShowSmartScanPreview(false);
+      if (result && "queued" in result && !result.queued) {
+        toast.success("No scan needed — host knowledge is sufficient.");
+      } else {
+        toast.success("Smart Scan queued.");
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to queue Smart Scan.",
+      );
+    }
+  }
 
   async function handleSaveHostname() {
     setHostnameError(null);
@@ -1183,16 +1216,32 @@ function HostDetailPanel({
 
         {/* Footer */}
         <div className="px-5 py-3 border-t border-border shrink-0 space-y-2">
-          <Button
-            icon={<ScanLine className="h-3.5 w-3.5" />}
-            onClick={() => {
-              onClose();
-              onScan(h.ip_address ?? "");
-            }}
-            className="w-full justify-center"
-          >
-            Scan this host
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              icon={<ScanLine className="h-3.5 w-3.5" />}
+              onClick={() => {
+                onClose();
+                onScan(h.ip_address ?? "");
+              }}
+              className="flex-1 justify-center"
+            >
+              Scan
+            </Button>
+            <Button
+              variant="secondary"
+              icon={<Zap className="h-3.5 w-3.5" />}
+              onClick={() => setShowSmartScanPreview(true)}
+              disabled={hasPendingScan || smartScanStageLoading}
+              title={
+                hasPendingScan
+                  ? "A scan is already pending for this host"
+                  : "Run the next recommended scan for this host"
+              }
+              className="flex-1 justify-center"
+            >
+              Smart Scan
+            </Button>
+          </div>
 
           {deleteError && (
             <p className="text-[11px] text-danger">{deleteError}</p>
@@ -1231,6 +1280,16 @@ function HostDetailPanel({
           )}
         </div>
       </div>
+
+      {showSmartScanPreview && smartScanStage && (
+        <HostSmartScanPreviewModal
+          hostIp={h.ip_address ?? ""}
+          stage={smartScanStage}
+          isPending={isSmartScanPending}
+          onConfirm={() => void handleSmartScanConfirm()}
+          onClose={() => setShowSmartScanPreview(false)}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/routes/hosts.tsx
+++ b/frontend/src/routes/hosts.tsx
@@ -52,6 +52,7 @@ import { useGroups, useAddHostsToGroup } from "../api/hooks/use-groups";
 import {
   useSmartScanStage,
   useTriggerSmartScan,
+  type TriggerHostResponse,
 } from "../api/hooks/use-smart-scan";
 import { HostSmartScanPreviewModal } from "../components/smart-scan-preview-modal";
 
@@ -286,7 +287,8 @@ function HostDetailPanel({
     try {
       const result = await triggerSmartScan(h.id ?? "");
       setShowSmartScanPreview(false);
-      if (result && "queued" in result && !result.queued) {
+      const typed = result as TriggerHostResponse;
+      if (!typed.queued) {
         toast.success("No scan needed — host knowledge is sufficient.");
       } else {
         toast.success("Smart Scan queued.");
@@ -1231,7 +1233,8 @@ function HostDetailPanel({
               variant="secondary"
               icon={<Zap className="h-3.5 w-3.5" />}
               onClick={() => setShowSmartScanPreview(true)}
-              disabled={hasPendingScan || smartScanStageLoading}
+              disabled={hasPendingScan}
+              loading={showSmartScanPreview && smartScanStageLoading}
               title={
                 hasPendingScan
                   ? "A scan is already pending for this host"

--- a/frontend/src/routes/networks.test.tsx
+++ b/frontend/src/routes/networks.test.tsx
@@ -93,6 +93,23 @@ import {
   useRerunDiscovery,
 } from "../api/hooks/use-discovery";
 
+vi.mock("../api/hooks/use-smart-scan", () => ({
+  useSmartScanSuggestions: vi.fn(),
+  useTriggerSmartScanBatch: vi.fn(),
+}));
+
+vi.mock("../components/smart-scan-preview-modal", () => ({
+  BatchSmartScanPreviewModal: () => null,
+}));
+
+import {
+  useSmartScanSuggestions,
+  useTriggerSmartScanBatch,
+} from "../api/hooks/use-smart-scan";
+
+const mockUseSmartScanSuggestions = vi.mocked(useSmartScanSuggestions);
+const mockUseTriggerSmartScanBatch = vi.mocked(useTriggerSmartScanBatch);
+
 const mockUseNetworks = vi.mocked(useNetworks);
 const mockUseNetworkExclusions = vi.mocked(useNetworkExclusions);
 const mockUseEnableNetwork = vi.mocked(useEnableNetwork);
@@ -259,6 +276,13 @@ beforeEach(() => {
   );
   mockUseRerunDiscovery.mockReturnValue(
     idleMutation as unknown as ReturnType<typeof useRerunDiscovery>,
+  );
+  mockUseSmartScanSuggestions.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useSmartScanSuggestions>);
+  mockUseTriggerSmartScanBatch.mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useTriggerSmartScanBatch>,
   );
 });
 

--- a/frontend/src/routes/networks.tsx
+++ b/frontend/src/routes/networks.tsx
@@ -12,6 +12,7 @@ import {
   ScanSearch,
   Radar,
   TrendingUp,
+  Zap,
 } from "lucide-react";
 import { SortHeader } from "../components/sort-header";
 import type { SortOrder } from "../components/sort-header";
@@ -47,6 +48,11 @@ import { EditNetworkModal } from "../components/edit-network-modal";
 import { CreateDiscoveryModal } from "../components/create-discovery-modal";
 import { ScanNetworkModal } from "../components/scan-network-modal";
 import { useToast } from "../components/toast-provider";
+import {
+  useSmartScanSuggestions,
+  useTriggerSmartScanBatch,
+} from "../api/hooks/use-smart-scan";
+import { BatchSmartScanPreviewModal } from "../components/smart-scan-preview-modal";
 import { formatRelativeTime, formatAbsoluteTime, cn } from "../lib/utils";
 import type { components } from "../api/types";
 
@@ -535,6 +541,7 @@ function NetworkDetailPanel({
   const [actionError, setActionError] = useState<string | null>(null);
   const [showEditModal, setShowEditModal] = useState(false);
   const [showScanModal, setShowScanModal] = useState(false);
+  const [showSmartScanPreview, setShowSmartScanPreview] = useState(false);
 
   const { toast } = useToast();
 
@@ -546,6 +553,26 @@ function NetworkDetailPanel({
     useDeleteNetwork();
   const { mutateAsync: discoverNetwork, isPending: isDiscovering } =
     useStartNetworkDiscovery();
+  const { data: smartScanSuggestions, isLoading: isSuggestionsLoading } =
+    useSmartScanSuggestions(showSmartScanPreview);
+  const { mutateAsync: triggerBatch, isPending: isBatchPending } =
+    useTriggerSmartScanBatch();
+
+  async function handleSmartScanBatch() {
+    try {
+      const result = await triggerBatch({});
+      setShowSmartScanPreview(false);
+      toast.success(
+        result.queued === 0
+          ? "No hosts needed scanning."
+          : `Smart Scan queued for ${result.queued} host${result.queued === 1 ? "" : "s"}.`,
+      );
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to queue Smart Scan batch.",
+      );
+    }
+  }
 
   const isTogglingActive = isEnabling || isDisabling;
   const n = initialNetwork;
@@ -685,6 +712,17 @@ function NetworkDetailPanel({
           >
             <Radar className="h-3 w-3 mr-1" />
             Scan hosts
+          </Button>
+
+          <Button
+            variant="secondary"
+            onClick={() => setShowSmartScanPreview(true)}
+            disabled={isSuggestionsLoading}
+            title="Queue the next recommended scan for all eligible hosts"
+            className="text-xs h-7 px-3"
+          >
+            <Zap className="h-3 w-3 mr-1" />
+            Smart Scan
           </Button>
 
           {showDeleteConfirm ? (
@@ -840,6 +878,16 @@ function NetworkDetailPanel({
 
       {showScanModal && (
         <ScanNetworkModal network={n} onClose={() => setShowScanModal(false)} />
+      )}
+
+      {showSmartScanPreview && smartScanSuggestions && (
+        <BatchSmartScanPreviewModal
+          networkName={n.name ?? n.cidr ?? "Network"}
+          summary={smartScanSuggestions}
+          isPending={isBatchPending}
+          onConfirm={() => void handleSmartScanBatch()}
+          onClose={() => setShowSmartScanPreview(false)}
+        />
       )}
     </>
   );

--- a/frontend/src/routes/networks.tsx
+++ b/frontend/src/routes/networks.tsx
@@ -560,7 +560,7 @@ function NetworkDetailPanel({
 
   async function handleSmartScanBatch() {
     try {
-      const result = await triggerBatch({});
+      const result = await triggerBatch({ network_cidr: n.cidr ?? undefined });
       setShowSmartScanPreview(false);
       toast.success(
         result.queued === 0

--- a/internal/api/handlers/smartscan.go
+++ b/internal/api/handlers/smartscan.go
@@ -177,9 +177,10 @@ func (h *SmartScanHandler) TriggerBatch(w http.ResponseWriter, r *http.Request) 
 	}
 
 	result, err := h.service.QueueBatch(r.Context(), services.BatchFilter{
-		Stage:   req.Stage,
-		HostIDs: hostIDs,
-		Limit:   req.Limit,
+		Stage:       req.Stage,
+		HostIDs:     hostIDs,
+		NetworkCIDR: req.NetworkCIDR,
+		Limit:       req.Limit,
 	})
 	if err != nil {
 		h.logger.Error("Failed to queue batch smart scan", "error", err)
@@ -190,9 +191,10 @@ func (h *SmartScanHandler) TriggerBatch(w http.ResponseWriter, r *http.Request) 
 }
 
 type triggerBatchRequest struct {
-	Stage   string   `json:"stage"`
-	HostIDs []string `json:"host_ids"`
-	Limit   int      `json:"limit"`
+	Stage       string   `json:"stage"`
+	HostIDs     []string `json:"host_ids"`
+	NetworkCIDR string   `json:"network_cidr"`
+	Limit       int      `json:"limit"`
 }
 
 // parseHostID extracts the host UUID from the path variable {id}.

--- a/internal/services/smartscan.go
+++ b/internal/services/smartscan.go
@@ -58,9 +58,10 @@ type SuggestionSummary struct {
 
 // BatchFilter constrains which hosts to include in a batch smart-scan trigger.
 type BatchFilter struct {
-	Stage   string      // empty = all eligible stages; otherwise one of ScanStage.Stage values
-	HostIDs []uuid.UUID // non-empty = only these hosts; empty = all hosts
-	Limit   int         // max hosts to queue; 0 = use defaultBatchLimit
+	Stage       string      // empty = all eligible stages; otherwise one of ScanStage.Stage values
+	HostIDs     []uuid.UUID // non-empty = only these hosts; empty = all hosts
+	NetworkCIDR string      // non-empty = only hosts whose IP falls within this CIDR
+	Limit       int         // max hosts to queue; 0 = use defaultBatchLimit
 }
 
 // BatchResult summarizes the outcome of a QueueBatch call.
@@ -444,7 +445,10 @@ func (s *SmartScanService) resolveHosts(ctx context.Context, filter BatchFilter)
 	}
 
 	// Fetch only up hosts to avoid wasting the query budget on gone/ignored entries.
-	hosts, _, err := s.hostRepo.ListHosts(ctx, &db.HostFilters{Status: "up"}, 0, maxBatchHostsQuery)
+	hosts, _, err := s.hostRepo.ListHosts(ctx, &db.HostFilters{
+		Status:  "up",
+		Network: filter.NetworkCIDR,
+	}, 0, maxBatchHostsQuery)
 	return hosts, err
 }
 


### PR DESCRIPTION
## Summary

- Adds a **Smart Scan** button to the host detail panel alongside the existing Scan button
- Adds a **Smart Scan** button to the network detail panel alongside Discover and Scan hosts
- Before any scan is queued, a **preview modal** explains what will happen and requires confirmation
- Extends the batch trigger backend to accept a `network_cidr` filter, scoping network-panel Smart Scans to hosts within that network's CIDR

### Host Smart Scan flow
1. Click Smart Scan in the host detail footer
2. Button shows a loading spinner while the stage is fetched via `GET /smart-scan/hosts/{id}/stage`
3. Preview modal shows the recommended stage (OS detection / port expansion / service scan / refresh / skip), scan type, port spec, and reason
4. If stage is not `skip`, user clicks Run Smart Scan → `POST /smart-scan/hosts/{id}/trigger`
5. Button is disabled when a scan is already pending for the host

### Network batch Smart Scan flow
1. Click Smart Scan in the network detail action bar
2. Preview modal loads `GET /smart-scan/suggestions` and shows fleet-wide gap counts grouped by category (no OS / no ports / no services / stale)
3. User clicks Run Smart Scan → `POST /smart-scan/trigger-batch` with `network_cidr` set to scope the batch to hosts in this network (up to 50 hosts)

### Backend changes
- `BatchFilter` gains a `NetworkCIDR` field; when non-empty, `resolveHosts` filters by `HostFilters.Network` (CIDR match)
- `triggerBatchRequest` and swagger mirror struct gain `network_cidr`
- Swagger spec and frontend types regenerated

## Test plan

- Open a host detail panel — verify both Scan and Smart Scan buttons appear side by side
- Click Smart Scan on a host with known gaps — verify the preview modal describes the recommended stage
- Click Smart Scan on a host whose knowledge score ≥ 80 — verify the modal shows "No action needed" with no Confirm button
- Click Run Smart Scan — verify a success toast appears and the scan appears in the scan list
- With a pending scan already running for a host, verify the Smart Scan button is disabled
- Open a network detail panel — verify Smart Scan button appears in the action bar
- Click Smart Scan on a network — verify the preview modal lists gap counts per category
- Confirm — verify a toast reports how many hosts were queued, and only hosts within the network CIDR are targeted

Closes #661
Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)