### PR TITLE
feat(nse): parse and persist NSE script output from nmap scans

### DIFF
--- a/internal/db/021_nse_port_metadata.sql
+++ b/internal/db/021_nse_port_metadata.sql
@@ -1,0 +1,7 @@
+-- Migration 021: NSE script metadata columns on port_banners
+-- http_title and ssh_key_fingerprint are populated by the nse_storage goroutine
+-- after scans that include NSE script execution.
+
+ALTER TABLE port_banners
+    ADD COLUMN IF NOT EXISTS http_title          TEXT,
+    ADD COLUMN IF NOT EXISTS ssh_key_fingerprint TEXT;

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -731,14 +731,16 @@ type Certificate struct {
 
 // PortBanner is a raw service banner captured from a host/port.
 type PortBanner struct {
-	ID        uuid.UUID `db:"id"         json:"id"`
-	HostID    uuid.UUID `db:"host_id"    json:"host_id"`
-	Port      int       `db:"port"       json:"port"`
-	Protocol  string    `db:"protocol"   json:"protocol"`
-	RawBanner *string   `db:"raw_banner" json:"raw_banner,omitempty"`
-	Service   *string   `db:"service"    json:"service,omitempty"`
-	Version   *string   `db:"version"    json:"version,omitempty"`
-	ScannedAt time.Time `db:"scanned_at" json:"scanned_at"`
+	ID                uuid.UUID `db:"id"                   json:"id"`
+	HostID            uuid.UUID `db:"host_id"              json:"host_id"`
+	Port              int       `db:"port"                 json:"port"`
+	Protocol          string    `db:"protocol"             json:"protocol"`
+	RawBanner         *string   `db:"raw_banner"           json:"raw_banner,omitempty"`
+	Service           *string   `db:"service"              json:"service,omitempty"`
+	Version           *string   `db:"version"              json:"version,omitempty"`
+	HTTPTitle         *string   `db:"http_title"           json:"http_title,omitempty"`
+	SSHKeyFingerprint *string   `db:"ssh_key_fingerprint"  json:"ssh_key_fingerprint,omitempty"`
+	ScannedAt         time.Time `db:"scanned_at"           json:"scanned_at"`
 }
 
 // SNMPInterface describes a single network interface collected via SNMP.

--- a/internal/db/repository_banners.go
+++ b/internal/db/repository_banners.go
@@ -44,10 +44,37 @@ func (r *BannerRepository) UpsertPortBanner(ctx context.Context, b *PortBanner) 
 	return nil
 }
 
+// UpsertNSEPortData writes NSE-derived fields (http_title, ssh_key_fingerprint,
+// and optionally a raw banner) for a port. On conflict it never overwrites an
+// existing raw_banner (ZGrab2 data takes precedence), but updates NSE-specific
+// columns with any new non-null value.
+func (r *BannerRepository) UpsertNSEPortData(ctx context.Context, b *PortBanner) error {
+	if b.ID == uuid.Nil {
+		b.ID = uuid.New()
+	}
+	b.ScannedAt = time.Now().UTC()
+
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO port_banners
+			(id, host_id, port, protocol, raw_banner, http_title, ssh_key_fingerprint, scanned_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		ON CONFLICT (host_id, port, protocol) DO UPDATE SET
+			raw_banner          = COALESCE(port_banners.raw_banner, EXCLUDED.raw_banner),
+			http_title          = COALESCE(EXCLUDED.http_title, port_banners.http_title),
+			ssh_key_fingerprint = COALESCE(EXCLUDED.ssh_key_fingerprint, port_banners.ssh_key_fingerprint),
+			scanned_at          = EXCLUDED.scanned_at`,
+		b.ID, b.HostID, b.Port, b.Protocol, b.RawBanner, b.HTTPTitle, b.SSHKeyFingerprint, b.ScannedAt)
+	if err != nil {
+		return sanitizeDBError("upsert nse port data", err)
+	}
+	return nil
+}
+
 // ListPortBanners returns all port banner records for a host.
 func (r *BannerRepository) ListPortBanners(ctx context.Context, hostID uuid.UUID) ([]*PortBanner, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, host_id, port, protocol, raw_banner, service, version, scanned_at
+		SELECT id, host_id, port, protocol, raw_banner, service, version,
+		       http_title, ssh_key_fingerprint, scanned_at
 		FROM port_banners
 		WHERE host_id = $1
 		ORDER BY port ASC`,
@@ -66,7 +93,8 @@ func (r *BannerRepository) ListPortBanners(ctx context.Context, hostID uuid.UUID
 		b := &PortBanner{}
 		if err := rows.Scan(
 			&b.ID, &b.HostID, &b.Port, &b.Protocol,
-			&b.RawBanner, &b.Service, &b.Version, &b.ScannedAt,
+			&b.RawBanner, &b.Service, &b.Version,
+			&b.HTTPTitle, &b.SSHKeyFingerprint, &b.ScannedAt,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan banner row: %w", err)
 		}

--- a/internal/db/repository_banners_unit_test.go
+++ b/internal/db/repository_banners_unit_test.go
@@ -18,7 +18,8 @@ import (
 // bannerCols is the column list returned by port_banners SELECT queries.
 var bannerCols = []string{
 	"id", "host_id", "port", "protocol",
-	"raw_banner", "service", "version", "scanned_at",
+	"raw_banner", "service", "version",
+	"http_title", "ssh_key_fingerprint", "scanned_at",
 }
 
 // certCols is the column list returned by certificates SELECT queries.
@@ -104,6 +105,49 @@ func TestBannerRepository_UpsertPortBanner_DBError(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// ── UpsertNSEPortData ───────────────────────────────────────────────────────
+
+func TestBannerRepository_UpsertNSEPortData_OK(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewBannerRepository(database)
+
+	hostID := uuid.New()
+	title := "Admin Console"
+	fingerprint := "2048 SHA256:abc123 (RSA)"
+
+	b := &PortBanner{
+		HostID:            hostID,
+		Port:              443,
+		Protocol:          ProtocolTCP,
+		HTTPTitle:         &title,
+		SSHKeyFingerprint: &fingerprint,
+	}
+
+	mock.ExpectExec("INSERT INTO port_banners").
+		WithArgs(sqlmock.AnyArg(), hostID, 443, ProtocolTCP,
+			b.RawBanner, &title, &fingerprint, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	require.NoError(t, repo.UpsertNSEPortData(context.Background(), b))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBannerRepository_UpsertNSEPortData_DBError(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewBannerRepository(database)
+
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnError(fmt.Errorf("deadlock"))
+
+	err := repo.UpsertNSEPortData(context.Background(), &PortBanner{
+		HostID:   uuid.New(),
+		Port:     80,
+		Protocol: ProtocolTCP,
+	})
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 // ── ListPortBanners ─────────────────────────────────────────────────────────
 
 func TestBannerRepository_ListPortBanners_OK(t *testing.T) {
@@ -116,8 +160,8 @@ func TestBannerRepository_ListPortBanners_OK(t *testing.T) {
 	raw2, svc2 := "220 FTP ready", "ftp"
 
 	rows := sqlmock.NewRows(bannerCols).
-		AddRow(uuid.New(), hostID, 22, ProtocolTCP, &raw1, &svc1, nil, now).
-		AddRow(uuid.New(), hostID, 21, ProtocolTCP, &raw2, &svc2, nil, now)
+		AddRow(uuid.New(), hostID, 22, ProtocolTCP, &raw1, &svc1, nil, nil, nil, now).
+		AddRow(uuid.New(), hostID, 21, ProtocolTCP, &raw2, &svc2, nil, nil, nil, now)
 
 	mock.ExpectQuery("SELECT .* FROM port_banners").
 		WithArgs(hostID).

--- a/internal/scanning/nse.go
+++ b/internal/scanning/nse.go
@@ -1,0 +1,175 @@
+// Package scanning — NSE script output parsing for nmap XML results.
+package scanning
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	nmap "github.com/Ullaakut/nmap/v3"
+)
+
+// parsePortScripts extracts structured NSE data from nmap port-level scripts.
+// Returns nil when no scripts are present or none contain actionable data.
+func parsePortScripts(scripts []nmap.Script) *NSEData {
+	if len(scripts) == 0 {
+		return nil
+	}
+	out := &NSEData{}
+	for i := range scripts {
+		s := &scripts[i]
+		switch s.ID {
+		case "banner":
+			out.Banner = strings.TrimSpace(s.Output)
+		case "http-title":
+			out.HTTPTitle = extractHTTPTitle(s)
+		case "ssh-hostkey":
+			out.SSHKeyFingerprint = extractSSHFingerprint(s)
+		case "ssl-cert":
+			out.SSLCert = parseSSLCert(s)
+		}
+	}
+	if out.isEmpty() {
+		return nil
+	}
+	return out
+}
+
+// parseHostScripts processes nmap host-level scripts and updates the host in place.
+// Host-level scripts (smb-os-discovery, nbstat) appear in the <hostscript> element
+// rather than under individual ports.
+func parseHostScripts(scripts []nmap.Script, host *Host) {
+	for i := range scripts {
+		s := &scripts[i]
+		switch s.ID {
+		case "smb-os-discovery":
+			applySSBOSDiscovery(s, host)
+		case "nbstat":
+			if name := findElem(s.Elements, "NetBIOS_Computer_Name"); name != "" && host.SMBHostname == "" {
+				host.SMBHostname = name
+			}
+		}
+	}
+}
+
+// extractHTTPTitle returns the page title from an http-title script output.
+func extractHTTPTitle(s *nmap.Script) string {
+	title := strings.TrimSpace(s.Output)
+	// Filter out nmap error messages that aren't real titles.
+	if strings.HasPrefix(title, "ERROR:") ||
+		strings.HasPrefix(title, "Did not follow redirect") {
+		return ""
+	}
+	return title
+}
+
+// extractSSHFingerprint returns the first key fingerprint line from ssh-hostkey output.
+func extractSSHFingerprint(s *nmap.Script) string {
+	line := strings.SplitN(strings.TrimSpace(s.Output), "\n", 2)[0]
+	return strings.TrimSpace(line)
+}
+
+// parseSSLCert extracts TLS certificate fields from an ssl-cert NSE script.
+// nmap XML structure:
+//
+//	<script id="ssl-cert">
+//	  <table key="subject"><elem key="commonName">example.com</elem></table>
+//	  <table key="issuer"><elem key="commonName">Let's Encrypt</elem></table>
+//	  <table key="validity">
+//	    <elem key="notBefore">2024-01-01T00:00:00</elem>
+//	    <elem key="notAfter">2024-04-01T00:00:00</elem>
+//	  </table>
+//	  <elem key="sig_algo">sha256WithRSAEncryption</elem>
+//	</script>
+func parseSSLCert(s *nmap.Script) *NSECertData {
+	subjectTable := findTable(s.Tables, "subject")
+	if subjectTable == nil {
+		return nil
+	}
+	cert := &NSECertData{
+		SubjectCN: findElem(subjectTable.Elements, "commonName"),
+	}
+	if issuerTable := findTable(s.Tables, "issuer"); issuerTable != nil {
+		cert.Issuer = findElem(issuerTable.Elements, "commonName")
+	}
+	if validityTable := findTable(s.Tables, "validity"); validityTable != nil {
+		if nb := findElem(validityTable.Elements, "notBefore"); nb != "" {
+			cert.NotBefore, _ = parseNmapTime(nb)
+		}
+		if na := findElem(validityTable.Elements, "notAfter"); na != "" {
+			cert.NotAfter, _ = parseNmapTime(na)
+		}
+	}
+	// Subject Alternative Names appear nested under extensions.
+	if extTable := findTable(s.Tables, "extensions"); extTable != nil {
+		for i := range extTable.Tables {
+			sub := &extTable.Tables[i]
+			if sub.Key == "Subject Alternative Name" {
+				for _, e := range sub.Elements {
+					cert.SANs = append(cert.SANs, e.Value)
+				}
+			}
+		}
+	}
+	cert.KeyType = findElem(s.Elements, "sig_algo")
+	return cert
+}
+
+// applySSBOSDiscovery updates the host with OS information from smb-os-discovery.
+// Only applied when nmap -O produced no result (OSAccuracy == 0), so the
+// fingerprint-grade detection is never overridden by SMB.
+func applySSBOSDiscovery(s *nmap.Script, host *Host) {
+	for _, e := range s.Elements {
+		switch e.Key {
+		case "os":
+			if host.OSAccuracy == 0 && host.OSName == "" {
+				host.OSName = e.Value
+				host.OSAccuracy = 60 // SMB OS is reliable but not fingerprint-grade
+				host.OSFamily = "Windows"
+			}
+		case "domain":
+			host.SMBDomain = e.Value
+		case "FQDN", "fqdn":
+			if host.SMBHostname == "" {
+				host.SMBHostname = e.Value
+			}
+		}
+	}
+}
+
+// findElem returns the value of the first Element with the given key.
+func findElem(elems []nmap.Element, key string) string {
+	for _, e := range elems {
+		if e.Key == key {
+			return strings.TrimSpace(e.Value)
+		}
+	}
+	return ""
+}
+
+// findTable returns a pointer to the first Table with the given key.
+func findTable(tables []nmap.Table, key string) *nmap.Table {
+	for i := range tables {
+		if tables[i].Key == key {
+			return &tables[i]
+		}
+	}
+	return nil
+}
+
+// nmapTimeFormats are the timestamp formats nmap uses in cert validity fields.
+var nmapTimeFormats = []string{
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04:05",
+	time.RFC3339,
+}
+
+// parseNmapTime parses a timestamp string from nmap XML (assumed UTC).
+func parseNmapTime(s string) (time.Time, error) {
+	for _, f := range nmapTimeFormats {
+		if t, err := time.Parse(f, s); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unrecognized nmap time format: %q", s)
+}

--- a/internal/scanning/nse_storage.go
+++ b/internal/scanning/nse_storage.go
@@ -1,0 +1,133 @@
+package scanning
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/anstrom/scanorama/internal/db"
+	"github.com/anstrom/scanorama/internal/logging"
+)
+
+const nseStorageTimeout = 2 * time.Minute
+
+// runNSEDataStorage writes NSE script data from the scan result into the
+// port_banners and certificates tables. Runs as a best-effort background
+// goroutine after every scan — errors are logged but never propagated.
+func runNSEDataStorage(database *db.DB, hosts []Host) {
+	defer func() {
+		if r := recover(); r != nil {
+			logging.Error("panic in NSE storage goroutine", "error", r)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), nseStorageTimeout)
+	defer cancel()
+
+	hostRepo := db.NewHostRepository(database)
+	bannerRepo := db.NewBannerRepository(database)
+
+	for i := range hosts {
+		h := &hosts[i]
+		if h.Status != "up" {
+			continue
+		}
+		if !hasNSEData(h) {
+			continue
+		}
+
+		ip := net.ParseIP(h.Address)
+		if ip == nil {
+			continue
+		}
+		dbHost, err := hostRepo.GetByIP(ctx, db.IPAddr{IP: ip})
+		if err != nil {
+			logging.Warn("nse storage: host not found by IP", "ip", h.Address, "error", err)
+			continue
+		}
+
+		for j := range h.Ports {
+			p := &h.Ports[j]
+			if p.NSE == nil {
+				continue
+			}
+			storePortNSE(ctx, bannerRepo, dbHost.ID, p)
+		}
+	}
+}
+
+// hasNSEData reports whether any port on the host has NSE output to persist.
+func hasNSEData(h *Host) bool {
+	for i := range h.Ports {
+		if h.Ports[i].NSE != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// storePortNSE writes the NSE data for a single port to the appropriate tables.
+func storePortNSE(ctx context.Context, bannerRepo *db.BannerRepository, hostID uuid.UUID, p *Port) {
+	nse := p.NSE
+
+	// Persist http_title, ssh_key_fingerprint, and raw banner into port_banners.
+	// UpsertNSEPortData uses COALESCE so that ZGrab2 raw banners are never
+	// overwritten by the (typically shorter) NSE banner output.
+	if nse.Banner != "" || nse.HTTPTitle != "" || nse.SSHKeyFingerprint != "" {
+		b := &db.PortBanner{
+			HostID:   hostID,
+			Port:     int(p.Number),
+			Protocol: p.Protocol,
+		}
+		if nse.Banner != "" {
+			b.RawBanner = &nse.Banner
+		}
+		if nse.HTTPTitle != "" {
+			b.HTTPTitle = &nse.HTTPTitle
+		}
+		if nse.SSHKeyFingerprint != "" {
+			b.SSHKeyFingerprint = &nse.SSHKeyFingerprint
+		}
+		if err := bannerRepo.UpsertNSEPortData(ctx, b); err != nil {
+			slog.Default().Warn("nse storage: failed to upsert port banner",
+				"host_id", hostID, "port", p.Number, "error", err)
+		}
+	}
+
+	// Persist ssl-cert data into the certificates table.
+	if nse.SSLCert != nil {
+		cert := nseToDBCert(hostID, int(p.Number), nse.SSLCert)
+		if err := bannerRepo.UpsertCertificate(ctx, cert); err != nil {
+			slog.Default().Warn("nse storage: failed to upsert certificate",
+				"host_id", hostID, "port", p.Number, "error", err)
+		}
+	}
+}
+
+// nseToDBCert converts NSECertData to a db.Certificate ready for upsert.
+func nseToDBCert(hostID uuid.UUID, port int, c *NSECertData) *db.Certificate {
+	cert := &db.Certificate{
+		HostID: hostID,
+		Port:   port,
+		SANs:   c.SANs,
+	}
+	if c.SubjectCN != "" {
+		cert.SubjectCN = &c.SubjectCN
+	}
+	if c.Issuer != "" {
+		cert.Issuer = &c.Issuer
+	}
+	if !c.NotBefore.IsZero() {
+		cert.NotBefore = &c.NotBefore
+	}
+	if !c.NotAfter.IsZero() {
+		cert.NotAfter = &c.NotAfter
+	}
+	if c.KeyType != "" {
+		cert.KeyType = &c.KeyType
+	}
+	return cert
+}

--- a/internal/scanning/nse_test.go
+++ b/internal/scanning/nse_test.go
@@ -1,0 +1,274 @@
+// Package scanning — unit tests for NSE script output parsing.
+package scanning
+
+import (
+	"testing"
+	"time"
+
+	nmap "github.com/Ullaakut/nmap/v3"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── parsePortScripts ──────────────────────────────────────────────────────────
+
+func TestParsePortScripts_Empty(t *testing.T) {
+	assert.Nil(t, parsePortScripts(nil))
+	assert.Nil(t, parsePortScripts([]nmap.Script{}))
+}
+
+func TestParsePortScripts_Banner(t *testing.T) {
+	scripts := []nmap.Script{{ID: "banner", Output: "  SSH-2.0-OpenSSH_8.9  "}}
+	got := parsePortScripts(scripts)
+	require.NotNil(t, got)
+	assert.Equal(t, "SSH-2.0-OpenSSH_8.9", got.Banner)
+	assert.Empty(t, got.HTTPTitle)
+	assert.Empty(t, got.SSHKeyFingerprint)
+	assert.Nil(t, got.SSLCert)
+}
+
+func TestParsePortScripts_HTTPTitle_Normal(t *testing.T) {
+	scripts := []nmap.Script{{ID: "http-title", Output: "Welcome to nginx"}}
+	got := parsePortScripts(scripts)
+	require.NotNil(t, got)
+	assert.Equal(t, "Welcome to nginx", got.HTTPTitle)
+}
+
+func TestParsePortScripts_HTTPTitle_ErrorFiltered(t *testing.T) {
+	scripts := []nmap.Script{{ID: "http-title", Output: "ERROR: No response from server"}}
+	got := parsePortScripts(scripts)
+	// ERROR prefix is filtered — the only field that would have been set is
+	// HTTPTitle; with it empty the result should be nil (isEmpty check).
+	assert.Nil(t, got)
+}
+
+func TestParsePortScripts_HTTPTitle_RedirectFiltered(t *testing.T) {
+	scripts := []nmap.Script{{ID: "http-title", Output: "Did not follow redirect to https://example.com/"}}
+	assert.Nil(t, parsePortScripts(scripts))
+}
+
+func TestParsePortScripts_SSHHostkey(t *testing.T) {
+	output := "2048 SHA256:abc123def456 (RSA)\n4096 SHA256:xyz789 (RSA)"
+	scripts := []nmap.Script{{ID: "ssh-hostkey", Output: output}}
+	got := parsePortScripts(scripts)
+	require.NotNil(t, got)
+	// Only the first line should be captured.
+	assert.Equal(t, "2048 SHA256:abc123def456 (RSA)", got.SSHKeyFingerprint)
+}
+
+func TestParsePortScripts_AllFieldsReturnedTogether(t *testing.T) {
+	scripts := []nmap.Script{
+		{ID: "banner", Output: "HTTP/1.1 200 OK"},
+		{ID: "http-title", Output: "My Page"},
+	}
+	got := parsePortScripts(scripts)
+	require.NotNil(t, got)
+	assert.Equal(t, "HTTP/1.1 200 OK", got.Banner)
+	assert.Equal(t, "My Page", got.HTTPTitle)
+}
+
+// ── parseSSLCert ──────────────────────────────────────────────────────────────
+
+func TestParseSSLCert_MissingSubjectTable(t *testing.T) {
+	s := &nmap.Script{ID: "ssl-cert", Output: ""}
+	assert.Nil(t, parseSSLCert(s))
+}
+
+func TestParseSSLCert_BasicFields(t *testing.T) {
+	s := &nmap.Script{
+		ID: "ssl-cert",
+		Tables: []nmap.Table{
+			{
+				Key:      "subject",
+				Elements: []nmap.Element{{Key: "commonName", Value: "example.com"}},
+			},
+			{
+				Key:      "issuer",
+				Elements: []nmap.Element{{Key: "commonName", Value: "Let's Encrypt Authority X3"}},
+			},
+			{
+				Key: "validity",
+				Elements: []nmap.Element{
+					{Key: "notBefore", Value: "2024-01-01T00:00:00"},
+					{Key: "notAfter", Value: "2024-04-01T00:00:00"},
+				},
+			},
+		},
+		Elements: []nmap.Element{{Key: "sig_algo", Value: "sha256WithRSAEncryption"}},
+	}
+
+	got := parseSSLCert(s)
+	require.NotNil(t, got)
+	assert.Equal(t, "example.com", got.SubjectCN)
+	assert.Equal(t, "Let's Encrypt Authority X3", got.Issuer)
+	assert.Equal(t, "sha256WithRSAEncryption", got.KeyType)
+
+	wantBefore, _ := time.Parse("2006-01-02T15:04:05", "2024-01-01T00:00:00")
+	wantAfter, _ := time.Parse("2006-01-02T15:04:05", "2024-04-01T00:00:00")
+	assert.Equal(t, wantBefore.UTC(), got.NotBefore)
+	assert.Equal(t, wantAfter.UTC(), got.NotAfter)
+}
+
+func TestParseSSLCert_SANs(t *testing.T) {
+	s := &nmap.Script{
+		ID: "ssl-cert",
+		Tables: []nmap.Table{
+			{
+				Key:      "subject",
+				Elements: []nmap.Element{{Key: "commonName", Value: "example.com"}},
+			},
+			{
+				Key: "extensions",
+				Tables: []nmap.Table{
+					{
+						Key: "Subject Alternative Name",
+						Elements: []nmap.Element{
+							{Value: "example.com"},
+							{Value: "www.example.com"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := parseSSLCert(s)
+	require.NotNil(t, got)
+	assert.Equal(t, []string{"example.com", "www.example.com"}, got.SANs)
+}
+
+// ── parseHostScripts ──────────────────────────────────────────────────────────
+
+func TestParseHostScripts_SMBOSDiscovery_AppliedWhenNoNmapOS(t *testing.T) {
+	host := &Host{}
+	scripts := []nmap.Script{
+		{
+			ID: "smb-os-discovery",
+			Elements: []nmap.Element{
+				{Key: "os", Value: "Windows Server 2019"},
+				{Key: "domain", Value: "CORP"},
+				{Key: "FQDN", Value: "srv01.corp.local"},
+			},
+		},
+	}
+
+	parseHostScripts(scripts, host)
+
+	assert.Equal(t, "Windows Server 2019", host.OSName)
+	assert.Equal(t, 60, host.OSAccuracy)
+	assert.Equal(t, "Windows", host.OSFamily)
+	assert.Equal(t, "CORP", host.SMBDomain)
+	assert.Equal(t, "srv01.corp.local", host.SMBHostname)
+}
+
+func TestParseHostScripts_SMBOSDiscovery_DoesNotOverrideNmapOS(t *testing.T) {
+	host := &Host{
+		OSName:     "Linux 5.4",
+		OSAccuracy: 95,
+		OSFamily:   "Linux",
+	}
+	scripts := []nmap.Script{
+		{
+			ID:       "smb-os-discovery",
+			Elements: []nmap.Element{{Key: "os", Value: "Windows 10"}},
+		},
+	}
+
+	parseHostScripts(scripts, host)
+
+	// nmap -O result must not be overridden.
+	assert.Equal(t, "Linux 5.4", host.OSName)
+	assert.Equal(t, 95, host.OSAccuracy)
+	assert.Equal(t, "Linux", host.OSFamily)
+}
+
+func TestParseHostScripts_NBStat_SetsHostname(t *testing.T) {
+	host := &Host{}
+	scripts := []nmap.Script{
+		{
+			ID: "nbstat",
+			Elements: []nmap.Element{
+				{Key: "NetBIOS_Computer_Name", Value: "WORKSTATION01"},
+			},
+		},
+	}
+
+	parseHostScripts(scripts, host)
+	assert.Equal(t, "WORKSTATION01", host.SMBHostname)
+}
+
+func TestParseHostScripts_NBStat_DoesNotOverrideSMBHostname(t *testing.T) {
+	host := &Host{SMBHostname: "from-smb-discovery"}
+	scripts := []nmap.Script{
+		{
+			ID:       "nbstat",
+			Elements: []nmap.Element{{Key: "NetBIOS_Computer_Name", Value: "from-nbstat"}},
+		},
+	}
+
+	parseHostScripts(scripts, host)
+	// smb-os-discovery hostname wins.
+	assert.Equal(t, "from-smb-discovery", host.SMBHostname)
+}
+
+// ── parseNmapTime ─────────────────────────────────────────────────────────────
+
+func TestParseNmapTime_RFC3339(t *testing.T) {
+	got, err := parseNmapTime("2024-01-15T10:30:00")
+	require.NoError(t, err)
+	assert.Equal(t, 2024, got.Year())
+	assert.Equal(t, time.January, got.Month())
+	assert.Equal(t, 15, got.Day())
+}
+
+func TestParseNmapTime_SpaceSeparated(t *testing.T) {
+	got, err := parseNmapTime("2024-06-01 12:00:00")
+	require.NoError(t, err)
+	assert.Equal(t, 2024, got.Year())
+	assert.Equal(t, time.June, got.Month())
+}
+
+func TestParseNmapTime_Invalid(t *testing.T) {
+	_, err := parseNmapTime("not-a-date")
+	require.Error(t, err)
+}
+
+// ── nseToDBCert ───────────────────────────────────────────────────────────────
+
+func TestNSEToDBCert_NilsForEmptyFields(t *testing.T) {
+	cert := nseToDBCert(uuid.New(), 443, &NSECertData{})
+	assert.Nil(t, cert.SubjectCN)
+	assert.Nil(t, cert.Issuer)
+	assert.Nil(t, cert.KeyType)
+	assert.Nil(t, cert.NotBefore)
+	assert.Nil(t, cert.NotAfter)
+}
+
+func TestNSEToDBCert_PopulatesAllFields(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	later := now.Add(90 * 24 * time.Hour)
+	id := uuid.New()
+
+	c := &NSECertData{
+		SubjectCN: "example.com",
+		Issuer:    "My CA",
+		KeyType:   "sha256WithRSAEncryption",
+		SANs:      []string{"example.com", "www.example.com"},
+		NotBefore: now,
+		NotAfter:  later,
+	}
+
+	got := nseToDBCert(id, 443, c)
+	require.NotNil(t, got.SubjectCN)
+	assert.Equal(t, "example.com", *got.SubjectCN)
+	require.NotNil(t, got.Issuer)
+	assert.Equal(t, "My CA", *got.Issuer)
+	require.NotNil(t, got.KeyType)
+	assert.Equal(t, "sha256WithRSAEncryption", *got.KeyType)
+	assert.Equal(t, []string{"example.com", "www.example.com"}, got.SANs)
+	require.NotNil(t, got.NotBefore)
+	assert.Equal(t, now, *got.NotBefore)
+	require.NotNil(t, got.NotAfter)
+	assert.Equal(t, later, *got.NotAfter)
+}

--- a/internal/scanning/nse_test.go
+++ b/internal/scanning/nse_test.go
@@ -57,6 +57,13 @@ func TestParsePortScripts_SSHHostkey(t *testing.T) {
 	assert.Equal(t, "2048 SHA256:abc123def456 (RSA)", got.SSHKeyFingerprint)
 }
 
+func TestParsePortScripts_UnrecognisedScript_ReturnsNil(t *testing.T) {
+	// A script whose ID we don't handle should leave all fields empty,
+	// triggering isEmpty() and returning nil rather than a zero-value struct.
+	scripts := []nmap.Script{{ID: "ftp-bounce", Output: "some output"}}
+	assert.Nil(t, parsePortScripts(scripts))
+}
+
 func TestParsePortScripts_AllFieldsReturnedTogether(t *testing.T) {
 	scripts := []nmap.Script{
 		{ID: "banner", Output: "HTTP/1.1 200 OK"},
@@ -212,6 +219,18 @@ func TestParseHostScripts_NBStat_DoesNotOverrideSMBHostname(t *testing.T) {
 	assert.Equal(t, "from-smb-discovery", host.SMBHostname)
 }
 
+func TestParseHostScripts_SMBOSDiscovery_LowercaseFQDN(t *testing.T) {
+	host := &Host{}
+	scripts := []nmap.Script{
+		{
+			ID:       "smb-os-discovery",
+			Elements: []nmap.Element{{Key: "fqdn", Value: "srv.corp.local"}},
+		},
+	}
+	parseHostScripts(scripts, host)
+	assert.Equal(t, "srv.corp.local", host.SMBHostname)
+}
+
 // ── parseNmapTime ─────────────────────────────────────────────────────────────
 
 func TestParseNmapTime_RFC3339(t *testing.T) {
@@ -227,6 +246,14 @@ func TestParseNmapTime_SpaceSeparated(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2024, got.Year())
 	assert.Equal(t, time.June, got.Month())
+}
+
+func TestParseNmapTime_RFC3339WithTimezone(t *testing.T) {
+	// Verify the time.RFC3339 fallback handles a Z-suffixed timestamp.
+	got, err := parseNmapTime("2024-01-15T10:30:00Z")
+	require.NoError(t, err)
+	assert.Equal(t, 2024, got.Year())
+	assert.Equal(t, time.January, got.Month())
 }
 
 func TestParseNmapTime_Invalid(t *testing.T) {

--- a/internal/scanning/queue.go
+++ b/internal/scanning/queue.go
@@ -22,6 +22,12 @@ const (
 	DefaultMaxQueueSize  = 50
 )
 
+// Worker status values.
+const (
+	workerStateIdle   = "idle"
+	workerStateActive = "active"
+)
+
 // Sentinel errors for queue operations.
 var (
 	ErrQueueFull   = errors.New("scan queue is full")
@@ -130,7 +136,7 @@ func NewScanQueue(maxConcurrent, maxQueueSize int) *ScanQueue {
 
 	states := make([]*workerState, maxConcurrent)
 	for i := range states {
-		states[i] = &workerState{status: "idle"}
+		states[i] = &workerState{status: workerStateIdle}
 	}
 
 	return &ScanQueue{
@@ -319,7 +325,7 @@ func (q *ScanQueue) executeJob(ctx context.Context, workerID int, job Job) {
 	jobStartedAt := time.Now()
 	ws := q.workerStates[workerID]
 	ws.mu.Lock()
-	ws.status = "active"
+	ws.status = workerStateActive
 	ws.jobID = job.ID()
 	ws.jobType = job.Type()
 	ws.jobTarget = job.Target()
@@ -346,7 +352,7 @@ func (q *ScanQueue) executeJob(ctx context.Context, workerID int, job Job) {
 	// Return worker to idle and update per-worker counters.
 	completedAt := time.Now()
 	ws.mu.Lock()
-	ws.status = "idle"
+	ws.status = workerStateIdle
 	ws.jobID = ""
 	ws.jobType = ""
 	ws.jobTarget = ""

--- a/internal/scanning/scan.go
+++ b/internal/scanning/scan.go
@@ -462,12 +462,9 @@ func convertNmapHost(h *nmap.Host) *Host {
 		host.Ports = append(host.Ports, port)
 	}
 
-	// Apply host-level NSE scripts (smb-os-discovery, nbstat) before OS detection
-	// so that SMBHostname/SMBDomain are populated and OSAccuracy is consulted
-	// by applySSBOSDiscovery correctly.
-	parseHostScripts(h.HostScripts, host)
-
 	// Capture OS detection data from the best match (highest accuracy).
+	// This must run before parseHostScripts so that applySSBOSDiscovery can
+	// check host.OSAccuracy and refuse to overwrite a real nmap fingerprint.
 	if len(h.OS.Matches) > 0 {
 		best := h.OS.Matches[0]
 		host.OSName = best.Name
@@ -477,6 +474,11 @@ func convertNmapHost(h *nmap.Host) *Host {
 			host.OSVersion = best.Classes[0].OSGeneration
 		}
 	}
+
+	// Apply host-level NSE scripts (smb-os-discovery, nbstat) after OS detection
+	// so that applySSBOSDiscovery correctly checks host.OSAccuracy before
+	// deciding whether to apply SMB-derived OS data.
+	parseHostScripts(h.HostScripts, host)
 
 	// Derive per-host scan duration from the nmap XML start/end timestamps.
 	// nmap.Timestamp is an alias for time.Time, so a zero value means the

--- a/internal/scanning/scan.go
+++ b/internal/scanning/scan.go
@@ -457,9 +457,15 @@ func convertNmapHost(h *nmap.Host) *Host {
 			Service:     p.Service.Name,
 			Version:     p.Service.Version,
 			ServiceInfo: p.Service.Product,
+			NSE:         parsePortScripts(p.Scripts),
 		}
 		host.Ports = append(host.Ports, port)
 	}
+
+	// Apply host-level NSE scripts (smb-os-discovery, nbstat) before OS detection
+	// so that SMBHostname/SMBDomain are populated and OSAccuracy is consulted
+	// by applySSBOSDiscovery correctly.
+	parseHostScripts(h.HostScripts, host)
 
 	// Capture OS detection data from the best match (highest accuracy).
 	if len(h.OS.Matches) > 0 {
@@ -680,6 +686,7 @@ func storeScanResults(
 	// Launch banner enrichment in the background — best-effort, non-blocking.
 	go runBannerEnrichment(database, result.Hosts)
 	go runSNMPEnrichment(database, result.Hosts, config)
+	go runNSEDataStorage(database, result.Hosts)
 
 	return nil
 }

--- a/internal/scanning/types.go
+++ b/internal/scanning/types.go
@@ -236,6 +236,36 @@ type Host struct {
 	// host, derived from the per-host start/end timestamps in the XML output.
 	// Nil when nmap did not report per-host timing (e.g. the host was down).
 	ScanDurationMs *int
+	// SMBHostname is the hostname reported by the smb-os-discovery or nbstat NSE script.
+	SMBHostname string
+	// SMBDomain is the domain or workgroup from the smb-os-discovery NSE script.
+	SMBDomain string
+}
+
+// NSECertData holds SSL certificate fields extracted from the ssl-cert NSE script.
+type NSECertData struct {
+	SubjectCN string
+	SANs      []string
+	Issuer    string
+	NotBefore time.Time
+	NotAfter  time.Time
+	KeyType   string
+}
+
+// NSEData holds parsed output from NSE scripts for a single port.
+type NSEData struct {
+	// Banner is the raw service banner from the `banner` NSE script.
+	Banner string
+	// HTTPTitle is the page title from the `http-title` NSE script.
+	HTTPTitle string
+	// SSHKeyFingerprint is the key fingerprint from the `ssh-hostkey` NSE script.
+	SSHKeyFingerprint string
+	// SSLCert holds structured TLS certificate data from the `ssl-cert` NSE script.
+	SSLCert *NSECertData
+}
+
+func (n *NSEData) isEmpty() bool {
+	return n.Banner == "" && n.HTTPTitle == "" && n.SSHKeyFingerprint == "" && n.SSLCert == nil
 }
 
 // Port represents the scan results for a single port.
@@ -252,6 +282,8 @@ type Port struct {
 	Version string
 	// ServiceInfo contains additional service details, if available
 	ServiceInfo string
+	// NSE holds structured output from NSE scripts, if any were run for this port.
+	NSE *NSEData
 }
 
 // HostStats contains summary statistics about a network scan.

--- a/internal/scanning/xml.go
+++ b/internal/scanning/xml.go
@@ -64,7 +64,14 @@ func SaveResults(result *ScanResult, filePath string) error {
 		}
 
 		for j, port := range host.Ports {
-			xmlHost.Ports[j] = PortXML(port)
+			xmlHost.Ports[j] = PortXML{
+				Number:      port.Number,
+				Protocol:    port.Protocol,
+				State:       port.State,
+				Service:     port.Service,
+				Version:     port.Version,
+				ServiceInfo: port.ServiceInfo,
+			}
 		}
 
 		xmlData.Hosts[i] = xmlHost
@@ -143,7 +150,14 @@ func LoadResults(filePath string) (*ScanResult, error) {
 		}
 
 		for j, xmlPort := range xmlHost.Ports {
-			host.Ports[j] = Port(xmlPort)
+			host.Ports[j] = Port{
+				Number:      xmlPort.Number,
+				Protocol:    xmlPort.Protocol,
+				State:       xmlPort.State,
+				Service:     xmlPort.Service,
+				Version:     xmlPort.Version,
+				ServiceInfo: xmlPort.ServiceInfo,
+			}
 		}
 
 		result.Hosts[i] = host


### PR DESCRIPTION
## Summary

- Adds full parsing of NSE script output from nmap scans: `ssl-cert`, `http-title`, `ssh-hostkey`, `banner`, `smb-os-discovery`, and `nbstat`
- SMB-derived OS detection fills in when nmap `-O` had no result (`OSAccuracy == 0`); never overrides fingerprint data (nmap OS detection block runs first in `convertNmapHost`)
- NSE data is persisted to `port_banners` (`http_title`, `ssh_key_fingerprint`) and `certificates` tables via a best-effort background goroutine
- COALESCE-safe conflict resolution: ZGrab2 raw banners are never overwritten by the shorter NSE banner; NSE fields win for `http_title`/`ssh_key_fingerprint`

## Test plan

- Verify a scan with NSE scripts (e.g. `-sV --script ssl-cert,http-title`) populates `http_title` in the port_banners API response
- Verify a scan against a Windows host with port 445 open populates `smb_hostname` and OS fields from `smb-os-discovery` when nmap `-O` finds nothing
- Verify running a second scan does not overwrite existing ZGrab2 raw banners

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)