### PR TITLE
fix(scanning): strip T: prefix for TCP-only port specs (nmap 7.99)

### DIFF
--- a/internal/scanning/scan.go
+++ b/internal/scanning/scan.go
@@ -283,20 +283,31 @@ func createAndRunScanner(ctx context.Context, config *ScanConfig) (*nmap.Run, er
 	return result, nil
 }
 
-// buildScanOptions creates nmap options based on scan configuration.
-func buildScanOptions(config *ScanConfig) []nmap.Option {
-	// Mixed-protocol support: if the port spec contains UDP ports (e.g. "T:22,80,U:53,161"),
-	// add an explicit UDP scan so nmap handles both TCP and UDP in a single run.
-	// Skip when using connect scan (-sT): UDP scanning always requires root (-sU),
-	// and combining -sU with -sT produces no results when running unprivileged.
-	// Strip the T:/U: protocol prefixes from the port spec in that case so nmap
-	// doesn't complain about the mixed-protocol syntax without a UDP scan mode.
-	hasUDP := strings.Contains(config.Ports, "U:")
-	if hasUDP && config.ScanType == scanTypeConnect {
-		// Resolve before building the options slice to avoid index mutation.
+// normalizePortSpec strips redundant or unsupported T:/U: protocol prefixes
+// from config.Ports and returns whether UDP ports remain after normalization.
+//
+// Two cases require stripping:
+//  1. TCP-only spec (no U: ports): the T: prefix is a no-op for TCP scans and
+//     triggers a nmap 7.99 regression where -sS --privileged produces "0 hosts up".
+//  2. Connect scan with UDP ports: -sU requires raw sockets and can't be combined
+//     with -sT unprivileged; drop the UDP ports and strip all prefixes.
+func normalizePortSpec(config *ScanConfig) (hasUDP bool) {
+	ports := strings.ToUpper(config.Ports)
+	hasUDP = strings.Contains(ports, "U:")
+	hasTCPPrefix := strings.Contains(ports, "T:")
+	switch {
+	case !hasUDP && hasTCPPrefix:
+		config.Ports = stripProtocolPrefixes(config.Ports)
+	case hasUDP && config.ScanType == scanTypeConnect:
 		config.Ports = stripProtocolPrefixes(config.Ports)
 		hasUDP = false
 	}
+	return hasUDP
+}
+
+// buildScanOptions creates nmap options based on scan configuration.
+func buildScanOptions(config *ScanConfig) []nmap.Option {
+	hasUDP := normalizePortSpec(config)
 
 	options := []nmap.Option{
 		nmap.WithTargets(config.Targets...),

--- a/internal/scanning/scan_unit_test.go
+++ b/internal/scanning/scan_unit_test.go
@@ -1273,3 +1273,76 @@ func TestValidateTargets(t *testing.T) {
 		assert.Contains(t, err.Error(), "--script=vuln")
 	})
 }
+
+// TestBuildScanOptions_ProtocolPrefixStripping verifies that buildScanOptions
+// strips the T: prefix from TCP-only port specs to work around a nmap 7.99
+// regression where T: with -sS --privileged produces "0 hosts up".
+func TestBuildScanOptions_ProtocolPrefixStripping(t *testing.T) {
+	base := ScanConfig{
+		Targets: []string{"10.0.0.1"},
+	}
+
+	t.Run("T: prefix stripped for SYN scan (nmap 7.99 workaround)", func(t *testing.T) {
+		cfg := base
+		cfg.ScanType = scanTypeSYN
+		cfg.Ports = "T:22,80,443,8006"
+		buildScanOptions(&cfg)
+		assert.Equal(t, "22,80,443,8006", cfg.Ports)
+	})
+
+	t.Run("T: prefix stripped for connect scan with no UDP", func(t *testing.T) {
+		cfg := base
+		cfg.ScanType = scanTypeConnect
+		cfg.Ports = "T:22,80,443"
+		buildScanOptions(&cfg)
+		assert.Equal(t, "22,80,443", cfg.Ports)
+	})
+
+	t.Run("plain port spec unchanged", func(t *testing.T) {
+		cfg := base
+		cfg.ScanType = scanTypeSYN
+		cfg.Ports = "22,80,443,8006"
+		buildScanOptions(&cfg)
+		assert.Equal(t, "22,80,443,8006", cfg.Ports)
+	})
+
+	t.Run("mixed T:/U: spec preserved for privileged non-connect scan", func(t *testing.T) {
+		cfg := base
+		cfg.ScanType = scanTypeSYN
+		cfg.Ports = "T:22,80,U:53,161"
+		buildScanOptions(&cfg)
+		assert.Equal(t, "T:22,80,U:53,161", cfg.Ports)
+	})
+
+	t.Run("mixed T:/U: spec stripped for connect scan", func(t *testing.T) {
+		cfg := base
+		cfg.ScanType = scanTypeConnect
+		cfg.Ports = "T:22,80,U:53,161"
+		buildScanOptions(&cfg)
+		assert.Equal(t, "22,80,53,161", cfg.Ports)
+	})
+
+	t.Run("T: prefix stripped for aggressive scan (same nmap 7.99 workaround)", func(t *testing.T) {
+		cfg := base
+		cfg.ScanType = scanTypeAggressive
+		cfg.Ports = "T:22,80,443"
+		buildScanOptions(&cfg)
+		assert.Equal(t, "22,80,443", cfg.Ports)
+	})
+
+	t.Run("T: prefix stripped for comprehensive scan", func(t *testing.T) {
+		cfg := base
+		cfg.ScanType = scanTypeComprehensive
+		cfg.Ports = "T:22,80,443"
+		buildScanOptions(&cfg)
+		assert.Equal(t, "22,80,443", cfg.Ports)
+	})
+
+	t.Run("lowercase t: prefix stripped (same as uppercase)", func(t *testing.T) {
+		cfg := base
+		cfg.ScanType = scanTypeSYN
+		cfg.Ports = "t:22,80,443"
+		buildScanOptions(&cfg)
+		assert.Equal(t, "22,80,443", cfg.Ports)
+	})
+}


### PR DESCRIPTION
## Summary

- nmap 7.99 has a regression where using the `T:` protocol prefix in a TCP-only port spec with `-sS --privileged` reliably produces `0 hosts up`, even when the host is reachable
- Plain port specs (e.g. `22,80,443`) work correctly; `T:22,80,443` does not
- `T:` is only meaningful in mixed TCP+UDP specs (e.g. `T:22,80,U:53,161`) to disambiguate — for TCP-only specs it is a no-op that triggers the nmap bug
- Strip the `T:` prefix early in `normalizePortSpec()` whenever no `U:` ports are present
- Extracted prefix normalization into `normalizePortSpec()` to keep `buildScanOptions` below the cyclomatic-complexity limit

## Test plan

- Start a SYN scan against a host using a port profile that generates `T:`-prefixed specs (e.g. any built-in profile); verify `hosts_up=1` and ports are returned
- Verify a mixed `T:22,80,U:53,161` spec is preserved unchanged for privileged SYN scans
- Verify a mixed spec is still fully stripped for connect scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)