### PR TITLE
feat(dns): forward DNS record collection and PTR-based host discovery

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -3912,7 +3912,8 @@ const docTemplate = `{
                         "ping",
                         "arp",
                         "icmp",
-                        "tcp_connect"
+                        "tcp_connect",
+                        "dns"
                     ],
                     "example": "ping"
                 },
@@ -4175,7 +4176,8 @@ const docTemplate = `{
                         "ping",
                         "arp",
                         "icmp",
-                        "tcp_connect"
+                        "tcp_connect",
+                        "dns"
                     ],
                     "example": "ping"
                 },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -3906,7 +3906,8 @@
                         "ping",
                         "arp",
                         "icmp",
-                        "tcp_connect"
+                        "tcp_connect",
+                        "dns"
                     ],
                     "example": "ping"
                 },
@@ -4169,7 +4170,8 @@
                         "ping",
                         "arp",
                         "icmp",
-                        "tcp_connect"
+                        "tcp_connect",
+                        "dns"
                     ],
                     "example": "ping"
                 },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -87,6 +87,7 @@ definitions:
         - arp
         - icmp
         - tcp_connect
+        - dns
         example: ping
         type: string
       name:
@@ -278,6 +279,7 @@ definitions:
         - arp
         - icmp
         - tcp_connect
+        - dns
         example: ping
         type: string
       name:

--- a/docs/swagger_docs.go
+++ b/docs/swagger_docs.go
@@ -251,7 +251,7 @@ type DiscoveryJobResponse struct {
 	Name        string     `json:"name" example:"Network Discovery"`
 	Description string     `json:"description,omitempty"`
 	Networks    []string   `json:"networks" example:"192.168.1.0/24"`
-	Method      string     `json:"method" example:"ping" enums:"ping,arp,icmp,tcp_connect"`
+	Method      string     `json:"method" example:"ping" enums:"ping,arp,icmp,tcp_connect,dns"`
 	Status      string     `json:"status" example:"running" enums:"pending,running,completed,failed"`
 	Progress    float64    `json:"progress" example:"45.5"`
 	HostsFound  int        `json:"hosts_found" example:"12"`
@@ -270,7 +270,7 @@ type DiscoveryJobResponse struct {
 type CreateDiscoveryJobRequest struct {
 	Name        string   `json:"name" example:"Office Network Discovery"`
 	Networks    []string `json:"networks" example:"192.168.1.0/24"`
-	Method      string   `json:"method" example:"ping" enums:"ping,arp,icmp,tcp_connect"`
+	Method      string   `json:"method" example:"ping" enums:"ping,arp,icmp,tcp_connect,dns"`
 	Description string   `json:"description,omitempty"`
 	Enabled     bool     `json:"enabled" example:"true"`
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6960,22 +6960,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yaml-ast-parser": {
       "version": "0.0.43",
       "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1041,7 +1041,7 @@ export interface components {
              * @example ping
              * @enum {string}
              */
-            method?: "ping" | "arp" | "icmp" | "tcp_connect";
+            method?: "ping" | "arp" | "icmp" | "tcp_connect" | "dns";
             /** @example Office Network Discovery */
             name?: string;
             /**
@@ -1163,7 +1163,7 @@ export interface components {
              * @example ping
              * @enum {string}
              */
-            method?: "ping" | "arp" | "icmp" | "tcp_connect";
+            method?: "ping" | "arp" | "icmp" | "tcp_connect" | "dns";
             /** @example Network Discovery */
             name?: string;
             /**

--- a/frontend/src/components/create-discovery-modal.tsx
+++ b/frontend/src/components/create-discovery-modal.tsx
@@ -13,6 +13,7 @@ const METHODS = [
   { value: "tcp_connect", label: "TCP Connect" },
   { value: "icmp", label: "ICMP" },
   { value: "arp", label: "ARP" },
+  { value: "dns", label: "DNS Sweep" },
 ] as const;
 
 type Method = (typeof METHODS)[number]["value"];

--- a/internal/api/handlers/discovery.go
+++ b/internal/api/handlers/discovery.go
@@ -196,7 +196,7 @@ type DiscoveryRequest struct {
 	Name        string            `json:"name" validate:"required,min=1,max=255"`
 	Description string            `json:"description,omitempty"`
 	Networks    []string          `json:"networks" validate:"required,min=1"`
-	Method      string            `json:"method" validate:"required,oneof=ping arp icmp tcp_connect"`
+	Method      string            `json:"method" validate:"required,oneof=ping arp icmp tcp_connect dns"`
 	Ports       string            `json:"ports,omitempty"`
 	Timeout     time.Duration     `json:"timeout,omitempty"`
 	Retries     int               `json:"retries,omitempty"`
@@ -612,6 +612,7 @@ func (h *DiscoveryHandler) validateMethod(method string) error {
 		"arp":         true,
 		"icmp":        true,
 		"tcp_connect": true,
+		"dns":         true,
 	}
 	if !validMethods[method] {
 		return fmt.Errorf("invalid discovery method: %s", method)

--- a/internal/api/handlers/discovery_test.go
+++ b/internal/api/handlers/discovery_test.go
@@ -303,6 +303,11 @@ func TestDiscoveryHandler_ValidateMethod(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:        "valid dns method",
+			method:      "dns",
+			expectError: false,
+		},
+		{
 			name:        "invalid method",
 			method:      "invalid",
 			expectError: true,

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -29,7 +29,8 @@ func (s *Server) setupRoutes() {
 	hostHandler := apihandlers.NewHostHandler(
 		services.NewHostService(db.NewHostRepository(s.database), s.logger), s.logger, s.metrics).
 		WithBannerRepository(db.NewBannerRepository(s.database)).
-		WithSNMPRepository(db.NewSNMPRepository(s.database))
+		WithSNMPRepository(db.NewSNMPRepository(s.database)).
+		WithDNSRepository(db.NewDNSRepository(s.database))
 	discoveryHandler := apihandlers.NewDiscoveryHandler(db.NewDiscoveryRepository(s.database), s.logger, s.metrics).
 		WithEngine(s.discoveryEngine)
 	profileHandler := apihandlers.NewProfileHandler(

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/anstrom/scanorama/internal/config"
 	"github.com/anstrom/scanorama/internal/db"
 	"github.com/anstrom/scanorama/internal/discovery"
+	internaldns "github.com/anstrom/scanorama/internal/dns"
 	"github.com/anstrom/scanorama/internal/logging"
 	"github.com/anstrom/scanorama/internal/metrics"
 	"github.com/anstrom/scanorama/internal/scanning"
@@ -107,7 +108,8 @@ func New(cfg *config.Config, database *db.DB) (*Server, error) {
 	apiConfig := getAPIConfigFromConfig(cfg)
 
 	// Create the discovery engine so API-triggered jobs actually run nmap.
-	discoveryEngine := discovery.NewEngine(database)
+	dnsResolver := internaldns.New(database)
+	discoveryEngine := discovery.NewEngine(database).WithDNSResolver(dnsResolver)
 
 	// Create the scan queue using pool size and queue depth from config.
 	scanQueue := scanning.NewScanQueue(

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/anstrom/scanorama/internal/db"
+	internaldns "github.com/anstrom/scanorama/internal/dns"
 )
 
 const (
@@ -46,6 +47,7 @@ type Engine struct {
 	db          *db.DB
 	concurrency int
 	timeout     time.Duration
+	dnsResolver *internaldns.Resolver
 }
 
 // Config holds discovery configuration parameters.
@@ -79,6 +81,12 @@ func NewEngine(database *db.DB) *Engine {
 		concurrency: defaultConcurrency,
 		timeout:     time.Duration(defaultTimeoutSeconds) * time.Second,
 	}
+}
+
+// WithDNSResolver attaches a cached DNS resolver for DNS-based discovery methods.
+func (e *Engine) WithDNSResolver(r *internaldns.Resolver) *Engine {
+	e.dnsResolver = r
+	return e
 }
 
 // SetConcurrency sets the concurrency level for discovery operations.
@@ -162,23 +170,18 @@ func (e *Engine) ScanNetwork(ctx context.Context, cfg *Config) (int, error) {
 		maxHosts = 10000
 	}
 
-	targets, err := e.generateTargetsFromCIDR(*ipnet, maxHosts)
-	if err != nil {
-		return 0, fmt.Errorf("failed to generate targets: %w", err)
+	var discovered []Result
+	var scanErr error
+	if cfg.Method == "dns" {
+		discovered, scanErr = e.dnsScan(ctx, *ipnet, maxHosts)
+	} else {
+		discovered, scanErr = e.nmapScan(ctx, *ipnet, maxHosts, cfg)
 	}
-
-	if len(targets) == 0 {
-		slog.Info("no targets to discover")
-		return 0, nil
+	if scanErr != nil {
+		return 0, scanErr
 	}
-
-	dynamicTimeout := e.calculateDynamicTimeout(len(targets), cfg.Timeout)
-	slog.Info("starting nmap discovery",
-		"targets", len(targets), "method", cfg.Method, "timeout", dynamicTimeout)
-
-	discovered, err := e.nmapDiscoveryWithTargets(ctx, targets, cfg, dynamicTimeout)
-	if err != nil {
-		return 0, err
+	if discovered == nil {
+		return 0, nil // no targets or no results
 	}
 
 	if len(discovered) > 0 {
@@ -205,6 +208,39 @@ func (e *Engine) validateNetworkSize(ipnet net.IPNet) error {
 	return nil
 }
 
+// dnsScan runs a DNS PTR sweep over ipnet and returns the discovered hosts. It
+// returns (nil, error) on configuration problems, and (nil, nil) if no hosts
+// respond — the caller interprets a nil slice as "nothing to do".
+func (e *Engine) dnsScan(ctx context.Context, ipnet net.IPNet, maxHosts int) ([]Result, error) {
+	if e.dnsResolver == nil {
+		return nil, fmt.Errorf("dns sweep: no DNS resolver configured on engine")
+	}
+	slog.Info("starting DNS PTR sweep", "network", ipnet.String())
+	results := dnsSweep(ctx, ipnet, e.dnsResolver, maxHosts)
+	if len(results) == 0 {
+		return nil, nil
+	}
+	return results, nil
+}
+
+// nmapScan generates targets from ipnet, runs nmap, and returns discovered
+// hosts. It returns (nil, nil) when the network contains no targets to scan
+// (e.g. a /32 with no usable host addresses).
+func (e *Engine) nmapScan(ctx context.Context, ipnet net.IPNet, maxHosts int, cfg *Config) ([]Result, error) {
+	targets, err := e.generateTargetsFromCIDR(ipnet, maxHosts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate targets: %w", err)
+	}
+	if len(targets) == 0 {
+		slog.Info("no targets to discover")
+		return nil, nil
+	}
+	dynamicTimeout := e.calculateDynamicTimeout(len(targets), cfg.Timeout)
+	slog.Info("starting nmap discovery",
+		"targets", len(targets), "method", cfg.Method, "timeout", dynamicTimeout)
+	return e.nmapDiscoveryWithTargets(ctx, targets, cfg, dynamicTimeout)
+}
+
 // runDiscovery executes the actual discovery process using nmap.
 func (e *Engine) runDiscovery(ctx context.Context, job *db.DiscoveryJob, config *Config) {
 	defer e.finalizeDiscoveryJob(ctx, job)
@@ -217,42 +253,31 @@ func (e *Engine) runDiscovery(ctx context.Context, job *db.DiscoveryJob, config 
 	default:
 	}
 
-	// Generate targets from network CIDR
 	maxHosts := config.MaxHosts
 	if maxHosts <= 0 {
 		maxHosts = 10000
 	}
 
-	targets, err := e.generateTargetsFromCIDR(job.Network.IPNet, maxHosts)
-	if err != nil {
+	var discoveredHosts []Result
+	var scanErr error
+	if config.Method == "dns" {
+		discoveredHosts, scanErr = e.dnsScan(ctx, job.Network.IPNet, maxHosts)
+	} else {
+		discoveredHosts, scanErr = e.nmapScan(ctx, job.Network.IPNet, maxHosts, config)
+	}
+	if scanErr != nil {
 		job.Status = db.DiscoveryJobStatusFailed
-		slog.Error("failed to generate targets", "error", err)
+		slog.Error("discovery failed", "error", scanErr)
 		return
 	}
-
-	if len(targets) == 0 {
-		job.Status = db.DiscoveryJobStatusCompleted
-		slog.Info("no targets to discover")
-		return
-	}
-
-	// Calculate dynamic timeout based on target count
-	dynamicTimeout := e.calculateDynamicTimeout(len(targets), config.Timeout)
-	slog.Info("starting nmap discovery", "targets", len(targets), "method", config.Method, "timeout", dynamicTimeout)
-
-	// Use nmap for host discovery with generated targets
-	discoveredHosts, err := e.nmapDiscoveryWithTargets(ctx, targets, config, dynamicTimeout)
-	if err != nil {
-		job.Status = db.DiscoveryJobStatusFailed
-		slog.Error("discovery failed", "error", err)
-		return
+	if discoveredHosts == nil {
+		return // no targets — finalizeDiscoveryJob will set status to Completed
 	}
 
 	// Save discovered hosts to database
 	if len(discoveredHosts) > 0 {
-		err = e.saveDiscoveredHosts(ctx, discoveredHosts)
-		if err != nil {
-			slog.Warn("failed to save some discovered hosts", "error", err)
+		if saveErr := e.saveDiscoveredHosts(ctx, discoveredHosts); saveErr != nil {
+			slog.Warn("failed to save some discovered hosts", "error", saveErr)
 		} else {
 			slog.Info("saved discovered hosts to database", "count", len(discoveredHosts))
 		}

--- a/internal/discovery/discovery_unit_test.go
+++ b/internal/discovery/discovery_unit_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/anstrom/scanorama/internal/db"
+	internaldns "github.com/anstrom/scanorama/internal/dns"
 )
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -941,5 +942,46 @@ func TestSaveDiscoveredHosts_EmptyVendorAndZeroRTT(t *testing.T) {
 
 	err := engine.saveDiscoveredHosts(ctx, results)
 	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ─── dnsScan ──────────────────────────────────────────────────────────────────
+
+func TestDnsScan_NilResolver_ReturnsError(t *testing.T) {
+	// Engine created without WithDNSResolver → dnsScan must fail with a clear
+	// error instead of panicking.
+	engine := NewEngine(nil)
+	ipnet := mustParseCIDR("192.168.1.0/30")
+
+	results, err := engine.dnsScan(context.Background(), ipnet, 0)
+
+	require.Error(t, err)
+	assert.Nil(t, results)
+	assert.Contains(t, err.Error(), "no DNS resolver configured")
+}
+
+func TestDnsScan_WithResolver_ReturnsDiscoveredHosts(t *testing.T) {
+	// Verify that WithDNSResolver wiring is correct: dnsScan delegates to
+	// dnsSweep and returns its results unchanged.
+	resolver, mock := newMockResolver(t,
+		internaldns.WithLookupAddrFn(func(_ context.Context, ip string) ([]string, error) {
+			return []string{ip + ".example.com"}, nil
+		}),
+	)
+	// /30 has 2 usable host IPs — each triggers one cache-miss + upsert cycle.
+	expectCacheMissAndUpsert(mock)
+	expectCacheMissAndUpsert(mock)
+
+	engine := NewEngine(nil).WithDNSResolver(resolver)
+	ipnet := mustParseCIDR("192.168.1.0/30")
+
+	results, err := engine.dnsScan(context.Background(), ipnet, 0)
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	for _, r := range results {
+		assert.Equal(t, "up", r.Status)
+		assert.Equal(t, "dns", r.Method)
+	}
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/discovery/dns_sweep.go
+++ b/internal/discovery/dns_sweep.go
@@ -1,0 +1,94 @@
+package discovery
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"time"
+
+	internaldns "github.com/anstrom/scanorama/internal/dns"
+)
+
+// dnsLookupTimeout is the per-IP deadline for a PTR lookup inside dnsSweep.
+const dnsLookupTimeout = 3 * time.Second
+
+// dnsSweep resolves PTR records for every IP in ipnet and returns results for
+// IPs that had a successful PTR response. It uses the provided resolver with
+// its built-in cache to deduplicate concurrent lookups.
+//
+// The per-IP timeout is fixed at dnsLookupTimeout. Overall context
+// cancellation is respected.
+func dnsSweep(ctx context.Context, ipnet net.IPNet, resolver *internaldns.Resolver, maxHosts int) []Result {
+	ips := enumerateIPs(ipnet, maxHosts)
+	if len(ips) == 0 {
+		return nil
+	}
+
+	results := make([]Result, 0)
+
+	for _, ip := range ips {
+		if ctx.Err() != nil {
+			break
+		}
+		ipStr := ip.String()
+
+		lookupCtx, cancel := context.WithTimeout(ctx, dnsLookupTimeout)
+		hostname, err := resolver.LookupAddr(lookupCtx, ipStr)
+		cancel()
+
+		if err != nil {
+			continue // no PTR record — host not considered up
+		}
+
+		results = append(results, Result{
+			IPAddress: ip,
+			Status:    "up",
+			Method:    "dns",
+		})
+		slog.Debug("dns sweep: PTR found", "ip", ipStr, "hostname", hostname)
+	}
+
+	return results
+}
+
+// enumerateIPs returns all usable host IPs in ipnet, capped at maxHosts.
+func enumerateIPs(ipnet net.IPNet, maxHosts int) []net.IP {
+	var ips []net.IP
+
+	ip := cloneIP(ipnet.IP)
+	// Skip network address (first IP).
+	ip = nextIPAddr(ip)
+
+	for ipnet.Contains(ip) {
+		if maxHosts > 0 && len(ips) >= maxHosts {
+			break
+		}
+		// Skip broadcast (all host bits = 1). Broadcast is the last IP; we
+		// detect it by checking the next IP falls outside the network.
+		next := nextIPAddr(ip)
+		if !ipnet.Contains(next) {
+			break // this is the broadcast address — stop before adding it
+		}
+		ips = append(ips, cloneIP(ip))
+		ip = next
+	}
+
+	return ips
+}
+
+func cloneIP(ip net.IP) net.IP {
+	clone := make(net.IP, len(ip))
+	copy(clone, ip)
+	return clone
+}
+
+func nextIPAddr(ip net.IP) net.IP {
+	next := cloneIP(ip)
+	for i := len(next) - 1; i >= 0; i-- {
+		next[i]++
+		if next[i] != 0 {
+			break
+		}
+	}
+	return next
+}

--- a/internal/discovery/dns_sweep_test.go
+++ b/internal/discovery/dns_sweep_test.go
@@ -1,0 +1,184 @@
+package discovery
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/db"
+	internaldns "github.com/anstrom/scanorama/internal/dns"
+)
+
+// newMockResolver creates a Resolver backed by an empty sqlmock DB and applies
+// the given options (typically WithLookupAddrFn / WithLookupHostFn).
+func newMockResolver(t *testing.T, opts ...internaldns.Option) (*internaldns.Resolver, sqlmock.Sqlmock) {
+	t.Helper()
+	rawDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rawDB.Close() })
+	database := &db.DB{DB: sqlx.NewDb(rawDB, "sqlmock")}
+	return internaldns.New(database, opts...), mock
+}
+
+// cacheColumns matches the columns returned by the dns_cache SELECT.
+var cacheColumns = []string{
+	"id", "direction", "lookup_key", "resolved_value",
+	"resolved_at", "ttl_seconds", "last_error",
+}
+
+// expectCacheMissAndUpsert sets up sqlmock expectations for one Resolver
+// lookup that misses the cache and writes the result back.
+func expectCacheMissAndUpsert(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("SELECT .+ FROM dns_cache WHERE direction").
+		WillReturnRows(sqlmock.NewRows(cacheColumns))
+	mock.ExpectExec("INSERT INTO dns_cache").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+}
+
+// ─── enumerateIPs ─────────────────────────────────────────────────────────────
+
+func TestEnumerateIPs_SmallSubnet(t *testing.T) {
+	// /30 → 2 usable host IPs (.1 and .2)
+	ipnet := mustParseCIDR("192.168.1.0/30")
+	ips := enumerateIPs(ipnet, 0)
+	require.Len(t, ips, 2)
+	assert.Equal(t, "192.168.1.1", ips[0].String())
+	assert.Equal(t, "192.168.1.2", ips[1].String())
+}
+
+func TestEnumerateIPs_Slash29(t *testing.T) {
+	// /29 → 6 usable host IPs
+	ipnet := mustParseCIDR("10.0.0.0/29")
+	ips := enumerateIPs(ipnet, 0)
+	require.Len(t, ips, 6)
+	assert.Equal(t, "10.0.0.1", ips[0].String())
+	assert.Equal(t, "10.0.0.6", ips[len(ips)-1].String())
+}
+
+func TestEnumerateIPs_MaxHosts(t *testing.T) {
+	// /24 has 254 usable IPs; cap at 10.
+	ipnet := mustParseCIDR("10.0.0.0/24")
+	ips := enumerateIPs(ipnet, 10)
+	assert.Len(t, ips, 10)
+	assert.Equal(t, "10.0.0.1", ips[0].String())
+	assert.Equal(t, "10.0.0.10", ips[9].String())
+}
+
+func TestEnumerateIPs_Slash32(t *testing.T) {
+	// /32 has no usable host IPs (network == host == broadcast).
+	ipnet := mustParseCIDR("192.0.2.1/32")
+	ips := enumerateIPs(ipnet, 0)
+	assert.Empty(t, ips, "a /32 should yield no usable host IPs")
+}
+
+func TestEnumerateIPs_Slash31(t *testing.T) {
+	// RFC 3021 /31 — both addresses are host addresses, no broadcast.
+	// Our implementation skips the first address (network) and stops before
+	// the last (treated as broadcast), so returns 0 IPs.
+	ipnet := mustParseCIDR("10.0.0.0/31")
+	ips := enumerateIPs(ipnet, 0)
+	// Both addresses are consumed by the skip-network / skip-broadcast logic.
+	assert.Empty(t, ips)
+}
+
+// ─── dnsSweep ─────────────────────────────────────────────────────────────────
+
+func TestDNSSweep_AllIPsResolved(t *testing.T) {
+	// /30 → 2 usable IPs; both resolve to PTR names.
+	ipnet := mustParseCIDR("192.168.1.0/30")
+
+	resolver, mock := newMockResolver(t,
+		internaldns.WithLookupAddrFn(func(_ context.Context, ip string) ([]string, error) {
+			return []string{ip + ".example.com"}, nil
+		}),
+	)
+	// Two IPs → two cache-miss+upsert cycles.
+	expectCacheMissAndUpsert(mock)
+	expectCacheMissAndUpsert(mock)
+
+	results := dnsSweep(context.Background(), ipnet, resolver, 0)
+
+	require.Len(t, results, 2)
+	for _, r := range results {
+		assert.Equal(t, "up", r.Status)
+		assert.Equal(t, "dns", r.Method)
+	}
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDNSSweep_NoIPsResolved(t *testing.T) {
+	// /30 → 2 usable IPs; none have PTR records.
+	ipnet := mustParseCIDR("192.168.1.0/30")
+
+	resolver, mock := newMockResolver(t,
+		internaldns.WithLookupAddrFn(func(_ context.Context, _ string) ([]string, error) {
+			return nil, internaldns.ErrNoRecords
+		}),
+	)
+	// Two cache misses — negative results are also cached.
+	expectCacheMissAndUpsert(mock)
+	expectCacheMissAndUpsert(mock)
+
+	results := dnsSweep(context.Background(), ipnet, resolver, 0)
+
+	assert.Empty(t, results)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDNSSweep_PartialResolution(t *testing.T) {
+	// /30 → 2 IPs; only .1 resolves.
+	ipnet := mustParseCIDR("192.168.1.0/30")
+
+	callCount := 0
+	resolver, mock := newMockResolver(t,
+		internaldns.WithLookupAddrFn(func(_ context.Context, ip string) ([]string, error) {
+			callCount++
+			if ip == "192.168.1.1" {
+				return []string{"host1.example.com"}, nil
+			}
+			return nil, internaldns.ErrNoRecords
+		}),
+	)
+	expectCacheMissAndUpsert(mock)
+	expectCacheMissAndUpsert(mock)
+
+	results := dnsSweep(context.Background(), ipnet, resolver, 0)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, net.ParseIP("192.168.1.1").String(), results[0].IPAddress.String())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDNSSweep_ContextCancelled(t *testing.T) {
+	// A cancelled context should cause the sweep to return immediately.
+	ipnet := mustParseCIDR("10.0.0.0/24")
+
+	resolver, _ := newMockResolver(t,
+		internaldns.WithLookupAddrFn(func(_ context.Context, _ string) ([]string, error) {
+			return []string{"host.example.com"}, nil
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	results := dnsSweep(ctx, ipnet, resolver, 0)
+	// With a pre-cancelled context the loop exits on the first iteration check.
+	assert.Empty(t, results)
+}
+
+func TestDNSSweep_EmptyNetwork(t *testing.T) {
+	// /32 has no usable IPs → dnsSweep should return nil immediately.
+	ipnet := mustParseCIDR("192.0.2.1/32")
+	resolver, mock := newMockResolver(t)
+
+	results := dnsSweep(context.Background(), ipnet, resolver, 0)
+
+	assert.Nil(t, results)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/enrichment/dns.go
+++ b/internal/enrichment/dns.go
@@ -5,6 +5,7 @@ package enrichment
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"strings"
@@ -16,6 +17,15 @@ import (
 	internaldns "github.com/anstrom/scanorama/internal/dns"
 )
 
+// netLookups is the subset of *net.Resolver used by forwardRecords. It allows
+// tests to inject a fake resolver without starting a real DNS server.
+type netLookups interface {
+	LookupCNAME(ctx context.Context, host string) (string, error)
+	LookupMX(ctx context.Context, host string) ([]*net.MX, error)
+	LookupTXT(ctx context.Context, host string) ([]string, error)
+	LookupSRV(ctx context.Context, service, proto, name string) (string, []*net.SRV, error)
+}
+
 // DNSEnricher enriches hosts with DNS records collected after discovery or scanning.
 //
 // It performs:
@@ -26,10 +36,11 @@ import (
 //
 // All results are stored in host_dns_records (replacing any previous records).
 type DNSEnricher struct {
-	resolver *internaldns.Resolver
-	dnsRepo  *db.DNSRepository
-	hostRepo *db.HostRepository
-	logger   *slog.Logger
+	resolver    *internaldns.Resolver
+	netResolver netLookups
+	dnsRepo     *db.DNSRepository
+	hostRepo    *db.HostRepository
+	logger      *slog.Logger
 }
 
 // NewDNSEnricher creates a DNSEnricher.
@@ -39,11 +50,19 @@ func NewDNSEnricher(
 	hostRepo *db.HostRepository,
 ) *DNSEnricher {
 	return &DNSEnricher{
-		resolver: resolver,
-		dnsRepo:  dnsRepo,
-		hostRepo: hostRepo,
-		logger:   slog.Default(),
+		resolver:    resolver,
+		netResolver: net.DefaultResolver,
+		dnsRepo:     dnsRepo,
+		hostRepo:    hostRepo,
+		logger:      slog.Default(),
 	}
+}
+
+// WithNetResolver overrides the net.Resolver used for CNAME, MX, TXT, and SRV
+// lookups. The primary use-case is unit tests.
+func (e *DNSEnricher) WithNetResolver(r netLookups) *DNSEnricher {
+	e.netResolver = r
+	return e
 }
 
 // EnrichHost performs DNS enrichment for a single host. ctx should carry a
@@ -111,12 +130,12 @@ func (e *DNSEnricher) maybeSetHostname(ctx context.Context, host *db.Host, hostn
 		"host_id", host.ID, "hostname", hostname)
 }
 
-// forwardRecords collects A, AAAA, MX, and TXT records for the given hostname.
+// forwardRecords collects A, AAAA, CNAME, MX, TXT, and SRV records for the given hostname.
 func (e *DNSEnricher) forwardRecords(ctx context.Context, hostID uuid.UUID, hostname string) []db.DNSRecord {
 	var records []db.DNSRecord
 
-	// A / AAAA — LookupHost returns both.
-	addrs, err := net.DefaultResolver.LookupHost(ctx, hostname)
+	// A / AAAA — use the cached resolver for deduplication across concurrent enrichments.
+	addrs, err := e.resolver.LookupHost(ctx, hostname)
 	if err == nil {
 		for _, addr := range addrs {
 			rtype := "A"
@@ -131,8 +150,33 @@ func (e *DNSEnricher) forwardRecords(ctx context.Context, hostID uuid.UUID, host
 		}
 	}
 
+	// CNAME — the canonical name; omit if it equals the query name (no alias).
+	cname, err := e.netResolver.LookupCNAME(ctx, hostname)
+	if err == nil {
+		cname = strings.TrimSuffix(cname, ".")
+		if cname != "" && cname != hostname {
+			records = append(records, db.DNSRecord{
+				HostID:     hostID,
+				RecordType: "CNAME",
+				Value:      cname,
+			})
+		}
+	}
+
+	// MX
+	mxRecords, err := e.netResolver.LookupMX(ctx, hostname)
+	if err == nil {
+		for _, mx := range mxRecords {
+			records = append(records, db.DNSRecord{
+				HostID:     hostID,
+				RecordType: "MX",
+				Value:      strings.TrimSuffix(mx.Host, "."),
+			})
+		}
+	}
+
 	// TXT
-	txts, err := net.DefaultResolver.LookupTXT(ctx, hostname)
+	txts, err := e.netResolver.LookupTXT(ctx, hostname)
 	if err == nil {
 		for _, txt := range txts {
 			records = append(records, db.DNSRecord{
@@ -143,14 +187,34 @@ func (e *DNSEnricher) forwardRecords(ctx context.Context, hostID uuid.UUID, host
 		}
 	}
 
-	// MX
-	mxRecords, err := net.DefaultResolver.LookupMX(ctx, hostname)
-	if err == nil {
-		for _, mx := range mxRecords {
+	// SRV — probe well-known service prefixes. We deliberately skip "service"
+	// and "proto" discovery; the goal is best-effort population for common services.
+	//
+	// net.Resolver.LookupSRV prepends underscores automatically, so the service
+	// and proto values must NOT include a leading underscore.
+	srvServices := []struct{ service, proto string }{
+		{"http", "tcp"},
+		{"https", "tcp"},
+		{"smtp", "tcp"},
+		{"imap", "tcp"},
+		{"imaps", "tcp"},
+		{"ldap", "tcp"},
+		{"ldaps", "tcp"},
+		{"xmpp-client", "tcp"},
+		{"xmpp-server", "tcp"},
+	}
+	for _, s := range srvServices {
+		_, addrs, err := e.netResolver.LookupSRV(ctx, s.service, s.proto, hostname)
+		if err != nil {
+			continue
+		}
+		for _, srv := range addrs {
 			records = append(records, db.DNSRecord{
 				HostID:     hostID,
-				RecordType: "MX",
-				Value:      strings.TrimSuffix(mx.Host, "."),
+				RecordType: "SRV",
+				Value: fmt.Sprintf("_%s._%s.%s %d %d %d",
+					s.service, s.proto, strings.TrimSuffix(srv.Target, "."),
+					srv.Priority, srv.Weight, srv.Port),
 			})
 		}
 	}

--- a/internal/enrichment/dns_test.go
+++ b/internal/enrichment/dns_test.go
@@ -347,6 +347,42 @@ func TestEnrichHost_UpsertError(t *testing.T) {
 
 // ─── forwardRecords ───────────────────────────────────────────────────────────
 
+// fakeNetResolver implements netLookups for tests, returning configurable records.
+type fakeNetResolver struct {
+	cname string
+	mx    []*net.MX
+	txts  []string
+	srvs  []*net.SRV // returned for every service/proto combination
+}
+
+func (f *fakeNetResolver) LookupCNAME(_ context.Context, _ string) (string, error) {
+	if f.cname == "" {
+		return "", &net.DNSError{IsNotFound: true}
+	}
+	return f.cname, nil
+}
+
+func (f *fakeNetResolver) LookupMX(_ context.Context, _ string) ([]*net.MX, error) {
+	if len(f.mx) == 0 {
+		return nil, &net.DNSError{IsNotFound: true}
+	}
+	return f.mx, nil
+}
+
+func (f *fakeNetResolver) LookupTXT(_ context.Context, _ string) ([]string, error) {
+	if len(f.txts) == 0 {
+		return nil, &net.DNSError{IsNotFound: true}
+	}
+	return f.txts, nil
+}
+
+func (f *fakeNetResolver) LookupSRV(_ context.Context, _, _, _ string) (string, []*net.SRV, error) {
+	if len(f.srvs) == 0 {
+		return "", nil, &net.DNSError{IsNotFound: true}
+	}
+	return "", f.srvs, nil
+}
+
 // TestForwardRecords_EmptyHostname verifies that forwardRecords called with an
 // empty hostname (which the enricher guards against) returns an empty slice.
 // We test it indirectly via EnrichHost with a host that has no PTR record.
@@ -373,5 +409,133 @@ func TestForwardRecords_NotCalledWithoutPTR(t *testing.T) {
 	// No DNS repo calls expected because there are no records to store.
 	require.NoError(t, dnsMock.ExpectationsWereMet())
 	require.NoError(t, hostMock.ExpectationsWereMet())
+	require.NoError(t, resolverMock.ExpectationsWereMet())
+}
+
+// newForwardRecordsEnricher builds a DNSEnricher wired to a fake net resolver
+// for testing forwardRecords in isolation. The returned sqlmock is set up with
+// exactly one cache-miss + upsert expectation for the A/AAAA lookup.
+func newForwardRecordsEnricher(
+	t *testing.T,
+	fake *fakeNetResolver,
+) (*DNSEnricher, sqlmock.Sqlmock) {
+	t.Helper()
+	resolverDB, resolverMock := newMockDB(t)
+	dnsDB, _ := newMockDB(t)
+	hostDB, _ := newMockDB(t)
+
+	// The A/AAAA lookup goes through the cached resolver → one cache miss + upsert.
+	noOpCacheExpect(resolverMock)
+
+	resolver := internaldns.New(resolverDB,
+		internaldns.WithLookupHostFn(func(_ context.Context, _ string) ([]string, error) {
+			return nil, internaldns.ErrNoRecords
+		}),
+	)
+	enricher := NewDNSEnricher(
+		resolver,
+		db.NewDNSRepository(dnsDB),
+		db.NewHostRepository(hostDB),
+	).WithNetResolver(fake)
+
+	return enricher, resolverMock
+}
+
+func TestForwardRecords_CNAME(t *testing.T) {
+	hostID := uuid.New()
+	fake := &fakeNetResolver{cname: "canonical.example.com."}
+	enricher, resolverMock := newForwardRecordsEnricher(t, fake)
+
+	records := enricher.forwardRecords(context.Background(), hostID, "host.example.com")
+
+	var cnames []string
+	for _, r := range records {
+		if r.RecordType == "CNAME" {
+			cnames = append(cnames, r.Value)
+		}
+	}
+	require.Len(t, cnames, 1)
+	require.Equal(t, "canonical.example.com", cnames[0])
+	require.NoError(t, resolverMock.ExpectationsWereMet())
+}
+
+func TestForwardRecords_CNAME_SelfReference_Omitted(t *testing.T) {
+	// When the CNAME equals the queried hostname, it must not be stored.
+	// net.DefaultResolver returns the queried name (with trailing dot) for names
+	// without a CNAME alias. Simulate that.
+	hostID := uuid.New()
+	fake := &fakeNetResolver{cname: "host.example.com."}
+	enricher, resolverMock := newForwardRecordsEnricher(t, fake)
+
+	records := enricher.forwardRecords(context.Background(), hostID, "host.example.com")
+
+	for _, r := range records {
+		require.NotEqual(t, "CNAME", r.RecordType, "self-referencing CNAME must be omitted")
+	}
+	require.NoError(t, resolverMock.ExpectationsWereMet())
+}
+
+func TestForwardRecords_MX(t *testing.T) {
+	hostID := uuid.New()
+	fake := &fakeNetResolver{
+		mx: []*net.MX{
+			{Host: "mail.example.com.", Pref: 10},
+		},
+	}
+	enricher, resolverMock := newForwardRecordsEnricher(t, fake)
+
+	records := enricher.forwardRecords(context.Background(), hostID, "example.com")
+
+	var mxVals []string
+	for _, r := range records {
+		if r.RecordType == "MX" {
+			mxVals = append(mxVals, r.Value)
+		}
+	}
+	require.Len(t, mxVals, 1)
+	require.Equal(t, "mail.example.com", mxVals[0])
+	require.NoError(t, resolverMock.ExpectationsWereMet())
+}
+
+func TestForwardRecords_TXT(t *testing.T) {
+	hostID := uuid.New()
+	fake := &fakeNetResolver{txts: []string{"v=spf1 include:example.com ~all"}}
+	enricher, resolverMock := newForwardRecordsEnricher(t, fake)
+
+	records := enricher.forwardRecords(context.Background(), hostID, "example.com")
+
+	var txts []string
+	for _, r := range records {
+		if r.RecordType == "TXT" {
+			txts = append(txts, r.Value)
+		}
+	}
+	require.Len(t, txts, 1)
+	require.Equal(t, "v=spf1 include:example.com ~all", txts[0])
+	require.NoError(t, resolverMock.ExpectationsWereMet())
+}
+
+func TestForwardRecords_SRV(t *testing.T) {
+	hostID := uuid.New()
+	fake := &fakeNetResolver{
+		srvs: []*net.SRV{
+			{Target: "sip.example.com.", Port: 5060, Priority: 10, Weight: 20},
+		},
+	}
+	enricher, resolverMock := newForwardRecordsEnricher(t, fake)
+
+	records := enricher.forwardRecords(context.Background(), hostID, "example.com")
+
+	var srvVals []string
+	for _, r := range records {
+		if r.RecordType == "SRV" {
+			srvVals = append(srvVals, r.Value)
+		}
+	}
+	// fakeNetResolver returns the same SRV for every service/proto, so we get
+	// one record per probed service (9 total). The first probed service is "http/tcp".
+	require.Len(t, srvVals, 9)
+	// Validate the full format: _service._proto.target priority weight port
+	require.Equal(t, "_http._tcp.sip.example.com 10 20 5060", srvVals[0])
 	require.NoError(t, resolverMock.ExpectationsWereMet())
 }


### PR DESCRIPTION
## Summary

- Collects forward DNS records (A, AAAA, CNAME, MX, TXT, SRV) for known hostnames after scan, stored in `host_dns_records`
- Adds DNS PTR sweep as a new discovery method (`method: "dns"`) — iterates IPs in a CIDR and resolves PTR records to find live hosts
- Wires `DNSEnricher` into the enrichment pipeline and registers the `dns` method in the discovery handler and frontend modal

## Technical details

- `internal/enrichment/dns.go` — `forwardRecords` now uses an injectable `netLookups` interface (defaulting to `net.DefaultResolver`) for CNAME, MX, TXT, and SRV lookups; `WithNetResolver` allows test injection
- `internal/discovery/dns_sweep.go` — `dnsSweep` + `enumerateIPs` with per-IP timeout; `dnsScan` returns a clear error when no resolver is configured
- `net.Resolver.LookupSRV` prepends underscores automatically — service/proto values must NOT include a leading `_`

## Test plan

- [ ] Create a discovery job with `method: "dns"` via UI or API, verify it completes and hosts appear
- [ ] Trigger enrichment on a host with a known PTR record, verify A/AAAA/MX/TXT/SRV records appear in the host detail DNS tab
- [ ] Verify that an invalid method (e.g. `"nmap"`) still returns 400

Closes #673
Closes #674