### PR TITLE
docs(claude): add CLAUDE.md with workflow rules

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -18,8 +18,8 @@ Run the full agent team review on $ARGUMENTS.
 Determine whether this is a **first review** or a **re-review** of a branch that was already reviewed:
 
 ```bash
-# Look for a previous review summary in the PR conversation (posted by Claude)
-PREV_REVIEW=$(gh api repos/anstrom/scanorama/issues/<PR>/comments \
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+PREV_REVIEW=$(gh api repos/${REPO}/issues/<PR>/comments \
   --jq '[.[] | select(.body | test("## PR Review:"))] | last | .body' 2>/dev/null)
 ```
 
@@ -29,7 +29,7 @@ If `PREV_REVIEW` is non-empty, this is a **re-review**. Extract:
 - The **"Verified" section** (what already passed in round 1)
 
 Pass this context to both Phase A agents so they know:
-1. What was already verified and should be treated as a **regression baseline** (only re-test if those subsystems changed)
+1. What was already verified — treat as regression baseline, only re-test if that subsystem changed
 2. Which specific blockers must now be confirmed fixed (highest priority)
 3. What is genuinely new since the last review commit
 
@@ -37,78 +37,212 @@ Pass this context to both Phase A agents so they know:
 
 **For re-reviews**, scope each agent accordingly:
 - **code-quality-reviewer**: Focus on (a) verifying each prior blocker/should-fix is now resolved, (b) any new code in commits added since the last review, (c) regressions in previously-clean code. Do NOT re-audit code that was already clean and hasn't changed.
-- **integration-tester**: Skip smoke tests for subsystems that passed in round 1 and have no new commits touching them. Focus on: (a) verifying the specific fixes for previously-flagged blockers, (b) regression spot-check of the changed subsystems only, (c) any new subsystems added since round 1.
+- **integration-tester**: Skip smoke tests for subsystems that passed in round 1 and have no new commits touching them. Focus on: (a) verifying the specific fixes for previously-flagged blockers, (b) regression spot-check of the changed subsystems only.
 
-## Pre-flight: swagger drift + test coverage audit (do this before Phase A)
-
-Before launching agents, run `git diff --stat origin/main...HEAD` to get the file list, then:
+## Pre-flight (run before Phase A — report results immediately)
 
 ### Swagger drift check
 Run `make docs` and then `git diff --exit-code docs/swagger/ frontend/src/api/types.ts`.
-- If the diff is non-empty: **blocker** — the swagger spec is out of sync. List the files that changed and instruct the author to commit the updated output.
-- This check is mandatory even if no handler files changed (swagger_docs.go may reference types from other packages).
+- Non-empty diff = **blocker**. List the files that changed and tell the author to commit them.
+- This is the authoritative swagger check — agents do not need to repeat it.
 
 ### Codecov annotations (if a PR exists and CI has run)
-Run: `gh pr checks <PR number> --json name,conclusion,detailsUrl | jq '.[] | select(.name | test("codecov"; "i"))'`
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+gh pr checks <PR> --json name,conclusion,detailsUrl | jq '.[] | select(.name | test("codecov"; "i"))'
+gh api repos/${REPO}/issues/<PR>/comments \
+  --jq '[.[] | select(.user.login == "codecov[bot]")] | last | .body' 2>/dev/null
+```
+Extract:
+- **Patch coverage** ≥ 40% (informational)
+- **Project coverage** delta — must not drop > 2% (blocking if CI fails on it)
+- **File-level table** — flag files where coverage dropped > 5 percentage points as should-fix
+- If no Codecov comment yet: note "pending" and skip
 
-Then fetch the Codecov PR comment to read patch and project coverage:
-`gh api repos/anstrom/scanorama/issues/<PR number>/comments --jq '[.[] | select(.user.login == "codecov[bot]")] | last | .body' 2>/dev/null`
-
-From the comment, extract:
-- **Patch coverage** — the percentage of *new/changed lines* that are covered. Codecov threshold is ≥40% (informational — does not block CI, but flag if below).
-- **Project coverage** — total coverage delta vs base branch. Threshold is must not drop >2% (blocking — CI fails if it does). Flag if the project check shows a negative delta.
-- **File-level coverage table** — list any changed files where coverage dropped significantly (>5 percentage points) vs the base branch. These are should-fix items even if under threshold.
-- If CI is still running (no Codecov comment yet): note "Codecov pending" and skip this check — do not block on it.
-- If there is no PR yet: skip this check entirely.
+### Commit structure audit
+Run `git log --oneline origin/main..HEAD`. Check two things:
+1. **Bare fixup! commits**: any commit whose subject starts with `fixup!` is a **blocker** — the author must run `git rebase --autosquash origin/main` and force-push before merge.
+2. **Bundled concerns**: a commit that addresses unrelated changes (e.g. a bug fix + a refactor + a new feature) is a **blocker** — the branch must be split.
 
 ### Test coverage audit
-Read the PR test plan and the diff, then answer these questions:
+Read the PR diff and test plan, then for each new exported function/method/handler:
+1. Does a test exist for the happy path? Required.
+2. Does a test exist for the primary error path? Required.
+3. For handlers: does a test exist for bad input (400)? Required.
+4. Are there edge cases handled in the code (nil guard, empty slice, zero count) with no corresponding test? Flag as gap.
+5. For each test plan item that describes automatable behaviour ("endpoint X returns Y", "function handles Z"), is there a test in the diff? If not, **blocker**.
 
-1. **Test plan vs. automation**: For each item in the PR test plan, decide whether it describes behaviour that *should* have a unit test or integration test (e.g. "endpoint X returns Y", "function Z handles edge case W"). If yes and no corresponding test exists in the diff, list it as a coverage gap — this is a blocker.
-2. **New code coverage** — apply these rules strictly:
-   - Every new exported function or method must have at least one test covering the happy path.
-   - Every non-trivial error path (error return, early return, branch that changes observable behaviour) must have a test that exercises it.
-   - Every new HTTP handler must have tests for: 200 success, 400 bad input, and the primary error path (404 or 500).
-   - Every new DB repository method must have at least one unit test or integration test.
-   - Absence of tests for non-trivial new code is a **blocker**, not a nice-to-have.
-   - Tautological tests (asserting language invariants or restating constants without exercising real logic) do not count as coverage.
+Report coverage gaps here, before agents launch, so the user sees them immediately.
 
-Summarise the coverage gaps before launching the agents, so the user sees them immediately regardless of how long the agent reviews take.
+## Code change detection (do this before Phase A)
+
+Run `git diff --name-only origin/main...HEAD` and check whether any changed file has a code extension (`.go`, `.ts`, `.tsx`, `.sql`, `.py`, `.sh`).
+
+- If **yes**: launch both Phase A agents (code-quality-reviewer + integration-tester).
+- If **no** (docs, markdown, YAML, skill files only): launch **only the code-quality-reviewer**. Skip the integration-tester entirely and note "N/A (docs-only)" in the final report under Live API smoke test.
 
 ## Phase A — Parallel reviews
 
-Launch **two agents in a single message** (parallel tool calls). Each gets a self-contained prompt — they cannot see each other's context.
+Launch agents in a **single message** (parallel tool calls). Wait for all to return before Phase B.
 
-**Agent 1: `code-quality-reviewer`**
-- Task description: "Code quality review of <branch> vs <base>"
-- Prompt must include: base branch, PR number (if any), the file list from `git diff --stat`, the user's stated intent (from PR title/body or a 1-line note), and an explicit instruction to focus on the diff only (not the whole codebase). Tell it to write its report as the final message and not to commit anything.
-- Explicitly ask it to audit test coverage: for each new exported function/method/handler in the diff, check whether the diff contains tests covering the happy path and key error cases. Tautological tests (asserting language invariants or restating constants) do not count as coverage.
-- **For re-reviews**: include the previous review's blocker/should-fix list and instruct the agent to: (1) confirm each prior item is fixed or still open, (2) review only code changed since the last review for new issues, (3) skip re-auditing previously-clean code that has not changed.
+### Agent 1: code-quality-reviewer
 
-**Agent 2: `integration-tester`**
-- Task description: "Integration test of <branch> against live dev env"
-- Prompt must include: base branch, PR number, the file list, which subsystems the diff touches (so it knows which CLI commands and API endpoints to prioritize), and an explicit instruction NOT to run `make dev-nuke` or destructive cleanup. Tell it to use the existing dev environment if one is already running.
-- **For re-reviews**: include the previous round's "Verified" section and instruct the agent to skip re-testing those items unless the relevant subsystem has new commits. The agent should focus on: (a) verifying previously-flagged blockers are fixed, (b) regression spot-check of changed subsystems only. State explicitly which tests to skip to avoid re-running what already passed.
-- **Cleanup requirement — include this verbatim in the prompt:** Before starting, record the current counts of scan jobs, profiles, and any other mutable resources that the tests will touch (e.g. `SELECT status, COUNT(*) FROM scan_jobs GROUP BY status`). After all tests complete, delete every resource the test session created: scan jobs queued during the session, profiles created during the session, discovery jobs, etc. Report the before/after counts to confirm cleanup. If a resource cannot be deleted via API (e.g. the DELETE endpoint doesn't exist), delete it directly via the database. Leaving test artifacts in the dev environment is a bug in the test run, not acceptable collateral.
-- **Scan failure reporting — include this verbatim in the prompt:** If scans fail, report the *specific error message* from the database (`error_message` column in `scan_jobs`), not just "expected without sudo". Distinguish between: (a) permission failures (raw socket / sudo required — acceptable in dev), (b) queue-full failures (means the test hammered the queue — flag as a test design issue), and (c) any other error. Never describe failures as "expected" without quoting the actual error and confirming it matches the known dev limitation.
+Prompt must include:
+- Base branch, PR number, file list from `git diff --stat`
+- PR intent (from title/body, one sentence)
+- The project conventions block below — paste it verbatim
+- Instruction to focus on the diff only, write the report as the final message, do not commit anything
 
-Run both in the foreground, in parallel, in the same tool-call message. Wait for both to return.
+**Full-stack path tracing — include this verbatim in the prompt:**
+
+```
+FULL-STACK PATH VERIFICATION
+
+For every new feature in this PR, trace the complete path from frontend to database and
+verify each layer agrees with the next. Do not assume a layer is correct because it compiles.
+
+1. FRONTEND → BACKEND CONTRACT
+   - What URL and HTTP method does the hook call? (check api.GET/POST path)
+   - What query params or request body does it send? (check the hook's params object)
+   - What response shape does it expect? (check how the hook reads data fields)
+   - Does this match: the route registered in internal/api/routes.go, the handler's param
+     parsing, and the response struct the handler encodes?
+   - Are field names consistent end-to-end? A hook reading data.host_count when the handler
+     returns HostCount (PascalCase, no json tag) is a silent bug.
+
+2. BACKEND → SERVICE CONTRACT
+   - Does the handler pass all the inputs the service method needs?
+   - Does the handler correctly interpret the service's return values? (e.g. uuid.Nil meaning
+     "not queued" vs an error meaning "failed")
+   - Are error types mapped to the right HTTP status codes? (CodeNotFound → 404,
+     CodeUnknown → 500, scanning.ErrQueueFull → 429)
+
+3. SERVICE → DATABASE CONTRACT
+   - Does the SQL query reference columns and tables that exist in the schema?
+   - Does the query return columns in the order the scan destination expects?
+   - Are nullable columns handled? (sql.NullString, sql.NullTime — not bare string/time.Time)
+   - Does the service correctly handle sql.ErrNoRows vs other DB errors?
+   - If the service filters or aggregates results, does the filter logic match the intent?
+     (e.g. filtering out null os_family rows when the SQL JOIN returns them)
+
+4. SCHEMA → MIGRATIONS
+   - Does any new code assume a column or index that isn't in the migration files?
+   - If a migration adds a NOT NULL column to an existing table, is there a default or backfill?
+
+Flag any mismatch at any layer as a blocker — these are the bugs that pass all unit tests
+and only surface at runtime.
+
+5. UNEXPOSED API SURFACE
+   After tracing all new endpoints, check whether any backend capability added in this PR
+   has no corresponding frontend hook or UI. This is not a blocker, but flag it as a
+   "nice to have" with a concrete suggestion: which hook file it should go in, what the
+   query key should be, and which page or component would benefit from surfacing it.
+   Examples: a new filter param on an existing endpoint that the frontend ignores, a new
+   aggregation endpoint with no widget, a new action endpoint with no button.
+```
+
+**Logical correctness — include this verbatim in the prompt:**
+
+```
+LOGICAL CORRECTNESS (check these before style)
+
+Read each new function and ask:
+- Does the logic actually do what the name and comment claim? Look for off-by-one errors,
+  wrong comparison operators, inverted conditions, and missed early returns.
+- Are there implicit assumptions that could be violated? (e.g. assumes slice is non-empty,
+  assumes map key exists, assumes context is non-nil, assumes DB returns rows in a specific order)
+- Is every code path handled? Trace through: what happens if the DB returns 0 rows? What if
+  the input is empty string? What if a pointer is nil?
+- Are function signatures complete and consistent with how callers use them? Look for:
+  - Parameters that are passed but ignored inside the function
+  - Return values that callers never check
+  - Context not threaded through when the function does IO
+  - Methods that modify receiver state without the receiver being a pointer
+- API contract mismatches: does the handler's response shape match what swagger_docs.go declares?
+  Does the frontend hook's expected response shape match what the backend actually returns?
+  Does the query param name in the hook match the param name the handler reads?
+- DB schema assumptions: does new code reference columns or tables that exist in the migrations?
+  Does it assume a column is NOT NULL when the schema allows NULL? Does it use the right type
+  (uuid vs string, timestamptz vs timestamp)?
+- Interface completeness: if a new method is added to an interface, are all implementations
+  updated? Check mock structs in test files — a mock that doesn't implement a new method will
+  fail to compile but may be in a file the author didn't update.
+- Concurrency: are shared fields accessed under a lock? Are goroutines properly waited on?
+  Does a goroutine capture a loop variable by reference?
+```
+
+**Project conventions to enforce — include this verbatim in the prompt:**
+
+```
+Project-specific conventions to enforce (from CLAUDE.md):
+
+COMMIT STRUCTURE
+- Each commit must address exactly one concern. Flag any commit that bundles unrelated changes.
+
+GO CONVENTIONS
+- Handlers: tested via httptest + gorilla/mux with a local mock struct using function fields.
+  Every new handler needs tests for: 200 success, 400 bad input, primary error path (404/500).
+- JSON key assertion: use map[string]any to decode responses, not the Go struct — this catches
+  missing json:"..." tags. Assert snake_case keys; flag any PascalCase keys in JSON output.
+- Nil vs empty slice: methods that return slices to be JSON-encoded must return make([]T, 0),
+  never nil. Test that the wire format is [] not null.
+- Error types: use apierrors.NewScanError(apierrors.CodeNotFound, ...) for typed errors,
+  fmt.Errorf("context: %w", err) for wrapping.
+- Test assertions: require for fatal (stops test on failure), assert for non-fatal. Never use
+  require where the test can meaningfully continue.
+- Services: DB-touching code uses go-sqlmock. Verify ExpectationsWereMet() is called at the
+  end of every test that sets up mock expectations.
+- Routes: if a new handler is added, verify it is registered in internal/api/routes.go.
+  A handler that isn't registered compiles and tests fine but doesn't exist at runtime.
+
+TYPESCRIPT CONVENTIONS
+- Every hook used in a page component must have a vi.mock(...) at the top of the component's
+  test file and a default return in setupDefaultMocks(). Missing mock = "No QueryClient set" in CI.
+- Hook tests: use renderHookWithQuery. Provide ok() and fail() helpers. Cover loading state,
+  success with real field assertions, and error state.
+- Component tests: assert on rendered text, not internals. Test loading skeleton (animate-pulse),
+  empty state, and error state in addition to happy path.
+- Tautological tests (asserting language invariants or restating constants without exercising
+  real logic) do not count as coverage.
+```
+
+For re-reviews: also include the previous review's blocker/should-fix list and instruct the agent to confirm each prior item is resolved before looking for new issues.
+
+### Agent 2: integration-tester
+
+Prompt must include:
+- Base branch, PR number, file list, which subsystems the diff touches
+- Instruction NOT to run `make dev-nuke` or destructive cleanup
+- Use the existing dev environment if running; ask before starting one
+
+**Cleanup requirement — include this verbatim:**
+> Before starting, record the current counts of scan jobs, profiles, and any other mutable resources the tests will touch (e.g. `SELECT status, COUNT(*) FROM scan_jobs GROUP BY status`). After all tests complete, delete every resource the test session created. Report before/after counts to confirm cleanup. If a DELETE endpoint doesn't exist, delete directly via the database. Leaving test artifacts is a bug in the test run.
+
+**Scan failure reporting — include this verbatim:**
+> If scans fail, report the specific error message from the `error_message` column in `scan_jobs`, not just "expected without sudo". Distinguish: (a) permission failures (raw socket / sudo — acceptable in dev), (b) queue-full failures (test design issue — flag it), (c) any other error. Never describe a failure as "expected" without quoting the actual error.
+
+**What the integration-tester should check:**
+- Live API responses match the expected shape (status codes, response body fields)
+- New routes are reachable (catches missing routes.go registration)
+- Any cross-layer contract: does the frontend hook's query key and params match what the backend expects?
+- Note explicitly which frontend behaviours cannot be verified without a browser (empty state rendering, loading skeleton) so the gap is visible in the report
+
+For re-reviews: skip re-testing subsystems that passed in round 1 and have no new commits. Focus on previously-flagged blockers and changed subsystems only.
 
 ## Phase B — Consolidation
 
-Once both reports are back, launch the third agent **sequentially** (it needs the outputs of the first two):
+Once both reports are back, launch the third agent **sequentially**:
 
-**Agent 3: `pr-quality-reviewer`**
-- Task description: "Final PR review with cross-agent findings"
-- Prompt should include:
-  - Branch + base + PR number
-  - The full reports from `code-quality-reviewer` and `integration-tester`, clearly labeled
-  - The current CI status from `gh pr view ... --json statusCheckRollup` (if a PR exists)
-  - An instruction to **deduplicate** findings across the two upstream reports, **resolve conflicts** when the two agents disagree, and produce a **single prioritized merge-or-block decision**.
+**Agent 3: pr-quality-reviewer**
 
-## Phase C — Final report to the user
+Include:
+- Branch + base + PR number
+- Full reports from both agents, clearly labeled
+- Current CI status from `gh pr view --json statusCheckRollup`
+- Pre-flight findings (swagger, codecov, commit audit, coverage gaps)
+- Instruction to deduplicate findings, resolve conflicts explicitly (not silently), and produce a single prioritized merge-or-block decision
 
-Print a single consolidated summary in this exact shape:
+## Phase C — Final report
 
 ```
 ## PR Review: <branch or #PR>
@@ -129,26 +263,21 @@ Print a single consolidated summary in this exact shape:
 - Unit tests: <pass/fail>
 - Lint/format: <pass/fail>
 - Live API smoke test: <pass/fail>
-- Cross-layer contract check: <pass/fail>
+- Routes registration: <pass/fail/n/a>
 - Codecov patch coverage: <X% / pending / no PR>
 
 ### Recommendation
 <merge | merge after fixing blockers | block — reason>
 ```
 
-Then print a one-line pointer to where the user can read each agent's full report if they want detail (or offer to print any of them in full).
+Offer to print any agent's full report on request.
 
 ## Rules
 
-- **Never commit, push, force-push, or merge anything** as part of this command. Read-only.
+- **Never commit, push, force-push, or merge anything** as part of this skill. Read-only.
 - **Don't modify config files** or run `make dev-nuke`.
 - If the dev environment isn't running and the user is on a feature branch, ask before running `make dev` (it requires sudo).
-- If `code-quality-reviewer` and `integration-tester` produce contradictory findings, surface the contradiction explicitly in the consolidation rather than picking one silently.
-- If there's no PR yet (just a local branch), still run the review — just note "no PR yet" in the CI status line.
-- **Check that every commit addresses exactly one concern.** If `git log origin/main..HEAD` reveals commits that bundle unrelated changes (e.g., two distinct bug fixes in one commit), flag it as a blocker — the branch must be split before merge.
-- **Check the PR test plan for CI-redundant items.** Items like "`go test ./...` passes" or "`golangci-lint` — 0 issues" are covered by CI and must not appear as manual checkboxes. Flag any such items as should-fix; test plans must only list live/manual verification steps that CI cannot perform.
-- **After making any code changes as part of the review process, update the PR title and body** using `gh pr edit` so they accurately reflect the current branch state. Summary, new endpoints, and test plan items must match what is actually in the branch.
-- **Test plan items that describe automatable behaviour must have tests.** If a test plan item says "endpoint X returns Y for input Z" or "function handles edge case W", that behaviour belongs in a unit or integration test — not just a manual checkbox. Flag any such item that has no corresponding test in the diff as a blocker.
-- **Swagger drift is a blocker.** Run `make docs` and `git diff --exit-code docs/swagger/ frontend/src/api/types.ts` — any diff means the spec is stale. The pre-push hook catches this locally; a CI failure here means the author skipped the hook.
-- **Thorough test coverage is required, not optional.** Low coverage is a blocker. Every new handler, service method, and repository method needs tests. "We'll add tests later" is not accepted.
-- **Do not re-verify in round 2+ what was already clean in round 1 and has not changed.** The cost of a review is proportional to how much it teaches — re-running identical tests that already passed adds noise without signal. Each round should advance the review, not repeat it.
+- If agents contradict each other, surface the contradiction explicitly — never resolve it silently.
+- If there's no PR yet, still run the review — note "no PR yet" in CI status.
+- **Swagger drift is checked in pre-flight only** — agents do not need to re-run `make docs`.
+- **Do not re-verify in round 2+ what was already clean in round 1 and hasn't changed.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,240 @@
+# Scanorama — Claude Code Rules
+
+## Release
+
+**Pushing a tag is the complete release action.** GoReleaser runs automatically via `.github/workflows/release.yml`.
+
+```bash
+git tag vX.Y.Z        # tag at HEAD of main
+git push origin vX.Y.Z  # triggers CI → GoReleaser → GitHub release
+```
+
+Never use `gh release create`. Never write changelogs manually. The pipeline owns everything after the tag push.
+
+## Branch Workflow
+
+Always branch off `main`. Never commit directly to `main` (branch protection enforced).
+
+```bash
+git checkout main && git pull --rebase origin main
+git checkout -b feat/my-feature
+```
+
+## Commits
+
+### Format
+
+```
+<type>(<subsystem>): <description>
+```
+
+- **Scope** = subsystem name (`queue`, `handlers`, `smartscan`, `dashboard`) — never a plan/wave/ticket reference
+- **Imperative mood**, present tense: "add X" not "added X"
+- **No adjectives**, no marketing language: "implement pagination" not "add robust comprehensive pagination"
+- **One concern per commit** — if a commit touches two unrelated things, split it
+
+### Types
+
+`feat` · `fix` · `docs` · `refactor` · `test` · `chore` · `ci` · `perf`
+
+### One commit per logical concern
+
+A PR should have as many commits as it has distinct concerns. Examples of correct granularity:
+
+```
+feat(db): add scan_results table migration
+feat(api): add GET /scan-results endpoint
+feat(dashboard): add scan results widget
+ci: add nightly scan job
+```
+
+Do **not** squash these into one. Keep them discrete so the history is readable per subsystem.
+
+### Fixup commits — for correcting mistakes only
+
+If you catch an error in a previous commit on the same branch (lint failure, typo, missed edge case), fix it with a fixup rather than a new standalone commit:
+
+```bash
+git commit --fixup=<sha>             # ties the correction to the original
+git rebase --autosquash origin/main  # folds it in before pushing
+```
+
+Never push bare `fixup!` commits. Never add a standalone "fix lint" or "oops" commit — always tie it back to the original with `--fixup`.
+
+## Before Every Push
+
+The git hooks enforce quality automatically:
+- **pre-commit**: runs `gofmt`, `go vet`, and `golangci-lint` on every commit
+- **pre-push**: runs backend tests (`-short -race`), frontend tests, and swagger drift check
+
+Before pushing, squash fixup commits and verify the fuller test suite passes:
+
+```bash
+git rebase --autosquash origin/main
+go test -race ./internal/...   # fuller than the hook's -short run (~30s)
+git push origin my-branch      # hook runs lint + swagger + tests automatically
+```
+
+If either test suite is red, fix before pushing — CI round-trip is 2–3 min.
+
+## Pull Requests
+
+- Every PR body must include `Closes #NNN` or `Fixes #NNN` (links to the issue and auto-closes it on merge)
+- Use `Mentions #NNN` when the PR is related to but does not close the issue
+- Merge strategy: always `gh pr merge --rebase` — never squash unless explicitly asked
+- Update the PR title and body with `gh pr edit` after any significant change to the branch
+- Run `review-pr` after every implementation — see **Code Review** section for how to prompt it
+
+### Test plans
+
+Test plans are for **live/manual verification only** — things CI cannot check.
+
+Never list `go test`, lint, build steps, or swagger checks as manual checkboxes. If behaviour can be tested automatically, write the test — a checkbox is not a substitute.
+
+## Linting
+
+The pre-commit hook blocks commits with lint failures. To fix before committing:
+
+```bash
+make lint-fix   # auto-fixes formatting, imports, and simple issues
+make lint       # shows what still needs manual attention
+```
+
+Key rules enforced by `.golangci.yml`:
+
+| Rule | Constraint |
+|------|-----------|
+| `lll` | Lines ≤ 120 characters |
+| `mnd` | No magic numbers in arguments, return values, conditions, cases, or operations |
+| `nestif` | Extract deeply nested if-else blocks to helper functions |
+| `goconst` | Strings appearing 3+ times must be named constants |
+| `funlen` | Functions ≤ 100 lines and ≤ 50 statements |
+| `gocyclo` | Cyclomatic complexity ≤ 15 |
+
+Fix lint violations with `git commit --fixup` + autosquash — never standalone fix commits.
+
+## Swagger
+
+Run `make docs` after any handler, route, or type change. Swagger drift is a CI blocker.
+
+```bash
+make docs
+git diff --exit-code docs/swagger/ frontend/src/api/types.ts  # must be empty
+```
+
+The pre-push hook catches this locally. A CI failure here means the hook was skipped.
+
+## Testing
+
+Tests are not optional. Every PR that adds or changes behaviour must include tests. "We'll add tests later" is not accepted.
+
+### Backend (Go)
+
+**Handlers** — test via `httptest` + `gorilla/mux`, never call the real service. Use a local mock struct with function fields so each test case wires only what it needs:
+
+```go
+type mockMyServicer struct {
+    doThingFn func(ctx context.Context, id uuid.UUID) (*MyResult, error)
+}
+func (m *mockMyServicer) DoThing(ctx context.Context, id uuid.UUID) (*MyResult, error) {
+    return m.doThingFn(ctx, id)
+}
+```
+
+Every new handler needs tests for: **200 success**, **400 bad input**, **404/500 error path**.
+
+Assert on JSON key names using `map[string]any` (not the Go struct) to catch missing `json:"..."` tags:
+```go
+var raw map[string]any
+require.NoError(t, json.NewDecoder(w.Body).Decode(&raw))
+assert.Equal(t, "expected", raw["snake_case_key"])
+```
+
+**Services** — use `go-sqlmock` for DB-touching code. Set up expectations with `mock.ExpectQuery(...).WillReturnRows(...)` and assert `mock.ExpectationsWereMet()` at the end. Use interface mocks (not real dependencies) for everything else.
+
+**Nil vs empty slice** — when a method returns a slice that will be JSON-encoded, always return `make([]T, 0)` not `nil`. Test that the wire format is `[]` not `null`:
+```go
+assert.Equal(t, "[]\n", w.Body.String())
+```
+
+### Frontend (TypeScript)
+
+**Hooks** — test via `renderHookWithQuery` from `test/utils`. Mock `api.GET/POST/PUT/DELETE` at the module level. Provide `ok()` and `fail()` helpers for clean response construction:
+
+```ts
+const ok = (data: unknown) => Promise.resolve({ data, error: undefined, response: new Response() })
+const fail = (msg = "error") => Promise.resolve({ data: undefined, error: { message: msg }, response: new Response() })
+```
+
+Cover: loading state, success with real data assertions, error state.
+
+**Page components** — test via `renderWithRouter`. Mock every hook the component uses with `vi.mock(...)` at the top of the file, and set defaults in `setupDefaultMocks()` called from `beforeEach`. Every hook in the component = one `vi.mock` in the test file, or CI fails with "No QueryClient set".
+
+**What to assert** — check rendered text, not component internals. Test loading skeletons (`animate-pulse`), empty states, and error states in addition to the happy path.
+
+### What counts as coverage
+
+- Happy path: required
+- Primary error path (service error, DB error, not found): required
+- Bad input / validation (400): required for handlers
+- Edge cases that appear in the PR (nil manager, empty result, zero count): required if the code handles them
+
+Tautological tests that only assert Go/TS language invariants (e.g. `assert.Equal(t, "idle", "idle")`) do not count.
+
+## Code Review
+
+Run `review-pr` after every implementation, before reporting done or creating a PR. Never claim a task is complete without it.
+
+Give the agent a targeted prompt — not just "review this". Include:
+
+1. **What changed** — list the files modified and what each does
+2. **What to check** — be specific based on what was implemented:
+   - New handler → check: HTTP status codes correct, all error paths handled, JSON keys are snake_case, nil guard before encoding slice
+   - New service method → check: error wrapping, context propagation, timeout, nil receiver guard
+   - New DB query → check: sqlmock expectations match real query, `ExpectationsWereMet()` called, `sql.ErrNoRows` handled
+   - New frontend hook → check: error state handled, loading state handled, staleTime set
+   - New frontend component → check: all hooks mocked in test file, loading/empty/error states rendered
+3. **Tests to verify** — point it at the test files and ask it to confirm coverage is non-tautological
+4. **Project conventions to enforce** — snake_case JSON, `make([]T, 0)` not nil slices at API boundaries, `apierrors.NewScanError` for typed errors, `require` for fatal assertions and `assert` for non-fatal
+
+Example prompt structure:
+```
+Review the implementation in these files: [list files]
+
+Context: [one sentence on what the feature does]
+
+Check specifically:
+- [handler/service/hook-specific items]
+- Test coverage: [list test files] — confirm happy path, error path, and bad input are covered
+- Confirm no tautological tests
+- Confirm JSON response keys are snake_case
+- Confirm empty slices serialize as [] not null
+
+Focus on the diff only. Report bugs and gaps, not style preferences.
+```
+
+## Go Code Conventions
+
+- Return `make([]T, 0)` (not `var s []T`) when a nil slice would serialize as JSON `null` — prefer `[]` at API boundaries
+- Wrap errors with `fmt.Errorf("context: %w", err)` for stack-traceable error chains
+- Use `sql.ErrNoRows` specifically for not-found; wrap in `apierrors.NewScanError(apierrors.CodeNotFound, ...)`
+- Repository pattern: all DB access via `*Repository` structs, never raw queries in handlers
+
+## Project Structure
+
+```
+internal/
+  api/handlers/   — HTTP handlers + tests
+  api/routes.go   — route registration
+  services/       — business logic
+  db/             — repository pattern, migrations
+  scanning/       — scan queue, job execution
+  profiles/       — scan profile management
+frontend/src/
+  api/hooks/      — React Query hooks
+  routes/         — page components
+  components/     — shared UI
+docs/
+  swagger/        — generated (never edit manually)
+  swagger_docs.go — source of truth for swagger annotations
+```


### PR DESCRIPTION
Adds `CLAUDE.md` at the repo root so Claude Code automatically loads the key workflow rules at the start of every session — eliminating repeated corrections about the release pipeline, fixup commit conventions, PR linking, lint requirements, and frontend test constraints.

Also updates the `review-pr` skill with expanded agent prompts: full-stack path tracing, logical correctness checks, and unexposed API surface detection. The two commits are coupled: the skill enforces the conventions that CLAUDE.md documents, so they ship together.

## What's documented (CLAUDE.md)

- **Release**: push tag → GoReleaser handles everything, never `gh release create`
- **Commits**: conventional format, subsystem scopes, no plan references, one concern per commit
- **Fixup commits**: must be squashed before pushing, never push bare `fixup!` commits
- **PR rules**: always rebase merge, always link to issue with `Closes #NNN`
- **Test plans**: live/manual verification only, automatable behaviour needs tests not checkboxes
- **Lint**: key rules (lll, mnd, nestif, goconst), fix via fixup not standalone commits
- **Frontend**: vi.mock completeness requirement for dashboard tests
- **Swagger**: run `make docs` after handler/type changes
- **Code Review**: run `review-pr` skill after every implementation

## What changed (SKILL.md)

- Full-stack path tracing: frontend → backend → service → DB → schema contract checks
- Logical correctness checks before style
- Unexposed API surface detection
- Integration tester skipped for docs-only PRs (no code = nothing to smoke test)
- Hardcoded repo slug replaced with dynamic `gh repo view` call
- Commit audit now explicitly flags bare `fixup!` commits

## Test plan

- Open a new Claude Code session in this repo and confirm `CLAUDE.md` loads in context
- Invoke `review-pr` on a feature branch and confirm the new path tracing and fixup! audit appear in agent prompts