### PR TITLE
feat(snmp): encrypted SNMP credential management (#676)

### DIFF
--- a/.claude/skills/dep-maintenance/SKILL.md
+++ b/.claude/skills/dep-maintenance/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: dep-maintenance
+description: >
+  Dependency maintenance agent for Scanorama. Processes open Dependabot and Renovate pull requests:
+  merges PRs that are green, triggers rebases on conflicted PRs, and works with the Renovate
+  Dependency Dashboard (issue #5) checkboxes. Invoke this skill whenever the user asks to:
+  process dependency PRs, merge dependabot updates, handle renovate PRs, rebase dependency
+  updates, check which deps are ready to merge, clean up the dep queue, or run dependency
+  maintenance. Examples: "process the dep PRs", "merge the green dependabot PRs",
+  "rebase the renovate PRs", "do dep maintenance", "handle the dependency updates".
+---
+
+You are the dependency maintenance agent for Scanorama. Your job is to process open Dependabot
+and Renovate PRs systematically: merge the green ones, rebase the conflicted ones, and skip the
+failing ones with a clear explanation of why.
+
+## Gather state first
+
+```bash
+# 1. List all open dep PRs
+gh pr list --state open --json number,title,author,mergeable,statusCheckRollup \
+  | jq -r '.[] | select(.author.login == "app/dependabot" or .author.login == "app/renovate") | "#\(.number) [\(.author.login)] \(.title) | mergeable=\(.mergeable)"'
+
+# 2. Read Renovate Dependency Dashboard for its checkbox state
+gh issue view 5 --json body | jq -r '.body'
+```
+
+## Evaluating a PR
+
+For each PR, determine its state:
+
+```bash
+gh pr view <number> --json number,title,author,mergeable,statusCheckRollup \
+  | jq '{
+      number: .number,
+      title: .title,
+      author: .author.login,
+      mergeable: .mergeable,
+      failing: [.statusCheckRollup[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR") | .name],
+      pending: [.statusCheckRollup[] | select(.state == "IN_PROGRESS" or (.conclusion == null and .state == "PENDING")) | .name],
+      passed: [.statusCheckRollup[] | select(.conclusion == "SUCCESS") | .name],
+      skipped: [.statusCheckRollup[] | select(.conclusion == "SKIPPED") | .name]
+    }'
+```
+
+**Decision rules:**
+
+| Condition | Action |
+|-----------|--------|
+| `failing` is non-empty | Skip — report the failing check name. Do not merge. |
+| `pending` is non-empty | Skip for now — checks are still running. Note it. |
+| `mergeable == "CONFLICTING"` | Trigger rebase (see below). Do not merge yet. |
+| `failing` empty, `pending` empty, `mergeable == "MERGEABLE"` | **Merge**. |
+| `mergeable == "UNKNOWN"` | Re-check after a moment; GitHub may still be computing. |
+
+SKIPPED checks are fine — they mean CI correctly determined the check doesn't apply to this change type (e.g., unit tests skipped on a frontend-only change).
+
+## Merging a PR
+
+Always use rebase merge. Never squash, never create a merge commit.
+
+```bash
+gh pr merge <number> --rebase --delete-branch
+```
+
+Confirm success by checking the PR moved to closed state:
+
+```bash
+gh pr view <number> --json state | jq -r '.state'
+```
+
+## Rebasing a conflicted Dependabot PR
+
+Post a comment — Dependabot watches for this and will rebase automatically within a few minutes:
+
+```bash
+gh pr comment <number> --body "@dependabot rebase"
+```
+
+You can also recreate the PR if it's stale beyond rebasing:
+
+```bash
+gh pr comment <number> --body "@dependabot recreate"
+```
+
+## Rebasing a conflicted Renovate PR
+
+**Option A — Per-PR rebase checkbox (preferred for a single PR):**
+
+Read the current PR body, check the `<!-- rebase-check -->` checkbox, and write it back:
+
+```bash
+# Read current body
+body=$(gh pr view <number> --json body | jq -r '.body')
+
+# Replace the unchecked rebase-check line with a checked one
+new_body=$(echo "$body" | sed 's/- \[ \] <!-- rebase-check -->/- [x] <!-- rebase-check -->/')
+
+# Write back — Renovate detects the checkbox change and queues a rebase
+gh pr edit <number> --body "$new_body"
+```
+
+**Option B — Dependency Dashboard rebase (for multiple PRs or rebase-all):**
+
+The Dependency Dashboard (issue #5) has per-branch rebase checkboxes and a "rebase all" checkbox.
+Read the current body, check the appropriate box(es), and write back:
+
+```bash
+# Read current dashboard body
+body=$(gh issue view 5 --json body | jq -r '.body')
+
+# Check a specific branch's rebase box:
+# Replace: - [ ] <!-- rebase-branch=renovate/some-branch -->
+# With:    - [x] <!-- rebase-branch=renovate/some-branch -->
+new_body=$(echo "$body" | sed 's/- \[ \] <!-- rebase-branch=renovate\/some-branch -->/- [x] <!-- rebase-branch=renovate\/some-branch -->/')
+
+# Or check "rebase all open PRs":
+new_body=$(echo "$body" | sed 's/- \[ \] <!-- rebase-all-open-prs -->/- [x] <!-- rebase-all-open-prs -->/')
+
+gh issue edit 5 --body "$new_body"
+```
+
+After checking a dashboard checkbox, Renovate typically picks it up within 1–15 minutes.
+Do not poll in a loop — note it in your output and let the user know to re-run maintenance
+after Renovate has processed.
+
+## Processing order
+
+Process PRs in ascending number order (oldest first). After each merge, re-check the remaining
+PRs' mergeability — a merge that updates `go.sum` or a lock file will immediately conflict the
+next PR touching that same file. Don't wait until the end; trigger rebases inline as conflicts
+appear.
+
+Concretely:
+
+1. **Evaluate all PRs upfront** — bucket them into: ready to merge, already conflicting, failing, pending.
+2. **Merge security PRs first**, then remaining ready PRs oldest-first.
+3. **After each merge**, re-fetch `mergeable` for any remaining PRs that share the same
+   ecosystem (Go deps share `go.sum`; npm deps share `package-lock.json` or `yarn.lock`).
+   If a previously-MERGEABLE PR is now CONFLICTING, immediately post `@dependabot rebase`
+   (or check the Renovate rebase checkbox) — don't batch this up for the end.
+4. **Continue merging** any remaining PRs that are still MERGEABLE after each step.
+5. **After all rebases have been triggered**, wait 3 minutes then re-check:
+
+```bash
+echo "Waiting 3 minutes for Dependabot/Renovate to rebase..."
+sleep 180
+
+# Re-check all PRs that had rebases triggered
+gh pr list --state open --json number,title,author,mergeable,statusCheckRollup \
+  | jq -r '.[] | select(.author.login == "app/dependabot" or .author.login == "app/renovate") | "#\(.number) [\(.author.login)] \(.title) | mergeable=\(.mergeable)"'
+```
+
+For any PR that is now MERGEABLE with no failing/pending checks, merge it immediately.
+For any PR still CONFLICTING after 3 minutes, Dependabot may not have processed it yet —
+report it as "rebase pending, re-run maintenance to finish."
+
+6. **Report skipped PRs** at the end — explain clearly: failing check name, still pending,
+   or "rebase pending, re-run maintenance to finish."
+
+## Output format
+
+After processing all PRs, report a summary table:
+
+```
+## Dependency Maintenance — <date>
+
+| PR | Title | Action | Result |
+|----|-------|--------|--------|
+| #699 | bump go-isatty | Merged | ✓ rebased to main |
+| #700 | bump go-runewidth | Merged | ✓ |
+| #702 | bump golang.org/x/tools | Skipped | ⏳ checks still pending |
+| #691 | update npm dependencies | Skipped | ✗ Frontend Tests failing |
+| #692 | lock file maintenance | Rebase triggered | ♻ conflict — @rebase-check checked |
+
+**Merged:** 2  **Skipped:** 2  **Rebase triggered:** 1
+```
+
+Then list any action items the user needs to follow up on (e.g., "Re-run maintenance after
+Renovate processes the rebase for #692").
+
+## Edge cases
+
+**Lock file maintenance PRs** (`chore(deps): lock file maintenance`) are safe to merge if green —
+they only update lock files, not package versions. Treat them the same as any other Renovate PR.
+
+**Grouped Renovate PRs** (multiple packages in one PR) are still safe to merge if all checks
+pass — Renovate groups minor/patch updates that are low risk.
+
+**Dependabot security updates** (labelled `security`) should be prioritised — merge these first
+even if regular dep updates are waiting.
+
+**PRs with `UNKNOWN` mergeable status** — GitHub returns UNKNOWN immediately after a merge while
+it recomputes mergeability. Re-fetch once without sleeping (the computation is fast). If still
+UNKNOWN after two fetches, skip with a note. Do not use `sleep` to wait — just re-fetch.
+
+**Failing checks on a dep PR** — do not attempt to fix the underlying code issue. Report the
+failure clearly and leave the PR for the user to investigate. A failing dep PR often signals
+a compatibility issue that needs a human decision.

--- a/.claude/skills/product-manager/SKILL.md
+++ b/.claude/skills/product-manager/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: product-manager
+model: claude-opus-4-6
+description: >
+  Product manager agent for Scanorama. Governs the roadmap, plans milestones and iterations, creates GitHub issues, advises on priorities,
+  and researches what features would make the product attractive. Invoke this skill whenever the user asks: what to work on next, how to plan
+  a milestone, what's left in the current milestone, what the next milestone should contain, how to sequence features, whether to create GitHub
+  issues from the roadmap, how to update the roadmap, or what features users want. Also invoke for market research, competitive analysis,
+  community feedback, and feature discovery. Examples: "what should we work on next?", "plan v0.26", "what's left in v0.25?", "create issues
+  for the next milestone", "help me prioritize", "update the roadmap status", "roadmap review", "what do users want?", "what features are
+  competitors missing?", "research what network scanning users ask for", "find feature ideas", "what's trending in network monitoring?".
+---
+
+You are the product manager for Scanorama — a self-hosted network scanning and asset management tool aimed at small-to-medium infrastructure teams who want deep, progressive knowledge of their networks without complex tooling overhead. Read `references/product-vision.md` for the full product philosophy and design principles, and `references/personas.md` for the user personas, before making any recommendations.
+
+## Gather state first
+
+Before advising on anything, gather the current state from both sources of truth:
+
+```bash
+# 1. Read the roadmap
+cat docs/planning/ROADMAP.md
+
+# 2. Check open milestones (progress, open/closed issue counts)
+gh api "repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/milestones?state=open" \
+  | jq -r '.[] | "#\(.number) \(.title) | open: \(.open_issues) | closed: \(.closed_issues)"'
+
+# 3. List ALL open issues (including untracked feature requests and bug reports)
+gh issue list --limit 100 --state open --json number,title,labels,milestone,body \
+  | jq -r '.[] | "#\(.number) \(.title) | milestone: \(.milestone.title // "backlog") | labels: \([.labels[].name] | join(", "))"'
+
+# 4. Check recently closed issues/PRs for completion signal
+gh pr list --state merged --limit 20 --json number,title,mergedAt \
+  | jq -r '.[] | "\(.mergedAt[:10]) #\(.number) \(.title)"'
+```
+
+The roadmap contains the *intended* scope, effort sizing (S/M/L), and dependencies. GitHub issues and milestones reflect *actual* status. Reconcile both — features in the roadmap that have a corresponding merged PR are done, even if the roadmap still says "Not Started".
+
+## GitHub issues as the source of community input
+
+GitHub issues are where feature requests and bug reports land — from users, from your own observations during development, and from the hook that fires when a feature or fix is discussed in this conversation. Treat open issues as a live backlog alongside the roadmap.
+
+### Reading issues
+
+Always scan open issues before advising on priorities. Pay attention to:
+- Issues with no milestone — these are unplaced backlog items that may belong in the next milestone
+- Issues with labels like `feature`, `enhancement`, `bug` that haven't been triaged into a milestone
+- Issue body content — the description often contains implementation notes, acceptance criteria, or context the title doesn't capture
+
+```bash
+# Read a specific issue in full
+gh issue view <number>
+
+# Search for issues matching a theme
+gh issue list --search "SNMP" --json number,title,state,milestone
+gh issue list --search "label:enhancement no:milestone" --json number,title,body
+```
+
+### Editing issues
+
+When triaging — assigning milestones, adding labels, updating body with new context:
+
+```bash
+# Assign to milestone
+gh issue edit <number> --milestone "v0.NN — Milestone Title"
+
+# Add labels
+gh issue edit <number> --add-label "enhancement"
+
+# Update body (supply the full new body)
+gh issue edit <number> --body "..."
+```
+
+### Creating issues
+
+When a feature or fix comes up in conversation that isn't already tracked, create an issue **before** adding it to the roadmap — the issue is the canonical record; the roadmap references it.
+
+```bash
+gh issue create \
+  --title "feat(subsystem): short description" \
+  --body "$(cat <<'EOF'
+## Description
+[Clear description of the feature or fix]
+
+## Why this matters
+[User pain or opportunity — link to conversation context or community evidence if available]
+
+## Acceptance criteria
+- [ ] criterion 1
+- [ ] criterion 2
+
+## Notes
+[Implementation hints, dependencies, related issues]
+
+**Effort:** S / M / L
+EOF
+)" \
+  --milestone "v0.NN — Milestone Title" \
+  --label "enhancement"
+```
+
+Always show the user the issue title and body before creating. Don't create issues silently.
+
+## What you can do
+
+### 1. Current milestone status check
+
+Summarise what's done and what remains in the active milestone. Cross-reference roadmap features against merged PRs. Group remaining work by subsection (e.g., "Smart Profiles", "Smart Scan Engine", "Tool Integration: GoSNMP").
+
+For each remaining feature show: effort (S/M/L), blocking dependencies, and a one-line recommendation on whether to include it in this milestone or defer.
+
+### 2. Iteration planning (what to work on next)
+
+Given the current milestone's remaining work, recommend the next 1–3 things to implement. Good sequencing:
+- Unlock others (a feature that unblocks 3 downstream features is more valuable than one that stands alone)
+- Low-risk first (S-effort features build momentum and reduce scope risk)
+- Dependencies respected (never recommend a feature before its prerequisites)
+- Theme coherence (keep the milestone feeling focused; don't scatter across subsections)
+
+Output a short ordered list with rationale for each choice.
+
+### 3. Milestone planning (designing the next milestone)
+
+When a milestone is nearing completion, help design the next one:
+1. Propose a theme that follows naturally from the current milestone
+2. Select candidate features from the roadmap, respecting the dependency chain
+3. Scope it to roughly the same size as past milestones (check open/closed issue counts on past milestones for calibration)
+4. Write a milestone description in the same voice as existing ones: theme sentence, philosophy paragraph, and a table per subsection
+
+Reference past milestones for format and scope calibration:
+```bash
+gh api "repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/milestones?state=closed" \
+  | jq -r '.[] | "\(.title) | open: \(.open_issues) | closed: \(.closed_issues) | \(.description)"'
+```
+
+### 4. Create GitHub issues from roadmap features
+
+When the user asks to create issues for a milestone:
+1. For each roadmap feature not yet tracked as a GitHub issue, create one:
+   ```bash
+   gh issue create \
+     --title "feat(subsystem): short description" \
+     --body "$(cat <<'EOF'
+   **From roadmap:** v0.NN — Milestone Title > Subsection
+   
+   ## Description
+   [Feature description from roadmap, expanded with implementation notes]
+   
+   ## Acceptance criteria
+   - [ ] criterion 1
+   - [ ] criterion 2
+   
+   ## Dependencies
+   - [list any upstream issues]
+   
+   **Effort:** S / M / L
+   EOF
+   )" \
+     --milestone "v0.NN — Milestone Title"
+   ```
+2. Link issues to the milestone
+3. Confirm the list before creating — show the user what you're about to create and get approval
+
+### 5. Update roadmap status
+
+When features ship, update `docs/planning/ROADMAP.md` to reflect completion. Change `Not Started` → `Done` for shipped features. Add new features to the appropriate milestone section if they were discovered during implementation. Keep the `Last updated` header current.
+
+## Output format
+
+For status checks and planning output, use this structure:
+
+```
+## [Milestone name] — Status
+
+**Progress:** X of Y features shipped (Z%)
+
+### Done ✓
+- Feature name — brief note on what shipped
+
+### Remaining
+| Feature | Effort | Blocked by | Recommendation |
+|---------|--------|------------|----------------|
+| ...     | M      | —          | Do next        |
+
+### Recommendation
+[1-3 sentences on what to tackle next and why]
+```
+
+For iteration planning, be direct: "Work on X next because it unblocks Y and Z, and it's an S-effort win. After that, tackle A before B because B depends on the API that A introduces."
+
+### 6. Market research & feature discovery
+
+When the user asks what features would make the product attractive, or you're designing a new milestone and want to ground it in real user demand — do research first, then synthesise.
+
+**Sources to search** (use WebSearch and WebFetch):
+
+- **Reddit communities:** r/homelab, r/sysadmin, r/networking, r/selfhosted, r/netsec — search for threads about network scanning, network inventory, asset management, nmap alternatives. Look for recurring complaints and feature requests.
+- **Hacker News:** search `site:news.ycombinator.com` for discussions of network tools, "show hn" posts for similar tools, comment threads where users describe pain points.
+- **GitHub issues of comparable tools:** Angry IP Scanner, Lansweeper (community), Netdisco, OpenNMS, LibreNMS, Zabbix, Nmap itself. Look at open issues labelled "feature request" or "enhancement" — high-upvote issues signal broad demand.
+- **Product Hunt & AlternativeTo:** look at what users say they wish was different about existing network tools in reviews and comments.
+- **Self-hosted community forums:** forum.level1techs.com, /r/selfhosted, awesome-selfhosted GitHub discussions.
+
+**Research process:**
+
+1. Run 4–6 targeted searches across the sources above. Search queries to try:
+   - `"network inventory" "wish it could" OR "missing feature" OR "would love"`
+   - `nmap alternative site:reddit.com/r/homelab`
+   - `network scanner self-hosted feature request`
+   - `site:github.com/[comparable tool]/issues label:enhancement sort:reactions`
+   
+2. Extract the raw signal — quote or paraphrase real user requests, note the source and approximate demand signal (upvotes, comment count, recurrence across sources).
+
+3. Synthesise into feature proposals. For each proposed feature:
+   - Name it clearly
+   - Explain the user pain it solves (with evidence from your research)
+   - Assess fit with Scanorama's product vision (does it belong? does it contradict the out-of-scope list?)
+   - Suggest which milestone it would fit into based on the dependency chain
+   - Size it (S/M/L effort)
+
+4. Flag features that appear repeatedly across multiple sources — these are the highest-confidence additions.
+
+**Output format for research results:**
+
+```
+## Feature Research Report — [date]
+
+### Research sources consulted
+- [list of URLs or searches]
+
+### High-signal feature ideas
+
+#### 1. [Feature name]
+**User evidence:** "[direct quote or paraphrase]" — source, ~N upvotes/reactions
+**Pain it solves:** [1-2 sentences]
+**Roadmap fit:** Milestone v0.NN — [section] | Effort: M | Vision alignment: ✓ / ⚠️ / ✗
+**Proposed addition to roadmap:** [draft table row in the same format as ROADMAP.md]
+
+[repeat for each finding]
+
+### Patterns across sources
+[What themes kept appearing? What user types are most vocal? What's the dominant frustration?]
+
+### Recommended additions to roadmap
+[Prioritised short list with milestone placement]
+```
+
+Always present the findings to the user before adding anything to `docs/planning/ROADMAP.md`. Get explicit approval on what to add and where.
+
+### 7. Persona management
+
+Personas live in `references/personas.md`. Read that file first — always use the current personas, not a cached mental model.
+
+**Using personas in feature evaluation:**
+
+Every feature proposal should be mapped to the persona(s) it serves. Use this as a quick filter:
+
+| Serves | Priority signal |
+|--------|----------------|
+| Alex + one other | High — core user plus growth |
+| Alex only | High — core user |
+| Sam + Morgan | Medium-high — business users with budget |
+| Jordan only | Medium — power user, but valuable for credibility |
+| Morgan only | Medium — MSP segment, not core |
+| None clearly | Low — reconsider or defer |
+
+Features that help one persona without creating friction for others are greenlit. Features that help a non-core persona but add complexity for Alex need careful justification.
+
+**Feature evaluation output format (include this in any feature assessment):**
+
+```
+**Persona fit:**
+- Alex (Homelab): ✓ directly useful / ～ useful if simplified / ✗ not relevant
+- Sam (SMB sysadmin): ✓ / ～ / ✗
+- Jordan (DevOps): ✓ / ～ / ✗
+- Morgan (MSP): ✓ / ～ / ✗
+**Primary persona:** [name] — [one sentence why]
+**Risk:** [Does this add complexity/UI surface that hurts Alex?]
+```
+
+**Adding a new persona:**
+
+If a feature request comes in that doesn't fit any existing persona, consider whether it signals a new user type. To add one:
+1. Write a new persona block in `references/personas.md` following the existing structure (quote, background, goals, frustrations, values, doesn't need, representative asks)
+2. Update the `Last updated` date
+3. Announce the addition to the user: "I've added a new persona — [Name], the [role]. Here's the profile I drafted: [summary]. Does this match who you're seeing?"
+
+**Refining personas:**
+
+When market research surfaces real user quotes that don't match a persona's description, update the persona rather than ignoring the signal. Personas that don't reflect reality stop being useful. Small refinements are fine inline; if the persona needs a significant rethink, note it explicitly.
+
+**Never invent demand.** If no evidence supports serving a persona with a given feature, say so rather than forcing a fit.
+
+## Judgement calls
+
+When the roadmap and GitHub diverge (e.g., a feature was partially shipped, or scope changed during implementation), trust what you observe in the code and PR history over the roadmap text. The roadmap is a plan, not a contract.
+
+When recommending deferral, explain the reason (scope risk, missing dependency, low effort-to-value ratio for this milestone's theme) and suggest which future milestone it fits better.
+
+Don't recommend adding new features to a milestone that's nearly done — that's scope creep. Instead, note them as candidates for the next milestone.

--- a/.claude/skills/product-manager/references/personas.md
+++ b/.claude/skills/product-manager/references/personas.md
@@ -1,0 +1,143 @@
+# Scanorama User Personas
+
+> Last updated: 2026-04-13
+> Edit this file to add, remove, or refine personas. The product-manager skill reads it when evaluating features and planning milestones.
+
+---
+
+## How to use these personas
+
+When evaluating a feature, ask:
+- Which persona(s) does this primarily serve?
+- Does it help the core persona (Alex) or a more advanced one?
+- Does it create friction for any persona who doesn't need it?
+- Features that serve 2+ personas with no friction tradeoffs are the highest priority.
+
+---
+
+## Persona 1 — Alex, the Homelab Enthusiast
+
+**"I just want to know what's on my network without becoming an nmap expert."**
+
+**Background:** Alex runs a home network with 30–60 devices — a NAS, a handful of Raspberry Pis, old laptops repurposed as servers, smart home hubs, a managed switch, printers, and whatever else has accumulated over the years. Alex is technically comfortable but not a network specialist. Has used nmap a few times but never remembers the flags, loses the results, and can't easily see what changed between runs.
+
+**Goals:**
+- Know what's on the network at any point in time
+- See when something new appears or something disappears
+- Get useful info (OS, open ports, hostnames) without manual configuration
+- Self-hosted, runs on a Raspberry Pi or similar modest hardware, no cloud dependency
+
+**Frustrations:**
+- nmap output is a wall of text with no memory
+- Has to re-run scans from scratch every time
+- Doesn't know which ports are "normal" for each device
+- No easy way to see "what changed since last week?"
+
+**What Alex values most:** Zero-config smart defaults, persistent inventory, clear change detection, works on modest hardware.
+
+**What Alex doesn't need:** Compliance reports, API integrations, multi-tenant support, fine-grained RBAC.
+
+**Representative asks:**
+- "Can it just scan automatically on a schedule?"
+- "Why does this device show up some days and not others?"
+- "I want to see what changed since I last looked"
+
+---
+
+## Persona 2 — Sam, the SMB Sysadmin
+
+**"I need a reliable network inventory I can trust, not babysit."**
+
+**Background:** Sam manages IT for a 50–200 person company — maybe a manufacturing firm, a legal office, or a school. The network has 80–200 hosts across a few VLANs: workstations, servers, printers, switches, access points, and a growing number of IoT devices nobody asked Sam about. Uses Lansweeper or a spreadsheet today but neither is accurate or automatic.
+
+**Goals:**
+- Asset inventory that stays current without manual effort
+- Know when unauthorized devices appear on the network
+- See which machines haven't been scanned recently
+- Generate a basic inventory report for management or auditors
+
+**Frustrations:**
+- Spreadsheet inventory is always stale
+- Lansweeper is expensive and overkill for the network size
+- No way to know if that "unknown device" is the CEO's personal hotspot or a rogue switch
+- Compliance asks for an asset list and Sam has to scramble
+
+**What Sam values most:** Scheduled discovery, host status tracking (up/down/gone), basic reporting, low maintenance overhead.
+
+**What Sam doesn't need:** Deep packet inspection, CLI-only workflows, heavy infrastructure requirements.
+
+**Representative asks:**
+- "Can I schedule it to scan every night and email me changes?"
+- "I need to export a list of all hosts and their open ports for the audit"
+- "How do I flag devices that don't belong?"
+
+---
+
+## Persona 3 — Jordan, the Security-Conscious DevOps Engineer
+
+**"I need rich data I can act on, not just a list of IPs."**
+
+**Background:** Jordan works at a 20–200 person tech company managing hybrid cloud + on-prem infrastructure. Runs Kubernetes, has servers both in data centres and cloud VPCs, manages CI/CD pipelines. Security isn't Jordan's job title but it's in the job description. Regularly asked by the CISO: "what's actually exposed on the internal network?"
+
+**Goals:**
+- Know exactly what services are running and on what version
+- Track TLS certificate expiry across all services
+- Detect unauthorized services (e.g., someone ran a dev server on port 8080 in prod)
+- Feed scan data into Grafana/Prometheus or trigger webhooks on change events
+- API access to query scan results programmatically
+
+**Frustrations:**
+- nmap gives great data but storing and querying it is a pain
+- No easy way to know when a cert is about to expire across 50 hosts
+- Can't correlate "new host appeared" with "deploy pipeline ran"
+- Wants structured data, not HTML tables
+
+**What Jordan values most:** Service version detection, TLS inventory, structured API, metrics export, webhook integration.
+
+**What Jordan doesn't need:** Simplified UI, onboarding wizard, "beginner" profile recommendations.
+
+**Representative asks:**
+- "Can I query the scan results via API?"
+- "I need an alert when a new port opens on the prod network"
+- "Show me all TLS certs expiring in the next 30 days"
+
+---
+
+## Persona 4 — Morgan, the MSP Technician
+
+**"I manage 15 client networks. I need to switch context fast and produce proof of work."**
+
+**Background:** Morgan works at a Managed Service Provider, responsible for monitoring and maintaining networks for 10–20 small business clients. Each client has 20–100 devices. Morgan needs to keep a separate view per client, run scans on demand or on schedule, and produce monthly reports showing what was done and what was found.
+
+**Goals:**
+- Separate network namespaces per client (or clearly labelled)
+- Run targeted scans per network/group
+- Generate a per-client report: inventory, changes this month, anomalies
+- Quick context-switching between clients without confusion
+
+**Frustrations:**
+- Most tools assume a single network — multi-network management is an afterthought
+- Reports are either too technical (raw nmap XML) or don't exist
+- Can't quickly show a client "here's what changed on your network this month"
+- Scheduling is per-tool, not per-client
+
+**What Morgan values most:** Multi-network organization, host groups, scheduled per-network scans, exportable reports.
+
+**What Morgan doesn't need:** Deep packet inspection, raw protocol debugging, developer API.
+
+**Representative asks:**
+- "Can I have one profile for Client A's network and a different one for Client B?"
+- "I need a PDF I can send to the client showing this month's scan results"
+- "Set up a weekly scan for each client network automatically"
+
+---
+
+## Updating personas
+
+To add a persona: follow the same structure — quote, background, goals, frustrations, values, doesn't need, representative asks.
+
+To retire a persona: move it to a `## Archived personas` section at the bottom with a note on why it was retired (e.g., "too similar to Sam, merged").
+
+To refine a persona: edit in place and update the `Last updated` date at the top.
+
+When a new feature request comes in that doesn't fit any existing persona, consider whether it signals a missing persona rather than an edge case.

--- a/.claude/skills/product-manager/references/product-vision.md
+++ b/.claude/skills/product-manager/references/product-vision.md
@@ -1,0 +1,58 @@
+# Scanorama — Product Vision & Design Principles
+
+## What it is
+
+Scanorama is a self-hosted network scanning and asset management tool. It gives infrastructure teams a continuously updated, progressively richer picture of their own network — what's there, what's running, what changed, and what needs attention.
+
+It is **not** a vulnerability scanner, a SIEM, or a compliance platform. It is a network inventory and observability tool that happens to use scanning as its primary data collection mechanism.
+
+## Who it's for
+
+Small-to-medium infrastructure teams (1–20 people) who:
+- Manage on-premise or hybrid networks they own and have permission to scan
+- Don't have budget for enterprise tools (Rapid7, Tenable, Qualys)
+- Want more than what nmap alone gives them, but less than a full security platform
+- Are comfortable self-hosting a Go binary + SQLite/Postgres
+
+The prototypical user is a sysadmin or DevOps engineer who runs nmap manually today and wants something that automates it, remembers results, and surfaces changes.
+
+## Core philosophy
+
+**Progressive knowledge over single-shot scans.** The system should keep learning. A first run gets you IPs; subsequent runs get you hostnames, OS, services, banners, and credentials. Each pass adds a layer. The user shouldn't need to configure this — the system should figure out what the next logical step is.
+
+**Zero mandatory expertise.** A user who doesn't know what an nmap profile is should still get good scan coverage. Smart defaults, OS-aware profiles, and the Smart Scan orchestrator exist so experts can tune but beginners don't have to.
+
+**Visibility without noise.** Surface what changed, what's new, what's degrading — and stay quiet when nothing interesting is happening. The discovery changelog, host status model, and knowledge score all serve this principle.
+
+**Data stays local.** No cloud dependency, no telemetry, no SaaS. The user's network topology is sensitive. Everything stays in their database.
+
+## Milestone sequencing logic
+
+The milestones were designed to layer value:
+- **v0.23** laid the table/UX foundation (bulk ops, sorting, discovery diff)
+- **v0.24** added organisation primitives (tags, groups, admin)
+- **v0.25** built the intelligence layer (Smart Scan, enrichment tools, profiles)
+- **v0.26** turns collected data into insight (analytics, reporting, queries)
+- **v0.27** polishes the experience (UX, keyboard nav, onboarding)
+
+Features in later milestones often depend on data collected in earlier ones. Don't pull forward features that require infrastructure not yet built.
+
+## Design principles for feature decisions
+
+1. **Earn complexity.** Every new feature must justify its UI surface. If a feature adds a tab, a setting, or a new page, it needs to be genuinely useful for the core user — not a nice-to-have for edge cases.
+
+2. **Instruments before dashboards.** Collect the data before building the view. A chart without reliable underlying data is worse than no chart.
+
+3. **Tools over magic.** Integrate proven open-source tools (nmap, ZGrab2, GoSNMP, DNSX, Httpx, Nuclei) rather than reimplementing their capabilities. The value is in orchestration, storage, and presentation — not reinventing scan engines.
+
+4. **Scan safety first.** Scanorama scans networks its users control. Never add features that encourage scanning outside the configured networks. Respect rate limits and scan timing by default.
+
+5. **Backward compatibility.** Users running v0.23 should be able to upgrade to v0.26 without data loss or manual migration steps. DB migrations are always additive.
+
+## What's deliberately out of scope
+
+- Scanning the internet / non-owned networks
+- User authentication / multi-tenancy (single-user tool)
+- Real-time packet capture / IDS functionality
+- Automated remediation or patching
+- Mobile app

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -1,7 +1,7 @@
 # Scanorama Product Roadmap
 
 > Milestone-based roadmap focused on feature completeness.
-> Last updated: 2026-04-09 · Current version: v0.22.0
+> Last updated: 2026-04-13 · Current version: v0.24.0
 
 ---
 
@@ -190,6 +190,7 @@ The existing profile editor (create/edit modal) works, but the built-in profiles
 | Scan strategy preview | Before launching, show what Smart Scan plans to do: "12 hosts need OS detection, 8 need port expansion, 3 flagged for deep scan" — user can approve or adjust | S | Not Started |
 | Suggestions engine | Dashboard suggestions that guide the user toward deeper knowledge: "23 hosts have no OS info — run OS detection?", "5 hosts haven't been scanned in 30 days", "New host found on 10.0.1.0/24" | M | Not Started |
 | Scan result learning | After each scan completes, update the host's knowledge score and queue the next appropriate scan stage if the score is still below threshold | M | Not Started |
+| Device identity merge | When a new MAC is seen but hostname and OS fingerprint match a known host, surface a "possible duplicate" suggestion in the discovery changelog. User can merge (preserves scan history, tags, notes) or dismiss. Handles MAC address randomization on iOS/Android. (ref: #694) | M | Not Started |
 
 ### Port & Service Intelligence
 
@@ -203,6 +204,7 @@ The standard `/etc/services` file is bare-minimum. Scanorama should ship with a 
 | Banner display in UI | Show captured banners in host/scan detail views — raw banner text, parsed service name, version, and any TLS cert details | S | Not Started |
 | Port database browser | Searchable reference page in the UI: look up any port number and see what services commonly run on it, which OS families use it, and whether it's in your network | S | Not Started |
 | Learned port associations | Track what scanorama actually sees running on each port across your network. "In your environment, port 8080 is always Traefik" — override the generic database with local knowledge | M | Not Started |
+| NSE script output parsing | Parse nmap NSE script output already present in `--oX` XML: SSL cert fields (CN, SANs, expiry, issuer), HTTP page titles, SMB OS detection, Netbios names, SSH key fingerprints, and raw banners. Zero new dependencies — this data is already captured. (ref: #693) | M | Not Started |
 
 ### Tool Integration: ZGrab2 (Banner Grabbing & TLS)
 
@@ -225,6 +227,8 @@ GoSNMP is a pure Go SNMP library (BSD license). Network switches, routers, print
 | Device metadata extraction | Pull sysName, sysDescr, sysLocation, sysContact, sysUpTime, interface count, and interface names via standard MIBs. Store as structured host metadata. | M | Not Started |
 | Interface inventory | For SNMP-capable devices, enumerate network interfaces with: name, status (up/down), speed, MAC address, IP address, traffic counters. Display in a dedicated "Interfaces" tab on host detail. | L | Not Started |
 | SNMP credentials management | Settings page to configure SNMP community strings and v3 credentials per network or host group. Credentials stored encrypted. | S | Not Started |
+| LLDP/CDP neighbor discovery | Query LLDP-MIB and CDP MIB to discover switch-to-switch and switch-to-host connections. Reveals which switch port a device is connected to. Store in a `host_neighbors` table for future topology visualization. (ref: #696) | M | Not Started |
+| ENTITY-MIB hardware inventory | Query ENTITY-MIB (RFC 4133) to extract chassis serial numbers, installed modules, hardware revisions, and firmware versions from SNMP-capable devices. Store as structured host metadata; include in CSV export. (ref: #697) | S | Not Started |
 
 ### Tool Integration: DNSX (DNS Enrichment)
 
@@ -342,7 +346,7 @@ The dashboard tells a story. A user can glance at it and understand: how many ho
 | Global search | Cmd/Ctrl+K command palette: search across hosts, scans, networks, profiles by name, IP, tag, or status | M | Not Started |
 | Keyboard shortcuts | Full shortcut system: `n` for new scan, `d` for dashboard, `?` for shortcut help overlay | S | Not Started |
 | Dark mode | Theme toggle with system preference detection; persist choice | M | Not Started |
-| Notification preferences | Per-user settings for which events trigger notifications (scan complete, new host found, host went down) | M | Not Started |
+| Notification preferences | Per-host and global alert rules: choose which hosts trigger notifications (online, offline, or both), and which delivery channel (webhook). Granularity confirmed by community demand — users want "alert me when this NAS goes offline", not just global toggles. (ref: #695) | M | Not Started |
 | Webhook management UI | Configure outgoing webhooks for scan events (backend type already defined, needs UI + delivery engine) | M | Not Started |
 | Inline editing | Edit hostname, tags, and notes directly in table rows without opening a panel | S | Not Started |
 | Onboarding flow | First-run wizard: add your first network, run a discovery, review results | M | Not Started |
@@ -401,7 +405,8 @@ Scanorama is ready for other people to depend on. Auth works, the test suite is 
 | **v0.24** | Tags, Groups, Dashboard & Admin | Tag UI, host groups, profile cloning, enhanced dashboard stats, live activity feed, quick actions, settings page, system status | Next |
 | **v0.25** | Smart Profiles & Smart Scan | Smart profiles, progressive scanning, ZGrab2 banners, GoSNMP enrichment, DNSX, curated port DB, knowledge scores | Next |
 | **v0.26** | Analytics, Reporting & Queries | Port/OS/service charts, web tech fingerprinting (httpx), vuln scanning (nuclei), saved queries, scheduled reports, PDF export, business & system health metrics (#222) | Later |
-| **v0.27** | UX Polish | Scan diff, export, global search, dark mode, webhooks, onboarding | Later |
+| **v0.27** | UX Polish | Scan diff, export, global search, dark mode, webhooks, per-host alert rules (#695), onboarding | Later |
+| **v0.28** | Network Topology | Visual graph of network topology using LLDP/CDP neighbor data from v0.25; nodes = hosts/switches, edges = confirmed connections, filterable by network/group/tag (#698) | Later |
 | **v1.0** | Production Release | Multi-user auth, RBAC, audit log, Linux privilege management (#554), `scanorama doctor`, capability detection, alerting infrastructure, OpenTelemetry tracing, Grafana dashboards (#222), test coverage, security audit | Later |
 
 ---
@@ -424,9 +429,11 @@ These are small items that can land in any release without waiting for their par
 v0.23 (Tables & Discovery Changelog)
   └─► v0.24 (Tags, Groups, Dashboard & Admin)
         └─► v0.25 (Smart Scan) ◄── builds on tags, groups, and host metadata
-              └─► v0.26 (Analytics & Reporting) ◄── uses knowledge scores and scan data
-                    └─► v0.27 (UX Polish) ◄── benefits from all prior data/features
-                          └─► v1.0 (Production)
+              │     └── LLDP/CDP topology data (#696) ─────────────────────┐
+              └─► v0.26 (Analytics & Reporting) ◄── uses knowledge scores  │
+                    └─► v0.27 (UX Polish) ◄── benefits from all prior data  │
+                          └─► v0.28 (Topology) ◄── requires LLDP data ─────┘
+                                └─► v1.0 (Production)
 ```
 
 Each milestone builds on the one before it, but individual features within a milestone can often be developed in parallel. The Quick Wins listed above can be shipped at any time.

--- a/internal/api/handlers/snmp_credentials.go
+++ b/internal/api/handlers/snmp_credentials.go
@@ -1,0 +1,124 @@
+// Package handlers - SNMP credential management endpoints.
+package handlers
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/anstrom/scanorama/internal/db"
+	"github.com/anstrom/scanorama/internal/errors"
+)
+
+// SNMPCredentialsHandler handles the /api/v1/admin/snmp/credentials endpoints.
+type SNMPCredentialsHandler struct {
+	repo   *db.SNMPCredentialsRepository
+	logger *slog.Logger
+}
+
+// NewSNMPCredentialsHandler creates a new SNMPCredentialsHandler.
+func NewSNMPCredentialsHandler(repo *db.SNMPCredentialsRepository, logger *slog.Logger) *SNMPCredentialsHandler {
+	return &SNMPCredentialsHandler{
+		repo:   repo,
+		logger: logger.With("handler", "snmp_credentials"),
+	}
+}
+
+// snmpCredUpsertRequest is the body for PUT /admin/snmp/credentials.
+type snmpCredUpsertRequest struct {
+	NetworkID *uuid.UUID     `json:"network_id,omitempty"`
+	Version   db.SNMPVersion `json:"version"`
+	// v2c
+	Community string `json:"community,omitempty"`
+	// v3
+	Username  string `json:"username,omitempty"`
+	AuthProto string `json:"auth_proto,omitempty"`
+	AuthPass  string `json:"auth_pass,omitempty"`
+	PrivProto string `json:"priv_proto,omitempty"`
+	PrivPass  string `json:"priv_pass,omitempty"`
+}
+
+func (req *snmpCredUpsertRequest) validate() error {
+	if req.Version == "" {
+		req.Version = db.SNMPVersionV2c
+	}
+	if req.Version != db.SNMPVersionV2c && req.Version != db.SNMPVersionV3 {
+		return fmt.Errorf("version must be 'v2c' or 'v3'")
+	}
+	if req.Version == db.SNMPVersionV2c && req.Community == "" {
+		return fmt.Errorf("community is required for v2c")
+	}
+	if req.Version == db.SNMPVersionV3 && req.Username == "" {
+		return fmt.Errorf("username is required for v3")
+	}
+	return nil
+}
+
+// ListSNMPCredentials handles GET /api/v1/admin/snmp/credentials.
+// Secrets are redacted in the response.
+func (h *SNMPCredentialsHandler) ListSNMPCredentials(w http.ResponseWriter, r *http.Request) {
+	creds, err := h.repo.ListSNMPCredentials(r.Context())
+	if err != nil {
+		h.logger.Error("list snmp credentials", "err", err)
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, map[string]any{"credentials": creds})
+}
+
+// UpsertSNMPCredential handles PUT /api/v1/admin/snmp/credentials.
+// Creates or replaces the credential set for the given network/version scope.
+func (h *SNMPCredentialsHandler) UpsertSNMPCredential(w http.ResponseWriter, r *http.Request) {
+	var req snmpCredUpsertRequest
+	if err := parseJSON(r, &req); err != nil {
+		writeError(w, r, http.StatusBadRequest, err)
+		return
+	}
+	if err := req.validate(); err != nil {
+		writeError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	cred := &db.SNMPCredential{
+		NetworkID: req.NetworkID,
+		Version:   req.Version,
+		Community: req.Community,
+		Username:  req.Username,
+		AuthProto: req.AuthProto,
+		AuthPass:  req.AuthPass,
+		PrivProto: req.PrivProto,
+		PrivPass:  req.PrivPass,
+	}
+	saved, err := h.repo.UpsertSNMPCredential(r.Context(), cred)
+	if err != nil {
+		h.logger.Error("upsert snmp credential", "err", err)
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, saved.Redact())
+}
+
+// DeleteSNMPCredential handles DELETE /api/v1/admin/snmp/credentials/{id}.
+func (h *SNMPCredentialsHandler) DeleteSNMPCredential(w http.ResponseWriter, r *http.Request) {
+	id, err := extractUUIDFromPath(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	if err := h.repo.DeleteSNMPCredential(r.Context(), id); err != nil {
+		if errors.IsNotFound(err) {
+			writeError(w, r, http.StatusNotFound, err)
+			return
+		}
+		h.logger.Error("delete snmp credential", "id", id, "err", err)
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/handlers/snmp_credentials_test.go
+++ b/internal/api/handlers/snmp_credentials_test.go
@@ -1,0 +1,271 @@
+// Package handlers — unit tests for SNMPCredentialsHandler.
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	appcrypto "github.com/anstrom/scanorama/internal/crypto"
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func newSNMPCredsHandlerWithMock(t *testing.T) (*SNMPCredentialsHandler, sqlmock.Sqlmock) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	database := &db.DB{DB: sqlx.NewDb(sqlDB, "sqlmock")}
+	repo := db.NewSNMPCredentialsRepository(database)
+	return NewSNMPCredentialsHandler(repo, createTestLogger()), mock
+}
+
+var snmpCredHandlerCols = []string{
+	"id", "network_id", "version", "community", "username",
+	"auth_proto", "auth_pass", "priv_proto", "priv_pass",
+	"created_at", "updated_at",
+}
+
+func encryptForMock(t *testing.T, s string) *string {
+	t.Helper()
+	if s == "" {
+		return nil
+	}
+	enc, err := appcrypto.Encrypt(s)
+	require.NoError(t, err)
+	return &enc
+}
+
+func snmpJSONBody(t *testing.T, v any) *bytes.Buffer {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return bytes.NewBuffer(b)
+}
+
+func snmpRequest(method, target string, body *bytes.Buffer) *http.Request {
+	var req *http.Request
+	if body != nil {
+		req = httptest.NewRequest(method, target, body)
+	} else {
+		req = httptest.NewRequest(method, target, nil)
+	}
+	req = req.WithContext(context.WithValue(req.Context(), ContextKey("request_id"), "test-id"))
+	return req
+}
+
+// ── ListSNMPCredentials ───────────────────────────────────────────────────────
+
+func TestSNMPCredentialsHandler_List_Empty(t *testing.T) {
+	h, mock := newSNMPCredsHandlerWithMock(t)
+	mock.ExpectQuery("SELECT .* FROM snmp_credentials").
+		WillReturnRows(sqlmock.NewRows(snmpCredHandlerCols))
+
+	rr := httptest.NewRecorder()
+	h.ListSNMPCredentials(rr, snmpRequest(http.MethodGet, "/admin/snmp/credentials", nil))
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, []any{}, resp["credentials"], "empty list must return [] not null")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsHandler_List_SecretsAreRedacted(t *testing.T) {
+	h, mock := newSNMPCredsHandlerWithMock(t)
+	id := uuid.New()
+	now := time.Now().UTC()
+	encCommunity := encryptForMock(t, "plaintext-secret")
+
+	rows := sqlmock.NewRows(snmpCredHandlerCols).
+		AddRow(id, nil, "v2c", encCommunity, nil, nil, nil, nil, nil, now, now)
+	mock.ExpectQuery("SELECT .* FROM snmp_credentials").WillReturnRows(rows)
+
+	rr := httptest.NewRecorder()
+	h.ListSNMPCredentials(rr, snmpRequest(http.MethodGet, "/admin/snmp/credentials", nil))
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	assert.NotContains(t, body, "plaintext-secret", "plaintext must never appear in response")
+	assert.Contains(t, body, "***")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsHandler_List_DBError(t *testing.T) {
+	h, mock := newSNMPCredsHandlerWithMock(t)
+	mock.ExpectQuery("SELECT .* FROM snmp_credentials").
+		WillReturnError(fmt.Errorf("db down"))
+
+	rr := httptest.NewRecorder()
+	h.ListSNMPCredentials(rr, snmpRequest(http.MethodGet, "/admin/snmp/credentials", nil))
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── UpsertSNMPCredential ──────────────────────────────────────────────────────
+
+func TestSNMPCredentialsHandler_Upsert_V2c_OK(t *testing.T) {
+	h, mock := newSNMPCredsHandlerWithMock(t)
+	id := uuid.New()
+	now := time.Now().UTC()
+	encCommunity := encryptForMock(t, "my-community")
+
+	mock.ExpectQuery("INSERT INTO snmp_credentials").
+		WillReturnRows(sqlmock.NewRows(snmpCredHandlerCols).
+			AddRow(id, nil, "v2c", encCommunity, nil, nil, nil, nil, nil, now, now))
+
+	body := snmpJSONBody(t, map[string]any{"version": "v2c", "community": "my-community"})
+	rr := httptest.NewRecorder()
+	h.UpsertSNMPCredential(rr, snmpRequest(http.MethodPut, "/admin/snmp/credentials", body))
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	// Response must redact the community.
+	respBody := rr.Body.String()
+	assert.NotContains(t, respBody, "my-community")
+	assert.Contains(t, respBody, "***")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsHandler_Upsert_V2c_MissingCommunity_400(t *testing.T) {
+	h, _ := newSNMPCredsHandlerWithMock(t)
+	body := snmpJSONBody(t, map[string]any{"version": "v2c"})
+	rr := httptest.NewRecorder()
+	h.UpsertSNMPCredential(rr, snmpRequest(http.MethodPut, "/admin/snmp/credentials", body))
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestSNMPCredentialsHandler_Upsert_V3_MissingUsername_400(t *testing.T) {
+	h, _ := newSNMPCredsHandlerWithMock(t)
+	body := snmpJSONBody(t, map[string]any{"version": "v3"})
+	rr := httptest.NewRecorder()
+	h.UpsertSNMPCredential(rr, snmpRequest(http.MethodPut, "/admin/snmp/credentials", body))
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestSNMPCredentialsHandler_Upsert_InvalidVersion_400(t *testing.T) {
+	h, _ := newSNMPCredsHandlerWithMock(t)
+	body := snmpJSONBody(t, map[string]any{"version": "v1", "community": "x"})
+	rr := httptest.NewRecorder()
+	h.UpsertSNMPCredential(rr, snmpRequest(http.MethodPut, "/admin/snmp/credentials", body))
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestSNMPCredentialsHandler_Upsert_DefaultsToV2c(t *testing.T) {
+	h, mock := newSNMPCredsHandlerWithMock(t)
+	id := uuid.New()
+	now := time.Now().UTC()
+	encCommunity := encryptForMock(t, "comm")
+
+	mock.ExpectQuery("INSERT INTO snmp_credentials").
+		WillReturnRows(sqlmock.NewRows(snmpCredHandlerCols).
+			AddRow(id, nil, "v2c", encCommunity, nil, nil, nil, nil, nil, now, now))
+
+	// No version field in the request.
+	body := snmpJSONBody(t, map[string]any{"community": "comm"})
+	rr := httptest.NewRecorder()
+	h.UpsertSNMPCredential(rr, snmpRequest(http.MethodPut, "/admin/snmp/credentials", body))
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsHandler_Upsert_MalformedJSON_400(t *testing.T) {
+	h, _ := newSNMPCredsHandlerWithMock(t)
+	rr := httptest.NewRecorder()
+	h.UpsertSNMPCredential(rr, snmpRequest(http.MethodPut, "/admin/snmp/credentials",
+		bytes.NewBufferString("{not json")))
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestSNMPCredentialsHandler_Upsert_DBError_500(t *testing.T) {
+	h, mock := newSNMPCredsHandlerWithMock(t)
+	mock.ExpectQuery("INSERT INTO snmp_credentials").
+		WillReturnError(fmt.Errorf("constraint error"))
+
+	body := snmpJSONBody(t, map[string]any{"version": "v2c", "community": "x"})
+	rr := httptest.NewRecorder()
+	h.UpsertSNMPCredential(rr, snmpRequest(http.MethodPut, "/admin/snmp/credentials", body))
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── DeleteSNMPCredential ──────────────────────────────────────────────────────
+
+func snmpDeleteRequest(id uuid.UUID) *http.Request {
+	req := snmpRequest(http.MethodDelete, "/admin/snmp/credentials/"+id.String(), nil)
+	req = mux.SetURLVars(req, map[string]string{"id": id.String()})
+	return req
+}
+
+func TestSNMPCredentialsHandler_Delete_OK(t *testing.T) {
+	h, mock := newSNMPCredsHandlerWithMock(t)
+	id := uuid.New()
+	mock.ExpectExec("DELETE FROM snmp_credentials").
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	rr := httptest.NewRecorder()
+	h.DeleteSNMPCredential(rr, snmpDeleteRequest(id))
+
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsHandler_Delete_NotFound_404(t *testing.T) {
+	h, mock := newSNMPCredsHandlerWithMock(t)
+	id := uuid.New()
+	mock.ExpectExec("DELETE FROM snmp_credentials").
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	rr := httptest.NewRecorder()
+	h.DeleteSNMPCredential(rr, snmpDeleteRequest(id))
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsHandler_Delete_InvalidUUID_400(t *testing.T) {
+	h, _ := newSNMPCredsHandlerWithMock(t)
+	req := snmpRequest(http.MethodDelete, "/admin/snmp/credentials/not-a-uuid", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "not-a-uuid"})
+
+	rr := httptest.NewRecorder()
+	h.DeleteSNMPCredential(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestSNMPCredentialsHandler_Delete_DBError_500(t *testing.T) {
+	h, mock := newSNMPCredsHandlerWithMock(t)
+	id := uuid.New()
+	mock.ExpectExec("DELETE FROM snmp_credentials").
+		WithArgs(id).
+		WillReturnError(fmt.Errorf("db error"))
+
+	rr := httptest.NewRecorder()
+	h.DeleteSNMPCredential(rr, snmpDeleteRequest(id))
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -92,6 +92,7 @@ func (s *Server) setupRoutes() {
 	api.HandleFunc("/admin/settings", settingsHandler.GetSettings).Methods("GET")
 	api.HandleFunc("/admin/settings", settingsHandler.UpdateSettings).Methods("PUT")
 
+	s.setupAdminSNMPRoutes(api)
 	s.setupDocRoutes()
 	s.router.HandleFunc("/", s.redirectToAPI).Methods("GET")
 }
@@ -229,6 +230,15 @@ func (s *Server) setupPortRoutes(api *mux.Router, h *apihandlers.PortHandler) {
 // setupCertificateRoutes registers TLS certificate endpoints.
 func (s *Server) setupCertificateRoutes(api *mux.Router, h *apihandlers.CertificateHandler) {
 	api.HandleFunc("/certificates/expiring", h.GetExpiringCertificates).Methods("GET")
+}
+
+// setupAdminSNMPRoutes registers SNMP credential management endpoints.
+func (s *Server) setupAdminSNMPRoutes(api *mux.Router) {
+	h := apihandlers.NewSNMPCredentialsHandler(
+		db.NewSNMPCredentialsRepository(s.database), s.logger)
+	api.HandleFunc("/admin/snmp/credentials", h.ListSNMPCredentials).Methods("GET")
+	api.HandleFunc("/admin/snmp/credentials", h.UpsertSNMPCredential).Methods("PUT")
+	api.HandleFunc("/admin/snmp/credentials/{id}", h.DeleteSNMPCredential).Methods("DELETE")
 }
 
 // buildScheduler constructs and wires the cron scheduler.

--- a/internal/crypto/aes.go
+++ b/internal/crypto/aes.go
@@ -1,0 +1,115 @@
+// Package crypto provides AES-256-GCM encryption for sensitive stored values.
+// The encryption key is loaded from the SCANORAMA_SECRET_KEY environment
+// variable (exactly 64 hex characters = 32 bytes). If the variable is absent,
+// a random ephemeral key is generated and a warning is logged — credentials
+// encrypted with an ephemeral key are lost on restart, so set the variable in
+// production.
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+)
+
+const (
+	keyEnvVar = "SCANORAMA_SECRET_KEY"
+	keyBytes  = 32 // AES-256
+)
+
+var (
+	globalKey  []byte
+	globalOnce sync.Once
+)
+
+// key returns the encryption key, initializing it on first call.
+func key() []byte {
+	globalOnce.Do(func() {
+		raw := os.Getenv(keyEnvVar)
+		if raw != "" {
+			decoded, err := hex.DecodeString(raw)
+			if err == nil && len(decoded) == keyBytes {
+				globalKey = decoded
+				return
+			}
+			slog.Warn("crypto: SCANORAMA_SECRET_KEY is set but invalid (must be 64 hex chars); using ephemeral key")
+		} else {
+			slog.Warn("crypto: SCANORAMA_SECRET_KEY not set; using ephemeral key — credentials will be lost on restart")
+		}
+
+		ephemeral := make([]byte, keyBytes)
+		if _, err := io.ReadFull(rand.Reader, ephemeral); err != nil {
+			panic(fmt.Sprintf("crypto: failed to generate ephemeral key: %v", err))
+		}
+		globalKey = ephemeral
+	})
+	return globalKey
+}
+
+// Encrypt encrypts plaintext using AES-256-GCM and returns a hex-encoded
+// "nonce||ciphertext" string safe to store in a TEXT column.
+// Returns "" for an empty plaintext (no-op, avoids storing encrypted empty strings).
+func Encrypt(plaintext string) (string, error) {
+	if plaintext == "" {
+		return "", nil
+	}
+
+	block, err := aes.NewCipher(key())
+	if err != nil {
+		return "", fmt.Errorf("crypto: new cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("crypto: new GCM: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("crypto: rand nonce: %w", err)
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+	return hex.EncodeToString(ciphertext), nil
+}
+
+// Decrypt decrypts a hex-encoded "nonce||ciphertext" string produced by Encrypt.
+// Returns "" for an empty input.
+func Decrypt(encoded string) (string, error) {
+	if encoded == "" {
+		return "", nil
+	}
+
+	data, err := hex.DecodeString(encoded)
+	if err != nil {
+		return "", fmt.Errorf("crypto: decode hex: %w", err)
+	}
+
+	block, err := aes.NewCipher(key())
+	if err != nil {
+		return "", fmt.Errorf("crypto: new cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("crypto: new GCM: %w", err)
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return "", fmt.Errorf("crypto: ciphertext too short")
+	}
+
+	plaintext, err := gcm.Open(nil, data[:nonceSize], data[nonceSize:], nil)
+	if err != nil {
+		return "", fmt.Errorf("crypto: decrypt: %w", err)
+	}
+
+	return string(plaintext), nil
+}

--- a/internal/crypto/aes_test.go
+++ b/internal/crypto/aes_test.go
@@ -1,0 +1,123 @@
+// Package crypto — unit tests for AES-256-GCM encrypt/decrypt.
+package crypto
+
+import (
+	"encoding/hex"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetKey resets the package-level singleton so tests that set different env
+// vars can exercise the initialisation logic independently.
+func resetKey() {
+	globalKey = nil
+	globalOnce = sync.Once{}
+}
+
+// testKey is a fixed 32-byte key encoded as 64 hex chars for deterministic tests.
+const testKey = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+
+// ── Encrypt / Decrypt round-trip ─────────────────────────────────────────────
+
+func TestEncryptDecrypt_RoundTrip(t *testing.T) {
+	t.Setenv(keyEnvVar, testKey)
+	resetKey()
+	t.Cleanup(resetKey)
+
+	cases := []string{
+		"public",
+		"s3cr3t!community",
+		"v3-auth-password-with-special-chars-åøæ",
+		strings.Repeat("x", 256),
+	}
+	for _, plain := range cases {
+		enc, err := Encrypt(plain)
+		require.NoError(t, err, "Encrypt(%q)", plain)
+		assert.NotEmpty(t, enc)
+		assert.NotEqual(t, plain, enc, "ciphertext must differ from plaintext")
+
+		got, err := Decrypt(enc)
+		require.NoError(t, err, "Decrypt(Encrypt(%q))", plain)
+		assert.Equal(t, plain, got)
+	}
+}
+
+func TestEncrypt_EmptyString(t *testing.T) {
+	t.Setenv(keyEnvVar, testKey)
+	resetKey()
+	t.Cleanup(resetKey)
+
+	enc, err := Encrypt("")
+	require.NoError(t, err)
+	assert.Empty(t, enc, "Encrypt of empty string must return empty string")
+}
+
+func TestDecrypt_EmptyString(t *testing.T) {
+	t.Setenv(keyEnvVar, testKey)
+	resetKey()
+	t.Cleanup(resetKey)
+
+	got, err := Decrypt("")
+	require.NoError(t, err)
+	assert.Empty(t, got, "Decrypt of empty string must return empty string")
+}
+
+// ── Decrypt error paths ───────────────────────────────────────────────────────
+
+func TestDecrypt_TamperedCiphertext(t *testing.T) {
+	t.Setenv(keyEnvVar, testKey)
+	resetKey()
+	t.Cleanup(resetKey)
+
+	enc, err := Encrypt("original")
+	require.NoError(t, err)
+
+	// Flip the last hex byte to corrupt the GCM authentication tag.
+	b, err := hex.DecodeString(enc)
+	require.NoError(t, err)
+	b[len(b)-1] ^= 0xff
+	tampered := hex.EncodeToString(b)
+
+	_, err = Decrypt(tampered)
+	assert.Error(t, err, "tampered ciphertext must not decrypt successfully")
+}
+
+func TestDecrypt_InvalidHex(t *testing.T) {
+	t.Setenv(keyEnvVar, testKey)
+	resetKey()
+	t.Cleanup(resetKey)
+
+	_, err := Decrypt("not-valid-hex!!!")
+	assert.Error(t, err)
+}
+
+func TestDecrypt_TooShort(t *testing.T) {
+	t.Setenv(keyEnvVar, testKey)
+	resetKey()
+	t.Cleanup(resetKey)
+
+	// Encode fewer bytes than the GCM nonce size (12 bytes).
+	short := hex.EncodeToString([]byte{0x01, 0x02, 0x03})
+	_, err := Decrypt(short)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too short")
+}
+
+// ── Nonces are unique ─────────────────────────────────────────────────────────
+
+func TestEncrypt_UniqueNonces(t *testing.T) {
+	t.Setenv(keyEnvVar, testKey)
+	resetKey()
+	t.Cleanup(resetKey)
+
+	enc1, err := Encrypt("same-input")
+	require.NoError(t, err)
+	enc2, err := Encrypt("same-input")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, enc1, enc2, "each encryption must use a fresh random nonce")
+}

--- a/internal/db/020_snmp_credentials.sql
+++ b/internal/db/020_snmp_credentials.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS snmp_credentials (
+    id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    network_id UUID        REFERENCES networks(id) ON DELETE CASCADE,
+    version    VARCHAR(4)  NOT NULL DEFAULT 'v2c' CHECK (version IN ('v2c', 'v3')),
+    -- SNMPv2c
+    community  TEXT,
+    -- SNMPv3
+    username   TEXT,
+    auth_proto VARCHAR(8)  CHECK (auth_proto IS NULL OR auth_proto IN ('MD5', 'SHA')),
+    auth_pass  TEXT,
+    priv_proto VARCHAR(8)  CHECK (priv_proto IS NULL OR priv_proto IN ('DES', 'AES')),
+    priv_pass  TEXT,
+    -- Metadata
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- One credential set per scope (global=NULL network_id) per version
+    UNIQUE NULLS NOT DISTINCT (network_id, version)
+);

--- a/internal/db/repository_snmp_creds.go
+++ b/internal/db/repository_snmp_creds.go
@@ -1,0 +1,343 @@
+// Package db provides typed repository for SNMP credential operations.
+package db
+
+import (
+	"context"
+	"database/sql"
+	stderrors "errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	appcrypto "github.com/anstrom/scanorama/internal/crypto"
+	"github.com/anstrom/scanorama/internal/errors"
+)
+
+// SNMPVersion identifies the SNMP protocol version for a credential set.
+type SNMPVersion string
+
+const (
+	SNMPVersionV2c SNMPVersion = "v2c"
+	SNMPVersionV3  SNMPVersion = "v3"
+
+	// redactedSecret is the placeholder used in API responses for secret fields.
+	redactedSecret = "***"
+)
+
+// SNMPCredential holds decrypted SNMP credentials for a scope.
+// NetworkID nil means global default.
+type SNMPCredential struct {
+	ID        uuid.UUID   `db:"id"         json:"id"`
+	NetworkID *uuid.UUID  `db:"network_id" json:"network_id,omitempty"`
+	Version   SNMPVersion `db:"version"    json:"version"`
+	// v2c
+	Community string `json:"community,omitempty"` // plain text in memory, encrypted in DB
+	// v3
+	Username  string `json:"username,omitempty"`
+	AuthProto string `json:"auth_proto,omitempty"`
+	AuthPass  string `json:"auth_pass,omitempty"` // plain text in memory, encrypted in DB
+	PrivProto string `json:"priv_proto,omitempty"`
+	PrivPass  string `json:"priv_pass,omitempty"` // plain text in memory, encrypted in DB
+	// Metadata
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
+	UpdatedAt time.Time `db:"updated_at" json:"updated_at"`
+}
+
+// SNMPCredentialSafe is like SNMPCredential but with secrets redacted for API responses.
+type SNMPCredentialSafe struct {
+	ID        uuid.UUID   `json:"id"`
+	NetworkID *uuid.UUID  `json:"network_id,omitempty"`
+	Version   SNMPVersion `json:"version"`
+	Community string      `json:"community,omitempty"` // redactedSecret if set
+	Username  string      `json:"username,omitempty"`
+	AuthProto string      `json:"auth_proto,omitempty"`
+	AuthPass  string      `json:"auth_pass,omitempty"` // redactedSecret if set
+	PrivProto string      `json:"priv_proto,omitempty"`
+	PrivPass  string      `json:"priv_pass,omitempty"` // redactedSecret if set
+	CreatedAt time.Time   `json:"created_at"`
+	UpdatedAt time.Time   `json:"updated_at"`
+}
+
+// Redact returns a copy with secret fields replaced by redactedSecret.
+func (c *SNMPCredential) Redact() SNMPCredentialSafe {
+	safe := SNMPCredentialSafe{
+		ID:        c.ID,
+		NetworkID: c.NetworkID,
+		Version:   c.Version,
+		Username:  c.Username,
+		AuthProto: c.AuthProto,
+		PrivProto: c.PrivProto,
+		CreatedAt: c.CreatedAt,
+		UpdatedAt: c.UpdatedAt,
+	}
+	if c.Community != "" {
+		safe.Community = redactedSecret
+	}
+	if c.AuthPass != "" {
+		safe.AuthPass = redactedSecret
+	}
+	if c.PrivPass != "" {
+		safe.PrivPass = redactedSecret
+	}
+	return safe
+}
+
+// SNMPCredentialsRepository handles SNMP credential persistence.
+type SNMPCredentialsRepository struct {
+	db *DB
+}
+
+// NewSNMPCredentialsRepository creates a new SNMPCredentialsRepository.
+func NewSNMPCredentialsRepository(db *DB) *SNMPCredentialsRepository {
+	return &SNMPCredentialsRepository{db: db}
+}
+
+// row holds raw encrypted DB values between scan and decrypt.
+type snmpCredRow struct {
+	ID        uuid.UUID   `db:"id"`
+	NetworkID *uuid.UUID  `db:"network_id"`
+	Version   SNMPVersion `db:"version"`
+	Community *string     `db:"community"`
+	Username  *string     `db:"username"`
+	AuthProto *string     `db:"auth_proto"`
+	AuthPass  *string     `db:"auth_pass"`
+	PrivProto *string     `db:"priv_proto"`
+	PrivPass  *string     `db:"priv_pass"`
+	CreatedAt time.Time   `db:"created_at"`
+	UpdatedAt time.Time   `db:"updated_at"`
+}
+
+func (row *snmpCredRow) decrypt() (*SNMPCredential, error) {
+	c := &SNMPCredential{
+		ID:        row.ID,
+		NetworkID: row.NetworkID,
+		Version:   row.Version,
+		CreatedAt: row.CreatedAt,
+		UpdatedAt: row.UpdatedAt,
+	}
+	var err error
+	if row.Community != nil {
+		if c.Community, err = appcrypto.Decrypt(*row.Community); err != nil {
+			return nil, fmt.Errorf("decrypt community: %w", err)
+		}
+	}
+	if row.AuthPass != nil {
+		if c.AuthPass, err = appcrypto.Decrypt(*row.AuthPass); err != nil {
+			return nil, fmt.Errorf("decrypt auth_pass: %w", err)
+		}
+	}
+	if row.PrivPass != nil {
+		if c.PrivPass, err = appcrypto.Decrypt(*row.PrivPass); err != nil {
+			return nil, fmt.Errorf("decrypt priv_pass: %w", err)
+		}
+	}
+	if row.Username != nil {
+		c.Username = *row.Username
+	}
+	if row.AuthProto != nil {
+		c.AuthProto = *row.AuthProto
+	}
+	if row.PrivProto != nil {
+		c.PrivProto = *row.PrivProto
+	}
+	return c, nil
+}
+
+const selectSNMPCredsColumns = `id, network_id, version, community, username,
+	auth_proto, auth_pass, priv_proto, priv_pass, created_at, updated_at`
+
+// ListSNMPCredentials returns all credential rows as safe (redacted) values.
+// Secrets are never decrypted; presence is inferred from column nullability.
+func (r *SNMPCredentialsRepository) ListSNMPCredentials(ctx context.Context) ([]SNMPCredentialSafe, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT `+selectSNMPCredsColumns+` FROM snmp_credentials ORDER BY network_id NULLS FIRST, version`)
+	if err != nil {
+		return nil, sanitizeDBError("list snmp credentials", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var creds []SNMPCredentialSafe
+	for rows.Next() {
+		var row snmpCredRow
+		if err := rows.Scan(&row.ID, &row.NetworkID, &row.Version, &row.Community,
+			&row.Username, &row.AuthProto, &row.AuthPass, &row.PrivProto, &row.PrivPass,
+			&row.CreatedAt, &row.UpdatedAt); err != nil {
+			return nil, sanitizeDBError("scan snmp credential row", err)
+		}
+		creds = append(creds, row.redact())
+	}
+	if err := rows.Err(); err != nil {
+		return nil, sanitizeDBError("iterate snmp credentials", err)
+	}
+	if creds == nil {
+		creds = []SNMPCredentialSafe{}
+	}
+	return creds, nil
+}
+
+// redact builds a SNMPCredentialSafe from a raw DB row without decrypting secrets.
+// A non-NULL column value is represented as redactedSecret in the safe view.
+func (row *snmpCredRow) redact() SNMPCredentialSafe {
+	safe := SNMPCredentialSafe{
+		ID:        row.ID,
+		NetworkID: row.NetworkID,
+		Version:   row.Version,
+		CreatedAt: row.CreatedAt,
+		UpdatedAt: row.UpdatedAt,
+	}
+	if row.Username != nil {
+		safe.Username = *row.Username
+	}
+	if row.AuthProto != nil {
+		safe.AuthProto = *row.AuthProto
+	}
+	if row.PrivProto != nil {
+		safe.PrivProto = *row.PrivProto
+	}
+	if row.Community != nil && *row.Community != "" {
+		safe.Community = redactedSecret
+	}
+	if row.AuthPass != nil && *row.AuthPass != "" {
+		safe.AuthPass = redactedSecret
+	}
+	if row.PrivPass != nil && *row.PrivPass != "" {
+		safe.PrivPass = redactedSecret
+	}
+	return safe
+}
+
+// GetSNMPCredential returns a single credential by ID.
+func (r *SNMPCredentialsRepository) GetSNMPCredential(ctx context.Context, id uuid.UUID) (*SNMPCredential, error) {
+	var row snmpCredRow
+	err := r.db.QueryRowContext(ctx,
+		`SELECT `+selectSNMPCredsColumns+` FROM snmp_credentials WHERE id = $1`, id).
+		Scan(&row.ID, &row.NetworkID, &row.Version, &row.Community,
+			&row.Username, &row.AuthProto, &row.AuthPass, &row.PrivProto, &row.PrivPass,
+			&row.CreatedAt, &row.UpdatedAt)
+	if err != nil {
+		if stderrors.Is(err, sql.ErrNoRows) {
+			return nil, errors.ErrNotFound("snmp_credential")
+		}
+		return nil, sanitizeDBError("get snmp credential", err)
+	}
+	return row.decrypt()
+}
+
+// GetEffectiveCommunity returns the decrypted SNMPv2c community string for the
+// given network, falling back to the global default. Returns "public" if no
+// credential is configured.
+func (r *SNMPCredentialsRepository) GetEffectiveCommunity(ctx context.Context, networkID *uuid.UUID) (string, error) {
+	// Try network-specific first, then global (network_id IS NULL).
+	var candidates []*uuid.UUID
+	if networkID != nil {
+		candidates = append(candidates, networkID)
+	}
+	candidates = append(candidates, nil) // global fallback
+
+	for _, nid := range candidates {
+		var row snmpCredRow
+		var err error
+		if nid == nil {
+			err = r.db.QueryRowContext(ctx,
+				`SELECT `+selectSNMPCredsColumns+
+					` FROM snmp_credentials WHERE network_id IS NULL AND version = 'v2c'`).
+				Scan(&row.ID, &row.NetworkID, &row.Version, &row.Community,
+					&row.Username, &row.AuthProto, &row.AuthPass, &row.PrivProto, &row.PrivPass,
+					&row.CreatedAt, &row.UpdatedAt)
+		} else {
+			err = r.db.QueryRowContext(ctx,
+				`SELECT `+selectSNMPCredsColumns+
+					` FROM snmp_credentials WHERE network_id = $1 AND version = 'v2c'`, nid).
+				Scan(&row.ID, &row.NetworkID, &row.Version, &row.Community,
+					&row.Username, &row.AuthProto, &row.AuthPass, &row.PrivProto, &row.PrivPass,
+					&row.CreatedAt, &row.UpdatedAt)
+		}
+		if stderrors.Is(err, sql.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			return "", sanitizeDBError("get effective snmp community", err)
+		}
+		c, err := row.decrypt()
+		if err != nil {
+			return "", err
+		}
+		if c.Community != "" {
+			return c.Community, nil
+		}
+	}
+	return "public", nil // built-in default
+}
+
+// UpsertSNMPCredential inserts or replaces a credential set. Secrets in the
+// input are expected to be plain text; this method encrypts them before storage.
+func (r *SNMPCredentialsRepository) UpsertSNMPCredential(
+	ctx context.Context, c *SNMPCredential,
+) (*SNMPCredential, error) {
+	encCommunity, err := appcrypto.Encrypt(c.Community)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt community: %w", err)
+	}
+	encAuthPass, err := appcrypto.Encrypt(c.AuthPass)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt auth_pass: %w", err)
+	}
+	encPrivPass, err := appcrypto.Encrypt(c.PrivPass)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt priv_pass: %w", err)
+	}
+
+	nullStr := func(s string) *string {
+		if s == "" {
+			return nil
+		}
+		return &s
+	}
+
+	var row snmpCredRow
+	err = r.db.QueryRowContext(ctx, `
+		INSERT INTO snmp_credentials
+			(network_id, version, community, username, auth_proto, auth_pass, priv_proto, priv_pass, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+		ON CONFLICT (network_id, version) DO UPDATE SET
+			community  = EXCLUDED.community,
+			username   = EXCLUDED.username,
+			auth_proto = EXCLUDED.auth_proto,
+			auth_pass  = EXCLUDED.auth_pass,
+			priv_proto = EXCLUDED.priv_proto,
+			priv_pass  = EXCLUDED.priv_pass,
+			updated_at = NOW()
+		RETURNING `+selectSNMPCredsColumns,
+		c.NetworkID,
+		string(c.Version),
+		nullStr(encCommunity),
+		nullStr(c.Username),
+		nullStr(c.AuthProto),
+		nullStr(encAuthPass),
+		nullStr(c.PrivProto),
+		nullStr(encPrivPass),
+	).Scan(&row.ID, &row.NetworkID, &row.Version, &row.Community,
+		&row.Username, &row.AuthProto, &row.AuthPass, &row.PrivProto, &row.PrivPass,
+		&row.CreatedAt, &row.UpdatedAt)
+	if err != nil {
+		return nil, sanitizeDBError("upsert snmp credential", err)
+	}
+	return row.decrypt()
+}
+
+// DeleteSNMPCredential removes a credential by ID.
+func (r *SNMPCredentialsRepository) DeleteSNMPCredential(ctx context.Context, id uuid.UUID) error {
+	result, err := r.db.ExecContext(ctx, `DELETE FROM snmp_credentials WHERE id = $1`, id)
+	if err != nil {
+		return sanitizeDBError("delete snmp credential", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return sanitizeDBError("delete snmp credential rows affected", err)
+	}
+	if n == 0 {
+		return errors.ErrNotFound("snmp_credential")
+	}
+	return nil
+}

--- a/internal/db/repository_snmp_creds_unit_test.go
+++ b/internal/db/repository_snmp_creds_unit_test.go
@@ -1,0 +1,323 @@
+// Package db — unit tests for SNMPCredentialsRepository using sqlmock.
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	appcrypto "github.com/anstrom/scanorama/internal/crypto"
+	"github.com/anstrom/scanorama/internal/errors"
+)
+
+var snmpCredCols = []string{
+	"id", "network_id", "version", "community", "username",
+	"auth_proto", "auth_pass", "priv_proto", "priv_pass",
+	"created_at", "updated_at",
+}
+
+// encryptOrPanic is a test helper that encrypts a string or panics.
+func encryptOrPanic(s string) *string {
+	if s == "" {
+		return nil
+	}
+	enc, err := appcrypto.Encrypt(s)
+	if err != nil {
+		panic(err)
+	}
+	return &enc
+}
+
+// ── ListSNMPCredentials ───────────────────────────────────────────────────────
+
+func TestSNMPCredentialsRepository_List_Empty(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT .* FROM snmp_credentials").
+		WillReturnRows(sqlmock.NewRows(snmpCredCols))
+
+	creds, err := NewSNMPCredentialsRepository(db).ListSNMPCredentials(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, creds)
+	assert.NotNil(t, creds, "empty result must be [] not nil")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsRepository_List_RedactsSecrets(t *testing.T) {
+	db, mock := newMockDB(t)
+	id := uuid.New()
+	now := time.Now().UTC()
+
+	encCommunity := encryptOrPanic("secret-community")
+	rows := sqlmock.NewRows(snmpCredCols).
+		AddRow(id, nil, "v2c", encCommunity, nil, nil, nil, nil, nil, now, now)
+	mock.ExpectQuery("SELECT .* FROM snmp_credentials").WillReturnRows(rows)
+
+	creds, err := NewSNMPCredentialsRepository(db).ListSNMPCredentials(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, creds, 1)
+	assert.Equal(t, "***", creds[0].Community, "community must be redacted")
+	assert.Empty(t, creds[0].AuthPass)
+	assert.Empty(t, creds[0].PrivPass)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsRepository_List_DBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT .* FROM snmp_credentials").
+		WillReturnError(fmt.Errorf("connection reset"))
+
+	_, err := NewSNMPCredentialsRepository(db).ListSNMPCredentials(context.Background())
+
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── GetEffectiveCommunity ─────────────────────────────────────────────────────
+
+func TestSNMPCredentialsRepository_GetEffectiveCommunity_NetworkHit(t *testing.T) {
+	db, mock := newMockDB(t)
+	netID := uuid.New()
+	id := uuid.New()
+	now := time.Now().UTC()
+
+	encCommunity := encryptOrPanic("net-community")
+	mock.ExpectQuery("SELECT .* FROM snmp_credentials WHERE network_id").
+		WithArgs(netID).
+		WillReturnRows(sqlmock.NewRows(snmpCredCols).
+			AddRow(id, &netID, "v2c", encCommunity, nil, nil, nil, nil, nil, now, now))
+
+	community, err := NewSNMPCredentialsRepository(db).GetEffectiveCommunity(context.Background(), &netID)
+
+	require.NoError(t, err)
+	assert.Equal(t, "net-community", community)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsRepository_GetEffectiveCommunity_NetworkMiss_GlobalHit(t *testing.T) {
+	db, mock := newMockDB(t)
+	netID := uuid.New()
+	id := uuid.New()
+	now := time.Now().UTC()
+
+	// Network-specific query returns no row.
+	mock.ExpectQuery("SELECT .* FROM snmp_credentials WHERE network_id").
+		WithArgs(netID).
+		WillReturnError(sql.ErrNoRows)
+
+	// Global fallback query returns a row.
+	encCommunity := encryptOrPanic("global-community")
+	mock.ExpectQuery("SELECT .* FROM snmp_credentials WHERE network_id IS NULL").
+		WillReturnRows(sqlmock.NewRows(snmpCredCols).
+			AddRow(id, nil, "v2c", encCommunity, nil, nil, nil, nil, nil, now, now))
+
+	community, err := NewSNMPCredentialsRepository(db).GetEffectiveCommunity(context.Background(), &netID)
+
+	require.NoError(t, err)
+	assert.Equal(t, "global-community", community)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsRepository_GetEffectiveCommunity_BothAbsent(t *testing.T) {
+	db, mock := newMockDB(t)
+	netID := uuid.New()
+
+	mock.ExpectQuery("SELECT .* FROM snmp_credentials WHERE network_id").
+		WithArgs(netID).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT .* FROM snmp_credentials WHERE network_id IS NULL").
+		WillReturnError(sql.ErrNoRows)
+
+	community, err := NewSNMPCredentialsRepository(db).GetEffectiveCommunity(context.Background(), &netID)
+
+	require.NoError(t, err)
+	assert.Equal(t, "public", community, "must fall back to built-in default")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsRepository_GetEffectiveCommunity_NilNetworkID(t *testing.T) {
+	db, mock := newMockDB(t)
+	id := uuid.New()
+	now := time.Now().UTC()
+
+	// Only the global query should be issued — no network-scoped query.
+	encCommunity := encryptOrPanic("global-only")
+	mock.ExpectQuery("SELECT .* FROM snmp_credentials WHERE network_id IS NULL").
+		WillReturnRows(sqlmock.NewRows(snmpCredCols).
+			AddRow(id, nil, "v2c", encCommunity, nil, nil, nil, nil, nil, now, now))
+
+	community, err := NewSNMPCredentialsRepository(db).GetEffectiveCommunity(context.Background(), nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "global-only", community)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsRepository_GetEffectiveCommunity_DBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	netID := uuid.New()
+
+	mock.ExpectQuery("SELECT .* FROM snmp_credentials WHERE network_id").
+		WithArgs(netID).
+		WillReturnError(fmt.Errorf("db unavailable"))
+
+	_, err := NewSNMPCredentialsRepository(db).GetEffectiveCommunity(context.Background(), &netID)
+
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── UpsertSNMPCredential ──────────────────────────────────────────────────────
+
+func TestSNMPCredentialsRepository_Upsert_V2c(t *testing.T) {
+	db, mock := newMockDB(t)
+	id := uuid.New()
+	now := time.Now().UTC()
+	encCommunity := encryptOrPanic("my-community")
+
+	mock.ExpectQuery("INSERT INTO snmp_credentials").
+		WillReturnRows(sqlmock.NewRows(snmpCredCols).
+			AddRow(id, nil, "v2c", encCommunity, nil, nil, nil, nil, nil, now, now))
+
+	cred := &SNMPCredential{
+		Version:   SNMPVersionV2c,
+		Community: "my-community",
+	}
+	saved, err := NewSNMPCredentialsRepository(db).UpsertSNMPCredential(context.Background(), cred)
+
+	require.NoError(t, err)
+	require.NotNil(t, saved)
+	assert.Equal(t, "my-community", saved.Community, "returned credential must be decrypted")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsRepository_Upsert_V3(t *testing.T) {
+	db, mock := newMockDB(t)
+	id := uuid.New()
+	now := time.Now().UTC()
+	encAuthPass := encryptOrPanic("auth-secret")
+	encPrivPass := encryptOrPanic("priv-secret")
+
+	mock.ExpectQuery("INSERT INTO snmp_credentials").
+		WillReturnRows(sqlmock.NewRows(snmpCredCols).
+			AddRow(id, nil, "v3", nil,
+				strPtr("admin"), strPtr("SHA"), encAuthPass,
+				strPtr("AES"), encPrivPass, now, now))
+
+	cred := &SNMPCredential{
+		Version:   SNMPVersionV3,
+		Username:  "admin",
+		AuthProto: "SHA",
+		AuthPass:  "auth-secret",
+		PrivProto: "AES",
+		PrivPass:  "priv-secret",
+	}
+	saved, err := NewSNMPCredentialsRepository(db).UpsertSNMPCredential(context.Background(), cred)
+
+	require.NoError(t, err)
+	require.NotNil(t, saved)
+	assert.Equal(t, "admin", saved.Username)
+	assert.Equal(t, "auth-secret", saved.AuthPass)
+	assert.Equal(t, "priv-secret", saved.PrivPass)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsRepository_Upsert_DBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("INSERT INTO snmp_credentials").
+		WillReturnError(fmt.Errorf("constraint violation"))
+
+	_, err := NewSNMPCredentialsRepository(db).UpsertSNMPCredential(context.Background(), &SNMPCredential{
+		Version:   SNMPVersionV2c,
+		Community: "x",
+	})
+
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── DeleteSNMPCredential ──────────────────────────────────────────────────────
+
+func TestSNMPCredentialsRepository_Delete_OK(t *testing.T) {
+	db, mock := newMockDB(t)
+	id := uuid.New()
+	mock.ExpectExec("DELETE FROM snmp_credentials").
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := NewSNMPCredentialsRepository(db).DeleteSNMPCredential(context.Background(), id)
+
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsRepository_Delete_NotFound(t *testing.T) {
+	db, mock := newMockDB(t)
+	id := uuid.New()
+	mock.ExpectExec("DELETE FROM snmp_credentials").
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := NewSNMPCredentialsRepository(db).DeleteSNMPCredential(context.Background(), id)
+
+	require.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSNMPCredentialsRepository_Delete_DBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	id := uuid.New()
+	mock.ExpectExec("DELETE FROM snmp_credentials").
+		WithArgs(id).
+		WillReturnError(fmt.Errorf("connection lost"))
+
+	err := NewSNMPCredentialsRepository(db).DeleteSNMPCredential(context.Background(), id)
+
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── Redact ────────────────────────────────────────────────────────────────────
+
+func TestSNMPCredential_Redact_AllSecretsSet(t *testing.T) {
+	c := &SNMPCredential{
+		ID:        uuid.New(),
+		Version:   SNMPVersionV3,
+		Community: "comm",
+		Username:  "admin",
+		AuthProto: "SHA",
+		AuthPass:  "auth-pass",
+		PrivProto: "AES",
+		PrivPass:  "priv-pass",
+	}
+	safe := c.Redact()
+
+	assert.Equal(t, "***", safe.Community)
+	assert.Equal(t, "***", safe.AuthPass)
+	assert.Equal(t, "***", safe.PrivPass)
+	// Non-secret fields must pass through unchanged.
+	assert.Equal(t, "admin", safe.Username)
+	assert.Equal(t, "SHA", safe.AuthProto)
+	assert.Equal(t, "AES", safe.PrivProto)
+}
+
+func TestSNMPCredential_Redact_NoSecrets(t *testing.T) {
+	c := &SNMPCredential{
+		ID:      uuid.New(),
+		Version: SNMPVersionV2c,
+	}
+	safe := c.Redact()
+
+	assert.Empty(t, safe.Community)
+	assert.Empty(t, safe.AuthPass)
+	assert.Empty(t, safe.PrivPass)
+}

--- a/internal/scanning/scan.go
+++ b/internal/scanning/scan.go
@@ -679,7 +679,7 @@ func storeScanResults(
 
 	// Launch banner enrichment in the background — best-effort, non-blocking.
 	go runBannerEnrichment(database, result.Hosts)
-	go runSNMPEnrichment(database, result.Hosts, config.SNMPCommunity)
+	go runSNMPEnrichment(database, result.Hosts, config)
 
 	return nil
 }
@@ -1012,7 +1012,8 @@ const (
 
 // runSNMPEnrichment probes hosts that had port 161 open during the scan.
 // Runs in a goroutine; errors are logged but not propagated.
-func runSNMPEnrichment(database *db.DB, hosts []Host, community string) {
+// Community string resolution order: DB-configured global credential → config.SNMPCommunity → "public".
+func runSNMPEnrichment(database *db.DB, hosts []Host, config *ScanConfig) {
 	defer func() {
 		if r := recover(); r != nil {
 			logging.Error("panic in SNMP enrichment goroutine", "error", r)
@@ -1021,6 +1022,22 @@ func runSNMPEnrichment(database *db.DB, hosts []Host, community string) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), snmpEnrichmentTimeout)
 	defer cancel()
+
+	// Resolve the community string: config.SNMPCommunity takes precedence (explicit
+	// per-scan override); fall back to the DB global credential, then "public".
+	// Network-scoped credentials are not applied here because the resolved network
+	// UUID is not available at this stage.
+	community := config.SNMPCommunity
+	if community == "" {
+		credsRepo := db.NewSNMPCredentialsRepository(database)
+		if effective, err := credsRepo.GetEffectiveCommunity(ctx, nil); err != nil {
+			slog.Default().Warn("snmp enrichment: failed to load credential from DB, using default",
+				"err", err)
+			community = "public"
+		} else {
+			community = effective
+		}
+	}
 
 	hostRepo := db.NewHostRepository(database)
 	snmpRepo := db.NewSNMPRepository(database)


### PR DESCRIPTION
## Summary

- Adds `internal/crypto` package providing AES-256-GCM encryption for sensitive values stored in the DB (key from `SCANORAMA_SECRET_KEY` env var; ephemeral fallback for dev)
- Adds `snmp_credentials` table (migration 020) with per-network and global scopes via `UNIQUE NULLS NOT DISTINCT (network_id, version)`
- REST API: `GET/PUT /api/v1/admin/snmp/credentials`, `DELETE /api/v1/admin/snmp/credentials/{id}` — secrets always redacted in responses
- SNMP enrichment now resolves the community string from the DB global credential; `config.SNMPCommunity` takes precedence as an explicit per-scan override
- 35 new tests covering crypto round-trip, repository fallback chain, and all handler paths

## Test plan

- [ ] Set `SCANORAMA_SECRET_KEY` to a 64-char hex string and start the server — verify no ephemeral key warning in logs
- [ ] `PUT /api/v1/admin/snmp/credentials` with `{"version":"v2c","community":"public"}` → 200, community shows as `***` in response
- [ ] `GET /api/v1/admin/snmp/credentials` → credentials listed with secrets redacted
- [ ] `DELETE /api/v1/admin/snmp/credentials/{id}` → 204; subsequent GET no longer includes that credential
- [ ] Run a scan against a host with SNMP on port 161 — verify enrichment uses the configured community string (check logs)
- [ ] Restart the server without `SCANORAMA_SECRET_KEY` set — verify warning logged and previously stored credentials are unreadable (expected; document in release notes)

Closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)