### PR TITLE
feat(smart-scan): profile recommendations by OS family

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -3627,6 +3627,47 @@ const docTemplate = `{
                 }
             }
         },
+        "/smart-scan/profile-recommendations": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns profile suggestions grouped by detected OS family.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "smart-scan"
+                ],
+                "summary": "Get profile recommendations",
+                "operationId": "getProfileRecommendations",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/docs.ProfileRecommendationResponse"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/smart-scan/suggestions": {
             "get": {
                 "security": [
@@ -4818,6 +4859,31 @@ const docTemplate = `{
                 }
             }
         },
+        "docs.ProfileRecommendationResponse": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "example": "port_expansion"
+                },
+                "host_count": {
+                    "type": "integer",
+                    "example": 42
+                },
+                "os_family": {
+                    "type": "string",
+                    "example": "Linux"
+                },
+                "profile_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "profile_name": {
+                    "type": "string",
+                    "example": "Linux Standard"
+                }
+            }
+        },
         "docs.ProfileResponse": {
             "type": "object",
             "properties": {
@@ -5292,6 +5358,10 @@ const docTemplate = `{
                 "network_cidr": {
                     "type": "string",
                     "example": "192.168.1.0/24"
+                },
+                "os_family": {
+                    "type": "string",
+                    "example": "Linux"
                 },
                 "stage": {
                     "type": "string",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -3621,6 +3621,47 @@
                 }
             }
         },
+        "/smart-scan/profile-recommendations": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns profile suggestions grouped by detected OS family.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "smart-scan"
+                ],
+                "summary": "Get profile recommendations",
+                "operationId": "getProfileRecommendations",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/docs.ProfileRecommendationResponse"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/smart-scan/suggestions": {
             "get": {
                 "security": [
@@ -4812,6 +4853,31 @@
                 }
             }
         },
+        "docs.ProfileRecommendationResponse": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "example": "port_expansion"
+                },
+                "host_count": {
+                    "type": "integer",
+                    "example": 42
+                },
+                "os_family": {
+                    "type": "string",
+                    "example": "Linux"
+                },
+                "profile_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "profile_name": {
+                    "type": "string",
+                    "example": "Linux Standard"
+                }
+            }
+        },
         "docs.ProfileResponse": {
             "type": "object",
             "properties": {
@@ -5286,6 +5352,10 @@
                 "network_cidr": {
                     "type": "string",
                     "example": "192.168.1.0/24"
+                },
+                "os_family": {
+                    "type": "string",
+                    "example": "Linux"
                 },
                 "stage": {
                     "type": "string",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -736,6 +736,24 @@ definitions:
         example: 3
         type: integer
     type: object
+  docs.ProfileRecommendationResponse:
+    properties:
+      action:
+        example: port_expansion
+        type: string
+      host_count:
+        example: 42
+        type: integer
+      os_family:
+        example: Linux
+        type: string
+      profile_id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      profile_name:
+        example: Linux Standard
+        type: string
+    type: object
   docs.ProfileResponse:
     properties:
       created_at:
@@ -1078,6 +1096,9 @@ definitions:
         type: integer
       network_cidr:
         example: 192.168.1.0/24
+        type: string
+      os_family:
+        example: Linux
         type: string
       stage:
         enum:
@@ -3577,6 +3598,32 @@ paths:
       summary: Trigger Smart Scan for a host
       tags:
       - Smart Scan
+  /smart-scan/profile-recommendations:
+    get:
+      description: Returns profile suggestions grouped by detected OS family.
+      operationId: getProfileRecommendations
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/docs.ProfileRecommendationResponse'
+            type: array
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Get profile recommendations
+      tags:
+      - smart-scan
   /smart-scan/suggestions:
     get:
       description: Returns fleet-wide counts of hosts in each knowledge-gap category.

--- a/docs/swagger_docs.go
+++ b/docs/swagger_docs.go
@@ -1396,6 +1396,19 @@ func TriggerSmartScan(_ http.ResponseWriter, _ *http.Request) {}
 // @ID triggerSmartScanBatch
 func TriggerSmartScanBatch(_ http.ResponseWriter, _ *http.Request) {}
 
+// GetProfileRecommendations godoc
+// @Summary Get profile recommendations
+// @Description Returns profile suggestions grouped by detected OS family.
+// @Tags smart-scan
+// @Produce json
+// @Success 200 {array} ProfileRecommendationResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Security ApiKeyAuth
+// @Router /smart-scan/profile-recommendations [get]
+// @ID getProfileRecommendations
+func GetProfileRecommendations(_ http.ResponseWriter, _ *http.Request) {}
+
 // ScanStageResponse is the response body for EvaluateHostStage.
 type ScanStageResponse struct {
 	Stage       string  `json:"stage" example:"os_detection" enums:"os_detection,port_expansion,service_scan,refresh,skip"`
@@ -1437,6 +1450,7 @@ type TriggerBatchRequest struct {
 	Stage       string   `json:"stage,omitempty" example:"os_detection" enums:"os_detection,port_expansion,service_scan,refresh,skip"`
 	HostIDs     []string `json:"host_ids,omitempty" example:"550e8400-e29b-41d4-a716-446655440000"`
 	NetworkCIDR string   `json:"network_cidr,omitempty" example:"192.168.1.0/24"`
+	OSFamily    string   `json:"os_family,omitempty" example:"Linux"`
 	Limit       int      `json:"limit,omitempty" example:"50"`
 }
 
@@ -1482,6 +1496,15 @@ type PortHostCountResponse struct {
 
 // PortHostCountListResponse is the response body for ListPortHostCounts.
 type PortHostCountListResponse = []PortHostCountResponse
+
+// ProfileRecommendationResponse is a single entry in the profile recommendations list.
+type ProfileRecommendationResponse struct {
+	OSFamily    string `json:"os_family" example:"Linux"`
+	HostCount   int    `json:"host_count" example:"42"`
+	ProfileID   string `json:"profile_id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	ProfileName string `json:"profile_name" example:"Linux Standard"`
+	Action      string `json:"action" example:"port_expansion"`
+}
 
 // BatchResultResponse is the response body for TriggerSmartScanBatch.
 type BatchResultResponse struct {

--- a/frontend/src/api/hooks/use-smart-scan.ts
+++ b/frontend/src/api/hooks/use-smart-scan.ts
@@ -64,24 +64,18 @@ export function useTriggerSmartScan() {
   });
 }
 
-export type ProfileRecommendation = {
-  os_family: string;
-  host_count: number;
-  profile_id: string;
-  profile_name: string;
-  action: string;
-};
+export type ProfileRecommendation =
+  components["schemas"]["docs.ProfileRecommendationResponse"];
 
 export function useProfileRecommendations(enabled = true) {
   return useQuery({
     queryKey: ["smart-scan", "profile-recommendations"],
     queryFn: async () => {
       const { data, error, response } = await api.GET(
-        "/smart-scan/profile-recommendations" as never,
-        {} as never,
+        "/smart-scan/profile-recommendations",
       );
       if (error) throw new ApiError(response.status, error);
-      return (data as ProfileRecommendation[]) ?? [];
+      return data ?? [];
     },
     enabled,
     staleTime: 120_000,

--- a/frontend/src/api/hooks/use-smart-scan.ts
+++ b/frontend/src/api/hooks/use-smart-scan.ts
@@ -64,6 +64,30 @@ export function useTriggerSmartScan() {
   });
 }
 
+export type ProfileRecommendation = {
+  os_family: string;
+  host_count: number;
+  profile_id: string;
+  profile_name: string;
+  action: string;
+};
+
+export function useProfileRecommendations(enabled = true) {
+  return useQuery({
+    queryKey: ["smart-scan", "profile-recommendations"],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        "/smart-scan/profile-recommendations" as never,
+        {} as never,
+      );
+      if (error) throw new ApiError(response.status, error);
+      return (data as ProfileRecommendation[]) ?? [];
+    },
+    enabled,
+    staleTime: 120_000,
+  });
+}
+
 export function useTriggerSmartScanBatch() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -900,6 +900,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/smart-scan/profile-recommendations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get profile recommendations
+         * @description Returns profile suggestions grouped by detected OS family.
+         */
+        get: operations["getProfileRecommendations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/smart-scan/suggestions": {
         parameters: {
             query?: never;
@@ -1457,6 +1477,18 @@ export interface components {
             /** @example 3 */
             total_pages?: number;
         };
+        "docs.ProfileRecommendationResponse": {
+            /** @example port_expansion */
+            action?: string;
+            /** @example 42 */
+            host_count?: number;
+            /** @example Linux */
+            os_family?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440000 */
+            profile_id?: string;
+            /** @example Linux Standard */
+            profile_name?: string;
+        };
         "docs.ProfileResponse": {
             created_at?: string;
             /** @example Fast TCP connect scan */
@@ -1673,6 +1705,8 @@ export interface components {
             limit?: number;
             /** @example 192.168.1.0/24 */
             network_cidr?: string;
+            /** @example Linux */
+            os_family?: string;
             /**
              * @example os_detection
              * @enum {string}
@@ -5181,6 +5215,44 @@ export interface operations {
             };
             /** @description Too Many Requests */
             429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getProfileRecommendations: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ProfileRecommendationResponse"][];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/routes/dashboard.test.tsx
+++ b/frontend/src/routes/dashboard.test.tsx
@@ -34,6 +34,11 @@ vi.mock("../api/hooks/use-expiring-certs", () => ({
   useExpiringCerts: vi.fn(),
 }));
 
+vi.mock("../api/hooks/use-smart-scan", () => ({
+  useProfileRecommendations: vi.fn(),
+  useTriggerSmartScanBatch: vi.fn(),
+}));
+
 vi.mock("../components/activity-feed", () => ({
   ActivityFeed: () => null,
 }));
@@ -45,6 +50,10 @@ import { useActiveHostCount } from "../api/hooks/use-hosts";
 import { useDiscoveryJobs, useDiscoveryDiff } from "../api/hooks/use-discovery";
 import { useStatsSummary } from "../api/hooks/use-dashboard";
 import { useExpiringCerts } from "../api/hooks/use-expiring-certs";
+import {
+  useProfileRecommendations,
+  useTriggerSmartScanBatch,
+} from "../api/hooks/use-smart-scan";
 
 const mockUseVersion = vi.mocked(useVersion);
 const mockUseNetworkStats = vi.mocked(useNetworkStats);
@@ -55,6 +64,8 @@ const mockUseDiscoveryJobs = vi.mocked(useDiscoveryJobs);
 const mockUseDiscoveryDiff = vi.mocked(useDiscoveryDiff);
 const mockUseStatsSummary = vi.mocked(useStatsSummary);
 const mockUseExpiringCerts = vi.mocked(useExpiringCerts);
+const mockUseProfileRecommendations = vi.mocked(useProfileRecommendations);
+const mockUseTriggerSmartScanBatch = vi.mocked(useTriggerSmartScanBatch);
 
 function setupDefaultMocks() {
   mockUseVersion.mockReturnValue({
@@ -123,6 +134,16 @@ function setupDefaultMocks() {
     data: { certificates: [], days: 30 },
     isLoading: false,
   } as unknown as ReturnType<typeof useExpiringCerts>);
+
+  mockUseProfileRecommendations.mockReturnValue({
+    data: [],
+    isLoading: false,
+  } as unknown as ReturnType<typeof useProfileRecommendations>);
+
+  mockUseTriggerSmartScanBatch.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useTriggerSmartScanBatch>);
 }
 
 beforeEach(() => {

--- a/frontend/src/routes/dashboard.tsx
+++ b/frontend/src/routes/dashboard.tsx
@@ -543,31 +543,34 @@ function ProfileRecommendationsWidget() {
         </div>
       ) : (
         <div className="space-y-1.5">
-          {(recs ?? []).map((rec) => (
-            <div
-              key={rec.os_family}
-              className="flex items-center gap-2 px-1 py-0.5"
-            >
-              <span className="text-xs font-mono text-text-secondary shrink-0 w-6 text-right tabular-nums">
-                {rec.host_count}
-              </span>
-              <span className="text-xs text-text-secondary capitalize flex-1 truncate">
-                {rec.os_family}
-              </span>
-              <span className="text-xs text-text-muted truncate max-w-[140px]">
-                {rec.profile_name}
-              </span>
-              <button
-                type="button"
-                onClick={() => queueForFamily(rec.os_family)}
-                disabled={triggerBatch.isPending}
-                className="shrink-0 flex items-center gap-1 text-[10px] px-2 h-5 rounded border border-accent/40 text-accent bg-accent/10 hover:bg-accent/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          {(recs ?? []).map((rec) => {
+            const family = rec.os_family ?? "";
+            return (
+              <div
+                key={family}
+                className="flex items-center gap-2 px-1 py-0.5"
               >
-                <ScanLine className="h-2.5 w-2.5" />
-                Queue Scan
-              </button>
-            </div>
-          ))}
+                <span className="text-xs font-mono text-text-secondary shrink-0 w-6 text-right tabular-nums">
+                  {rec.host_count ?? 0}
+                </span>
+                <span className="text-xs text-text-secondary capitalize flex-1 truncate">
+                  {family}
+                </span>
+                <span className="text-xs text-text-muted truncate max-w-[140px]">
+                  {rec.profile_name ?? "—"}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => queueForFamily(family)}
+                  disabled={triggerBatch.isPending || !family}
+                  className="shrink-0 flex items-center gap-1 text-[10px] px-2 h-5 rounded border border-accent/40 text-accent bg-accent/10 hover:bg-accent/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <ScanLine className="h-2.5 w-2.5" />
+                  Queue Scan
+                </button>
+              </div>
+            );
+          })}
           <p className="text-[10px] text-text-muted pt-1">
             Hosts grouped by OS family — queue a port expansion scan for each.
           </p>

--- a/frontend/src/routes/dashboard.tsx
+++ b/frontend/src/routes/dashboard.tsx
@@ -8,6 +8,10 @@ import { useDiscoveryJobs, useDiscoveryDiff } from "../api/hooks/use-discovery";
 import { useStatsSummary } from "../api/hooks/use-dashboard";
 import { useExpiringCerts } from "../api/hooks/use-expiring-certs";
 import type { ExpiringCertificate } from "../api/hooks/use-expiring-certs";
+import {
+  useProfileRecommendations,
+  useTriggerSmartScanBatch,
+} from "../api/hooks/use-smart-scan";
 import { StatCard } from "../components/stat-card";
 import { SystemInfoCard } from "../components/system-info-card";
 import { RecentScansTable } from "../components/recent-scans-table";
@@ -24,6 +28,7 @@ import {
   AlertCircle,
   Clock,
   ShieldAlert,
+  Layers,
 } from "lucide-react";
 import { Button } from "../components/button";
 import { RunScanModal } from "../components";
@@ -506,6 +511,72 @@ function ExpiringCertsWidget() {
   );
 }
 
+// ── Profile recommendations widget ───────────────────────────────────────────
+
+function ProfileRecommendationsWidget() {
+  const { data: recs, isLoading } = useProfileRecommendations();
+  const triggerBatch = useTriggerSmartScanBatch();
+
+  if (!isLoading && (!recs || recs.length === 0)) return null;
+
+  function queueForFamily(osFamily: string) {
+    triggerBatch.mutate({ os_family: osFamily, stage: "port_expansion" });
+  }
+
+  return (
+    <div className="mt-6 bg-surface rounded-lg border border-border p-4">
+      <div className="flex items-center gap-2 mb-3">
+        <Layers className="h-3.5 w-3.5 shrink-0 text-accent" />
+        <p className="text-xs font-medium text-text-primary">
+          Profile Recommendations
+        </p>
+        {!isLoading && recs && (
+          <span className="ml-auto text-xs font-semibold tabular-nums px-1.5 py-0.5 rounded bg-accent/15 text-accent">
+            {recs.length}
+          </span>
+        )}
+      </div>
+      {isLoading ? (
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+        </div>
+      ) : (
+        <div className="space-y-1.5">
+          {(recs ?? []).map((rec) => (
+            <div
+              key={rec.os_family}
+              className="flex items-center gap-2 px-1 py-0.5"
+            >
+              <span className="text-xs font-mono text-text-secondary shrink-0 w-6 text-right tabular-nums">
+                {rec.host_count}
+              </span>
+              <span className="text-xs text-text-secondary capitalize flex-1 truncate">
+                {rec.os_family}
+              </span>
+              <span className="text-xs text-text-muted truncate max-w-[140px]">
+                {rec.profile_name}
+              </span>
+              <button
+                type="button"
+                onClick={() => queueForFamily(rec.os_family)}
+                disabled={triggerBatch.isPending}
+                className="shrink-0 flex items-center gap-1 text-[10px] px-2 h-5 rounded border border-accent/40 text-accent bg-accent/10 hover:bg-accent/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <ScanLine className="h-2.5 w-2.5" />
+                Queue Scan
+              </button>
+            </div>
+          ))}
+          <p className="text-[10px] text-text-muted pt-1">
+            Hosts grouped by OS family — queue a port expansion scan for each.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ── Page ──────────────────────────────────────────────────────────────────────
 
 export function DashboardPage() {
@@ -610,6 +681,9 @@ export function DashboardPage() {
 
       {/* Expiring TLS certificates */}
       <ExpiringCertsWidget />
+
+      {/* Profile recommendations */}
+      <ProfileRecommendationsWidget />
 
       {/* Modals / panels */}
       {selectedScan && (

--- a/internal/api/handlers/smartscan.go
+++ b/internal/api/handlers/smartscan.go
@@ -20,6 +20,7 @@ import (
 // smartScanServicer is the service interface consumed by SmartScanHandler.
 type smartScanServicer interface {
 	GetSuggestions(ctx context.Context) (*services.SuggestionSummary, error)
+	GetProfileRecommendations(ctx context.Context) ([]services.ProfileRecommendation, error)
 	EvaluateHostByID(ctx context.Context, hostID uuid.UUID) (*services.ScanStage, error)
 	QueueSmartScan(ctx context.Context, hostID uuid.UUID) (uuid.UUID, error)
 	QueueBatch(ctx context.Context, filter services.BatchFilter) (*services.BatchResult, error)
@@ -180,6 +181,7 @@ func (h *SmartScanHandler) TriggerBatch(w http.ResponseWriter, r *http.Request) 
 		Stage:       req.Stage,
 		HostIDs:     hostIDs,
 		NetworkCIDR: req.NetworkCIDR,
+		OSFamily:    req.OSFamily,
 		Limit:       req.Limit,
 	})
 	if err != nil {
@@ -194,7 +196,30 @@ type triggerBatchRequest struct {
 	Stage       string   `json:"stage"`
 	HostIDs     []string `json:"host_ids"`
 	NetworkCIDR string   `json:"network_cidr"`
+	OSFamily    string   `json:"os_family"`
 	Limit       int      `json:"limit"`
+}
+
+// GetProfileRecommendations handles GET /api/v1/smart-scan/profile-recommendations.
+//
+//	@Summary		Get profile recommendations
+//	@Description	Returns profile suggestions grouped by detected OS family.
+//	@Tags			smart-scan
+//	@Produce		json
+//	@Success		200	{array}		services.ProfileRecommendation
+//	@Failure		500	{object}	ErrorResponse
+//	@Router			/smart-scan/profile-recommendations [get]
+func (h *SmartScanHandler) GetProfileRecommendations(w http.ResponseWriter, r *http.Request) {
+	recs, err := h.service.GetProfileRecommendations(r.Context())
+	if err != nil {
+		h.logger.Error("Failed to get profile recommendations", "error", err)
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	if recs == nil {
+		recs = []services.ProfileRecommendation{}
+	}
+	writeJSON(w, r, http.StatusOK, recs)
 }
 
 // parseHostID extracts the host UUID from the path variable {id}.

--- a/internal/api/handlers/smartscan_test.go
+++ b/internal/api/handlers/smartscan_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,14 +23,24 @@ import (
 // ── mock ──────────────────────────────────────────────────────────────────────
 
 type mockSmartScanServicer struct {
-	getSuggestionsFn   func(ctx context.Context) (*services.SuggestionSummary, error)
-	evaluateHostByIDFn func(ctx context.Context, id uuid.UUID) (*services.ScanStage, error)
-	queueSmartScanFn   func(ctx context.Context, id uuid.UUID) (uuid.UUID, error)
-	queueBatchFn       func(ctx context.Context, f services.BatchFilter) (*services.BatchResult, error)
+	getSuggestionsFn            func(ctx context.Context) (*services.SuggestionSummary, error)
+	getProfileRecommendationsFn func(ctx context.Context) ([]services.ProfileRecommendation, error)
+	evaluateHostByIDFn          func(ctx context.Context, id uuid.UUID) (*services.ScanStage, error)
+	queueSmartScanFn            func(ctx context.Context, id uuid.UUID) (uuid.UUID, error)
+	queueBatchFn                func(ctx context.Context, f services.BatchFilter) (*services.BatchResult, error)
 }
 
 func (m *mockSmartScanServicer) GetSuggestions(ctx context.Context) (*services.SuggestionSummary, error) {
 	return m.getSuggestionsFn(ctx)
+}
+
+func (m *mockSmartScanServicer) GetProfileRecommendations(
+	ctx context.Context,
+) ([]services.ProfileRecommendation, error) {
+	if m.getProfileRecommendationsFn != nil {
+		return m.getProfileRecommendationsFn(ctx)
+	}
+	return []services.ProfileRecommendation{}, nil
 }
 
 func (m *mockSmartScanServicer) EvaluateHostByID(ctx context.Context, id uuid.UUID) (*services.ScanStage, error) {
@@ -57,6 +68,7 @@ func newSmartScanHandler(svc smartScanServicer) *SmartScanHandler {
 func routeSmartScan(h *SmartScanHandler, method, path string, body []byte) *httptest.ResponseRecorder {
 	r := mux.NewRouter()
 	r.HandleFunc("/api/v1/smart-scan/suggestions", h.GetSuggestions).Methods("GET")
+	r.HandleFunc("/api/v1/smart-scan/profile-recommendations", h.GetProfileRecommendations).Methods("GET")
 	r.HandleFunc("/api/v1/smart-scan/hosts/{id}/stage", h.EvaluateHost).Methods("GET")
 	r.HandleFunc("/api/v1/smart-scan/hosts/{id}/trigger", h.TriggerHost).Methods("POST")
 	r.HandleFunc("/api/v1/smart-scan/trigger-batch", h.TriggerBatch).Methods("POST")
@@ -263,4 +275,74 @@ func TestSmartScan_TriggerBatch_EmptyBody_UsesDefaults(t *testing.T) {
 
 	w := routeSmartScan(newSmartScanHandler(svc), "POST", "/api/v1/smart-scan/trigger-batch", nil)
 	assert.Equal(t, http.StatusAccepted, w.Code)
+}
+
+// ── GetProfileRecommendations ─────────────────────────────────────────────────
+
+func TestSmartScan_GetProfileRecommendations_ReturnsRecommendations(t *testing.T) {
+	svc := &mockSmartScanServicer{
+		getProfileRecommendationsFn: func(_ context.Context) ([]services.ProfileRecommendation, error) {
+			return []services.ProfileRecommendation{
+				{OSFamily: "Linux", HostCount: 5, ProfileID: "p1", ProfileName: "Linux Standard",
+					Action: "port_expansion"},
+				{OSFamily: "Windows", HostCount: 3, ProfileID: "p2", ProfileName: "Windows Standard",
+					Action: "port_expansion"},
+			}, nil
+		},
+	}
+
+	w := routeSmartScan(newSmartScanHandler(svc), "GET", "/api/v1/smart-scan/profile-recommendations", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body []services.ProfileRecommendation
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+	require.Len(t, body, 2)
+	assert.Equal(t, "Linux", body[0].OSFamily)
+	assert.Equal(t, 5, body[0].HostCount)
+	assert.Equal(t, "Linux Standard", body[0].ProfileName)
+	assert.Equal(t, "Windows", body[1].OSFamily)
+}
+
+func TestSmartScan_GetProfileRecommendations_EmptyResult_ReturnsEmptyArray(t *testing.T) {
+	svc := &mockSmartScanServicer{
+		getProfileRecommendationsFn: func(_ context.Context) ([]services.ProfileRecommendation, error) {
+			return nil, nil
+		},
+	}
+
+	w := routeSmartScan(newSmartScanHandler(svc), "GET", "/api/v1/smart-scan/profile-recommendations", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body []services.ProfileRecommendation
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+	assert.NotNil(t, body, "empty result must be [] not null")
+	assert.Empty(t, body)
+}
+
+func TestSmartScan_GetProfileRecommendations_ServiceError_Returns500(t *testing.T) {
+	svc := &mockSmartScanServicer{
+		getProfileRecommendationsFn: func(_ context.Context) ([]services.ProfileRecommendation, error) {
+			return nil, fmt.Errorf("db unavailable")
+		},
+	}
+
+	w := routeSmartScan(newSmartScanHandler(svc), "GET", "/api/v1/smart-scan/profile-recommendations", nil)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestSmartScan_TriggerBatch_OSFamily_PassedToFilter(t *testing.T) {
+	svc := &mockSmartScanServicer{
+		queueBatchFn: func(_ context.Context, f services.BatchFilter) (*services.BatchResult, error) {
+			assert.Equal(t, "linux", f.OSFamily)
+			return &services.BatchResult{Queued: 3, Details: []services.BatchDetailEntry{}}, nil
+		},
+	}
+
+	body, _ := json.Marshal(map[string]any{"os_family": "linux", "stage": "port_expansion"})
+	w := routeSmartScan(newSmartScanHandler(svc), "POST", "/api/v1/smart-scan/trigger-batch", body)
+	require.Equal(t, http.StatusAccepted, w.Code)
+
+	var result services.BatchResult
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&result))
+	assert.Equal(t, 3, result.Queued)
 }

--- a/internal/api/handlers/smartscan_test.go
+++ b/internal/api/handlers/smartscan_test.go
@@ -313,9 +313,13 @@ func TestSmartScan_GetProfileRecommendations_EmptyResult_ReturnsEmptyArray(t *te
 	w := routeSmartScan(newSmartScanHandler(svc), "GET", "/api/v1/smart-scan/profile-recommendations", nil)
 	require.Equal(t, http.StatusOK, w.Code)
 
+	// Pin the wire format: the handler must serialize nil service result as []
+	// not null. bytes.Buffer.String() does not advance the read position, so
+	// decoding from the same body afterwards still works.
+	assert.Equal(t, "[]\n", w.Body.String(), "empty result must serialize as [] not null")
 	var body []services.ProfileRecommendation
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
-	assert.NotNil(t, body, "empty result must be [] not null")
+	assert.NotNil(t, body)
 	assert.Empty(t, body)
 }
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -110,6 +110,7 @@ func (s *Server) setupSystemRoutes(api *mux.Router) {
 // setupSmartScanRoutes registers Smart Scan evaluation and trigger endpoints.
 func (s *Server) setupSmartScanRoutes(api *mux.Router, h *apihandlers.SmartScanHandler) {
 	api.HandleFunc("/smart-scan/suggestions", h.GetSuggestions).Methods("GET")
+	api.HandleFunc("/smart-scan/profile-recommendations", h.GetProfileRecommendations).Methods("GET")
 	api.HandleFunc("/smart-scan/hosts/{id}/stage", h.EvaluateHost).Methods("GET")
 	api.HandleFunc("/smart-scan/hosts/{id}/trigger", h.TriggerHost).Methods("POST")
 	api.HandleFunc("/smart-scan/trigger-batch", h.TriggerBatch).Methods("POST")

--- a/internal/services/smartscan.go
+++ b/internal/services/smartscan.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -61,10 +62,21 @@ type BatchFilter struct {
 	Stage             string      // empty = all eligible stages; otherwise one of ScanStage.Stage values
 	HostIDs           []uuid.UUID // non-empty = only these hosts; empty = all hosts
 	NetworkCIDR       string      // non-empty = only hosts whose IP falls within this CIDR
+	OSFamily          string      // non-empty = only hosts whose os_family matches (case-insensitive)
 	Limit             int         // max hosts to queue; 0 = use defaultBatchLimit
 	Source            string      // db.ScanSourceAPI / ScanSourceScheduled; defaults to ScanSourceAPI
 	ScoreThreshold    int         // 0 = no filter; >0 = only hosts with knowledge_score < threshold
 	MaxStalenessHours int         // 0 = no filter; >0 = only hosts not seen within N hours
+}
+
+// ProfileRecommendation suggests a scan profile for a group of hosts sharing
+// the same detected OS family.
+type ProfileRecommendation struct {
+	OSFamily    string `json:"os_family"`
+	HostCount   int    `json:"host_count"`
+	ProfileID   string `json:"profile_id"`
+	ProfileName string `json:"profile_name"`
+	Action      string `json:"action"` // the ScanStage.Stage value to use
 }
 
 // BatchResult summarizes the outcome of a QueueBatch call.
@@ -229,6 +241,65 @@ func (s *SmartScanService) GetSuggestions(ctx context.Context) (*SuggestionSumma
 		TotalHosts:  total,
 		GeneratedAt: time.Now(),
 	}, nil
+}
+
+// GetProfileRecommendations returns profile suggestions grouped by OS family.
+// For each OS family present in the fleet, it finds the best matching profile
+// template. Only families with an available profile are returned — an empty
+// slice means there are no actionable recommendations.
+func (s *SmartScanService) GetProfileRecommendations(ctx context.Context) ([]ProfileRecommendation, error) {
+	ctx, cancel := context.WithTimeout(ctx, smartScanQueryTimeout)
+	defer cancel()
+
+	// Query host counts grouped by OS family (active hosts only).
+	rows, err := s.database.QueryContext(ctx, `
+		SELECT os_family, COUNT(*) AS host_count
+		FROM hosts
+		WHERE os_family IS NOT NULL AND os_family != '' AND status = 'up'
+		GROUP BY os_family
+		ORDER BY host_count DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query OS family distribution: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	type osFamilyCount struct {
+		family string
+		count  int
+	}
+	var families []osFamilyCount
+	for rows.Next() {
+		var fc osFamilyCount
+		if err := rows.Scan(&fc.family, &fc.count); err != nil {
+			return nil, fmt.Errorf("failed to scan OS family row: %w", err)
+		}
+		families = append(families, fc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if s.profileManager == nil {
+		return nil, nil
+	}
+
+	var recs []ProfileRecommendation
+	for _, fc := range families {
+		matched, err := s.profileManager.GetByOSFamily(ctx, fc.family)
+		if err != nil || len(matched) == 0 {
+			continue // no matching profile — skip this OS family
+		}
+		// Prefer the first result (profiles are ordered by specificity in the DB).
+		p := matched[0]
+		recs = append(recs, ProfileRecommendation{
+			OSFamily:    fc.family,
+			HostCount:   fc.count,
+			ProfileID:   p.ID,
+			ProfileName: p.Name,
+			Action:      "port_expansion",
+		})
+	}
+	return recs, nil
 }
 
 // EvaluateHostByID is a convenience wrapper that loads the host then calls EvaluateHost.
@@ -545,10 +616,28 @@ func (s *SmartScanService) resolveHosts(ctx context.Context, filter BatchFilter)
 		return nil, err
 	}
 
+	// Apply OS family filter in-memory — avoids a separate DB query since the
+	// full host list is already fetched and capped at maxBatchHostsQuery.
+	if filter.OSFamily != "" {
+		hosts = filterByOSFamily(hosts, filter.OSFamily)
+	}
+
 	if filter.ScoreThreshold <= 0 && filter.MaxStalenessHours <= 0 {
 		return hosts, nil
 	}
 	return applyKnowledgeFilter(hosts, filter), nil
+}
+
+// filterByOSFamily retains only hosts whose OS family matches the given value
+// (case-insensitive).
+func filterByOSFamily(hosts []*db.Host, family string) []*db.Host {
+	out := make([]*db.Host, 0, len(hosts))
+	for _, h := range hosts {
+		if h.OSFamily != nil && strings.EqualFold(*h.OSFamily, family) {
+			out = append(out, h)
+		}
+	}
+	return out
 }
 
 // applyKnowledgeFilter retains hosts that are below the score threshold OR

--- a/internal/services/smartscan.go
+++ b/internal/services/smartscan.go
@@ -248,6 +248,10 @@ func (s *SmartScanService) GetSuggestions(ctx context.Context) (*SuggestionSumma
 // template. Only families with an available profile are returned — an empty
 // slice means there are no actionable recommendations.
 func (s *SmartScanService) GetProfileRecommendations(ctx context.Context) ([]ProfileRecommendation, error) {
+	if s.profileManager == nil {
+		return []ProfileRecommendation{}, nil
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, smartScanQueryTimeout)
 	defer cancel()
 
@@ -279,11 +283,7 @@ func (s *SmartScanService) GetProfileRecommendations(ctx context.Context) ([]Pro
 		return nil, err
 	}
 
-	if s.profileManager == nil {
-		return nil, nil
-	}
-
-	var recs []ProfileRecommendation
+	recs := make([]ProfileRecommendation, 0)
 	for _, fc := range families {
 		matched, err := s.profileManager.GetByOSFamily(ctx, fc.family)
 		if err != nil || len(matched) == 0 {
@@ -291,6 +291,11 @@ func (s *SmartScanService) GetProfileRecommendations(ctx context.Context) ([]Pro
 		}
 		// Prefer the first result (profiles are ordered by specificity in the DB).
 		p := matched[0]
+		// Skip generic catch-all profiles (os_family = NULL/empty in DB) — they
+		// match every OS family but don't represent a meaningful recommendation.
+		if len(p.OSFamily) == 0 {
+			continue
+		}
 		recs = append(recs, ProfileRecommendation{
 			OSFamily:    fc.family,
 			HostCount:   fc.count,

--- a/internal/services/smartscan_test.go
+++ b/internal/services/smartscan_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/anstrom/scanorama/internal/db"
+	"github.com/anstrom/scanorama/internal/profiles"
 )
 
 func discardLogger() *slog.Logger {
@@ -725,18 +726,14 @@ func TestFilterByOSFamily_EmptyFamilyReturnsNone(t *testing.T) {
 
 // ── GetProfileRecommendations ─────────────────────────────────────────────────
 
-func TestGetProfileRecommendations_NilProfileManager_ReturnsNil(t *testing.T) {
-	database, mock := newSmartScanMockDB(t)
-	// DB query still runs; profileManager nil causes early return.
-	mock.ExpectQuery("SELECT os_family").
-		WillReturnRows(sqlmock.NewRows([]string{"os_family", "host_count"}).
-			AddRow("linux", 5))
-
+func TestGetProfileRecommendations_NilProfileManager_ReturnsEmpty(t *testing.T) {
+	database, _ := newSmartScanMockDB(t)
+	// nil profileManager causes early return before any DB query.
 	svc := &SmartScanService{database: database, profileManager: nil}
 	recs, err := svc.GetProfileRecommendations(context.Background())
 	require.NoError(t, err)
-	assert.Nil(t, recs)
-	require.NoError(t, mock.ExpectationsWereMet())
+	assert.NotNil(t, recs, "nil profileManager must return [] not nil")
+	assert.Empty(t, recs)
 }
 
 func TestGetProfileRecommendations_DBError_ReturnsError(t *testing.T) {
@@ -744,7 +741,8 @@ func TestGetProfileRecommendations_DBError_ReturnsError(t *testing.T) {
 	mock.ExpectQuery("SELECT os_family").
 		WillReturnError(fmt.Errorf("connection reset"))
 
-	svc := &SmartScanService{database: database}
+	// profileManager must be non-nil so the nil guard does not short-circuit.
+	svc := &SmartScanService{database: database, profileManager: &profiles.Manager{}}
 	_, err := svc.GetProfileRecommendations(context.Background())
 	require.Error(t, err)
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -755,9 +753,11 @@ func TestGetProfileRecommendations_NoHosts_ReturnsEmpty(t *testing.T) {
 	mock.ExpectQuery("SELECT os_family").
 		WillReturnRows(sqlmock.NewRows([]string{"os_family", "host_count"}))
 
-	svc := &SmartScanService{database: database, profileManager: nil}
+	// profileManager must be non-nil so the DB query runs.
+	svc := &SmartScanService{database: database, profileManager: &profiles.Manager{}}
 	recs, err := svc.GetProfileRecommendations(context.Background())
 	require.NoError(t, err)
-	assert.Nil(t, recs)
+	assert.NotNil(t, recs, "no hosts must return [] not nil")
+	assert.Empty(t, recs)
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/services/smartscan_test.go
+++ b/internal/services/smartscan_test.go
@@ -694,3 +694,70 @@ func TestExceedsAutoQueueLimit_DBErrorFailsOpen(t *testing.T) {
 	assert.False(t, exceeded, "DB error must fail open (allow the queue)")
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
+
+// ── filterByOSFamily ──────────────────────────────────────────────────────────
+
+func TestFilterByOSFamily_MatchesCaseInsensitive(t *testing.T) {
+	linux := strPtr("linux")
+	windows := strPtr("Windows")
+	empty := strPtr("")
+	hosts := []*db.Host{
+		{ID: uuid.New(), OSFamily: linux, IPAddress: mustParseIP("10.0.0.1")},
+		{ID: uuid.New(), OSFamily: windows, IPAddress: mustParseIP("10.0.0.2")},
+		{ID: uuid.New(), OSFamily: empty, IPAddress: mustParseIP("10.0.0.3")},
+		{ID: uuid.New(), OSFamily: nil, IPAddress: mustParseIP("10.0.0.4")},
+	}
+
+	got := filterByOSFamily(hosts, "Linux")
+	require.Len(t, got, 1)
+	assert.Equal(t, hosts[0].ID, got[0].ID)
+}
+
+func TestFilterByOSFamily_EmptyFamilyReturnsNone(t *testing.T) {
+	// A nil OSFamily host must not match even when the filter is "".
+	// filterByOSFamily is only called with non-empty filter values, but ensure
+	// the nil-check is robust.
+	hosts := []*db.Host{{ID: uuid.New(), OSFamily: nil, IPAddress: mustParseIP("10.0.0.1")}}
+	got := filterByOSFamily(hosts, "")
+	// nil-check: no os_family match for ""
+	assert.Empty(t, got)
+}
+
+// ── GetProfileRecommendations ─────────────────────────────────────────────────
+
+func TestGetProfileRecommendations_NilProfileManager_ReturnsNil(t *testing.T) {
+	database, mock := newSmartScanMockDB(t)
+	// DB query still runs; profileManager nil causes early return.
+	mock.ExpectQuery("SELECT os_family").
+		WillReturnRows(sqlmock.NewRows([]string{"os_family", "host_count"}).
+			AddRow("linux", 5))
+
+	svc := &SmartScanService{database: database, profileManager: nil}
+	recs, err := svc.GetProfileRecommendations(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, recs)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetProfileRecommendations_DBError_ReturnsError(t *testing.T) {
+	database, mock := newSmartScanMockDB(t)
+	mock.ExpectQuery("SELECT os_family").
+		WillReturnError(fmt.Errorf("connection reset"))
+
+	svc := &SmartScanService{database: database}
+	_, err := svc.GetProfileRecommendations(context.Background())
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetProfileRecommendations_NoHosts_ReturnsEmpty(t *testing.T) {
+	database, mock := newSmartScanMockDB(t)
+	mock.ExpectQuery("SELECT os_family").
+		WillReturnRows(sqlmock.NewRows([]string{"os_family", "host_count"}))
+
+	svc := &SmartScanService{database: database, profileManager: nil}
+	recs, err := svc.GetProfileRecommendations(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, recs)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
## Summary

- Adds `GetProfileRecommendations` to `SmartScanService` — groups hosts by OS family, matches each to the best scan profile via `ProfileManager.GetByOSFamily`, and returns only actionable entries (families that have a matching profile)
- Adds `OSFamily` filter to `BatchFilter` and `triggerBatchRequest` so `/smart-scan/trigger-batch` can target a specific OS family
- Adds `GET /smart-scan/profile-recommendations` endpoint with handler, route, and handler tests
- Adds `ProfileRecommendationResponse` to swagger docs and regenerates `types.ts` — removing the `as never` workaround in the hook
- Adds `ProfileRecommendationsWidget` to the dashboard — renders conditionally (hidden when no recommendations), shows OS family / host count / profile name, and a Queue Scan button per row

## Test plan

- [ ] Start the app with mixed-OS hosts; verify the widget appears on the dashboard
- [ ] Click Queue Scan for one OS family; confirm a batch scan is queued in the Scans list
- [ ] With no hosts in DB, verify the widget is hidden (returns null)
- [ ] `GET /api/v1/smart-scan/profile-recommendations` returns `[]` when no profiles match any OS family

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)