### PR TITLE
feat(enrichment): adaptive protocol probing for unidentified ports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,21 @@
 # Scanorama — Claude Code Rules
 
+## Project State & Planning
+
+**GitHub is the source of truth for current state and upcoming work.**
+
+To determine the current version and what comes next:
+
+```bash
+git describe --tags --abbrev=0          # current released version
+gh milestone list                       # active milestones = upcoming releases
+gh issue list --state open --milestone <name>  # issues in the next milestone
+```
+
+- Local planning docs (`docs/planning/`) may be stale — always cross-check against GitHub milestones and open issues
+- The next work items come from open issues on the active milestone, not from local docs
+- When starting a new feature, check `gh issue view <NNN>` for the canonical spec
+
 ## Release
 
 **Pushing a tag is the complete release action.** GoReleaser runs automatically via `.github/workflows/release.yml`.
@@ -74,6 +90,10 @@ git rebase --autosquash origin/main
 go test -race ./internal/...   # fuller than the hook's -short run (~30s)
 git push origin my-branch      # hook runs lint + swagger + tests automatically
 ```
+
+Run tests against the **committed** state, not the working tree. Unstaged changes can mask
+failures CI will catch — ensure `git status` shows no unstaged modifications to source or
+test files before running the suite.
 
 If either test suite is red, fix before pushing — CI round-trip is 2–3 min.
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LDFLAGS     := -X 'main.version=$(VERSION)' -X 'main.commit=$(COMMIT)' -X 'main.
 
 # Go
 GO      := go
-GOTEST  := $(GO) test
+GOTEST  := $(GO) test -race
 GOBUILD := $(GO) build
 
 # Docker compose

--- a/docs/superpowers/plans/2026-04-15-adaptive-port-probing.md
+++ b/docs/superpowers/plans/2026-04-15-adaptive-port-probing.md
@@ -1,0 +1,682 @@
+# Adaptive Port Probing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When nmap finds an open port with no identified service, probe it with HTTP → HTTPS → SSH → plain TCP in sequence, stopping at first identification, and permanently mark the (host, port) pair so this extended probe never runs again.
+
+**Architecture:** A new `extended_probe_done` boolean column on `port_banners` tracks whether the extended sequence has run. `grabOne` checks this flag in its default branch. A new `probeUnknown` method runs the sequence. A per-host cap of 20 extended probes per scan cycle is enforced in `EnrichHosts` via a counter in a new `AllowExtendedProbe` field on `PortInfo`.
+
+**Tech Stack:** Go, `go-sqlmock` for DB unit tests, `httptest` + in-process SSH server for enrichment tests (existing pattern in `banner_zgrab2_test.go`).
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `internal/db/024_port_banners_extended_probe.sql` | **Create** — migration adding `extended_probe_done` column |
+| `internal/db/models.go` | **Modify** — add `ExtendedProbeDone bool` to `PortBanner` |
+| `internal/db/repository_banners.go` | **Modify** — add `IsExtendedProbeDone` and `MarkExtendedProbeDone` methods |
+| `internal/db/repository_banners_unit_test.go` | **Modify** — tests for the two new methods |
+| `internal/enrichment/banner.go` | **Modify** — add `AllowExtendedProbe` to `PortInfo`, rate-cap logic in `EnrichHosts`, `probeUnknown` method, updated `grabOne` default branch |
+| `internal/enrichment/banner_zgrab2_test.go` | **Modify** — tests for `probeUnknown` against in-process servers |
+
+---
+
+## Task 1: DB migration
+
+**Files:**
+- Create: `internal/db/024_port_banners_extended_probe.sql`
+
+- [ ] **Step 1.1: Create the migration file**
+
+```sql
+-- Migration 024: track whether extended protocol probing has been attempted
+-- for a port. Set once per (host_id, port) combination; never reset.
+
+ALTER TABLE port_banners
+    ADD COLUMN IF NOT EXISTS extended_probe_done BOOLEAN NOT NULL DEFAULT FALSE;
+```
+
+- [ ] **Step 1.2: Verify it applies cleanly against a running dev DB**
+
+```bash
+make migrate   # or however migrations are applied in this project
+```
+
+Look for any error output. If the migration tool is not `make migrate`, check `Makefile` for the correct target.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add internal/db/024_port_banners_extended_probe.sql
+git commit -m "feat(db): add extended_probe_done column to port_banners"
+```
+
+---
+
+## Task 2: Model field
+
+**Files:**
+- Modify: `internal/db/models.go` around line 734
+
+- [ ] **Step 2.1: Add the field to `PortBanner`**
+
+In `internal/db/models.go`, add `ExtendedProbeDone` as the last field of `PortBanner`:
+
+```go
+// PortBanner is a raw service banner captured from a host/port.
+type PortBanner struct {
+	ID                  uuid.UUID `db:"id"                     json:"id"`
+	HostID              uuid.UUID `db:"host_id"                json:"host_id"`
+	Port                int       `db:"port"                   json:"port"`
+	Protocol            string    `db:"protocol"               json:"protocol"`
+	RawBanner           *string   `db:"raw_banner"             json:"raw_banner,omitempty"`
+	Service             *string   `db:"service"                json:"service,omitempty"`
+	Version             *string   `db:"version"                json:"version,omitempty"`
+	HTTPTitle           *string   `db:"http_title"             json:"http_title,omitempty"`
+	SSHKeyFingerprint   *string   `db:"ssh_key_fingerprint"    json:"ssh_key_fingerprint,omitempty"`
+	HTTPStatusCode      *int16    `db:"http_status_code"       json:"http_status_code,omitempty"`
+	HTTPRedirect        *string   `db:"http_redirect"          json:"http_redirect,omitempty"`
+	HTTPResponseHeaders JSONB     `db:"http_response_headers"  json:"http_response_headers,omitempty"`
+	ScannedAt           time.Time `db:"scanned_at"             json:"scanned_at"`
+	ExtendedProbeDone   bool      `db:"extended_probe_done"    json:"-"`
+}
+```
+
+- [ ] **Step 2.2: Confirm compilation**
+
+```bash
+go build ./internal/db/...
+```
+
+Expected: no output (clean build).
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add internal/db/models.go
+git commit -m "feat(db): add ExtendedProbeDone field to PortBanner model"
+```
+
+---
+
+## Task 3: Repository methods
+
+**Files:**
+- Modify: `internal/db/repository_banners.go`
+- Modify: `internal/db/repository_banners_unit_test.go`
+
+### 3a — Write the failing tests first
+
+- [ ] **Step 3.1: Write tests for `IsExtendedProbeDone` and `MarkExtendedProbeDone`**
+
+Append to `internal/db/repository_banners_unit_test.go`:
+
+```go
+// ── IsExtendedProbeDone ────────────────────────────────────────────────────
+
+func TestBannerRepository_IsExtendedProbeDone_NoRow(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewBannerRepository(database)
+
+	hostID := uuid.New()
+	mock.ExpectQuery("SELECT extended_probe_done FROM port_banners").
+		WithArgs(hostID, 9999, ProtocolTCP).
+		WillReturnRows(sqlmock.NewRows([]string{"extended_probe_done"}))
+
+	done, err := repo.IsExtendedProbeDone(context.Background(), hostID, 9999)
+	require.NoError(t, err)
+	assert.False(t, done)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBannerRepository_IsExtendedProbeDone_FalseRow(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewBannerRepository(database)
+
+	hostID := uuid.New()
+	mock.ExpectQuery("SELECT extended_probe_done FROM port_banners").
+		WithArgs(hostID, 80, ProtocolTCP).
+		WillReturnRows(sqlmock.NewRows([]string{"extended_probe_done"}).AddRow(false))
+
+	done, err := repo.IsExtendedProbeDone(context.Background(), hostID, 80)
+	require.NoError(t, err)
+	assert.False(t, done)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBannerRepository_IsExtendedProbeDone_TrueRow(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewBannerRepository(database)
+
+	hostID := uuid.New()
+	mock.ExpectQuery("SELECT extended_probe_done FROM port_banners").
+		WithArgs(hostID, 8080, ProtocolTCP).
+		WillReturnRows(sqlmock.NewRows([]string{"extended_probe_done"}).AddRow(true))
+
+	done, err := repo.IsExtendedProbeDone(context.Background(), hostID, 8080)
+	require.NoError(t, err)
+	assert.True(t, done)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBannerRepository_IsExtendedProbeDone_DBError(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewBannerRepository(database)
+
+	hostID := uuid.New()
+	mock.ExpectQuery("SELECT extended_probe_done FROM port_banners").
+		WillReturnError(fmt.Errorf("connection lost"))
+
+	done, err := repo.IsExtendedProbeDone(context.Background(), hostID, 22)
+	require.Error(t, err)
+	assert.False(t, done)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── MarkExtendedProbeDone ─────────────────────────────────────────────────
+
+func TestBannerRepository_MarkExtendedProbeDone_OK(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewBannerRepository(database)
+
+	hostID := uuid.New()
+	mock.ExpectExec("INSERT INTO port_banners").
+		WithArgs(sqlmock.AnyArg(), hostID, 9999, ProtocolTCP, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := repo.MarkExtendedProbeDone(context.Background(), hostID, 9999)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBannerRepository_MarkExtendedProbeDone_DBError(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewBannerRepository(database)
+
+	hostID := uuid.New()
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnError(fmt.Errorf("disk full"))
+
+	err := repo.MarkExtendedProbeDone(context.Background(), hostID, 9999)
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+```
+
+- [ ] **Step 3.2: Run the tests and confirm they fail**
+
+```bash
+go test ./internal/db/... -run "TestBannerRepository_IsExtendedProbeDone|TestBannerRepository_MarkExtendedProbeDone" -v
+```
+
+Expected: FAIL — `repo.IsExtendedProbeDone undefined`, `repo.MarkExtendedProbeDone undefined`.
+
+### 3b — Implement
+
+- [ ] **Step 3.3: Add `IsExtendedProbeDone` and `MarkExtendedProbeDone` to `repository_banners.go`**
+
+Append to `internal/db/repository_banners.go` before the closing of the file:
+
+```go
+// IsExtendedProbeDone reports whether extended protocol probing has already
+// been attempted for the given host/port pair over TCP.
+// Returns false when no banner row exists yet — caller should proceed with probing.
+func (r *BannerRepository) IsExtendedProbeDone(ctx context.Context, hostID uuid.UUID, port int) (bool, error) {
+	var done bool
+	err := r.db.QueryRowContext(ctx,
+		`SELECT extended_probe_done FROM port_banners
+		 WHERE host_id = $1 AND port = $2 AND protocol = $3`,
+		hostID, port, ProtocolTCP,
+	).Scan(&done)
+	if err != nil {
+		if stderrors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, sanitizeDBError("is extended probe done", err)
+	}
+	return done, nil
+}
+
+// MarkExtendedProbeDone records that extended protocol probing has been
+// attempted for the given host/port pair. Inserts a minimal row if none
+// exists; otherwise sets extended_probe_done = true on the existing row.
+func (r *BannerRepository) MarkExtendedProbeDone(ctx context.Context, hostID uuid.UUID, port int) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO port_banners (id, host_id, port, protocol, extended_probe_done, scanned_at)
+		VALUES ($1, $2, $3, $4, true, $5)
+		ON CONFLICT (host_id, port, protocol) DO UPDATE SET
+			extended_probe_done = true`,
+		uuid.New(), hostID, port, ProtocolTCP, time.Now().UTC())
+	if err != nil {
+		return sanitizeDBError("mark extended probe done", err)
+	}
+	return nil
+}
+```
+
+Note: `stderrors` and `sql` are already imported in this file.
+
+- [ ] **Step 3.4: Run the tests and confirm they pass**
+
+```bash
+go test ./internal/db/... -run "TestBannerRepository_IsExtendedProbeDone|TestBannerRepository_MarkExtendedProbeDone" -v
+```
+
+Expected: PASS for all 6 tests.
+
+- [ ] **Step 3.5: Run the full db package tests to confirm no regressions**
+
+```bash
+go test ./internal/db/... -count=1
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add internal/db/repository_banners.go internal/db/repository_banners_unit_test.go
+git commit -m "feat(db): add IsExtendedProbeDone and MarkExtendedProbeDone to BannerRepository"
+```
+
+---
+
+## Task 4: `PortInfo` field and rate cap in `EnrichHosts`
+
+**Files:**
+- Modify: `internal/enrichment/banner.go`
+
+The `PortInfo` struct needs an `AllowExtendedProbe` field so `grabOne` knows whether the per-host cap has been reached. `EnrichHosts` sets this field before dispatching goroutines.
+
+- [ ] **Step 4.1: Add `AllowExtendedProbe` to `PortInfo` and the cap constant**
+
+In `internal/enrichment/banner.go`, update the constants block and the `PortInfo` struct:
+
+```go
+const (
+	bannerReadBytes          = 1024
+	bannerDialTimeout        = 5 * time.Second
+	bannerReadTimeout        = 3 * time.Second
+	bannerConcurrency        = 10
+	maxExtendedProbesPerHost = 20
+
+	zgrabUserAgent    = "Mozilla/5.0 zgrab/0.x"
+	zgrabMaxSizeKB    = 256
+	zgrabMaxRedirects = 3
+
+	serviceSSH = "ssh"
+)
+
+// PortInfo carries a port number and its nmap-detected service name.
+type PortInfo struct {
+	Number             int
+	Service            string // nmap-detected service name, e.g. "http", "ssh", ""
+	AllowExtendedProbe bool   // set by EnrichHosts; true when within per-host extended-probe cap
+}
+```
+
+- [ ] **Step 4.2: Add the rate-cap counter to `EnrichHosts`**
+
+Replace the existing `EnrichHosts` function body with:
+
+```go
+// EnrichHosts grabs banners for all targets concurrently.
+// Errors are logged rather than returned — enrichment is best-effort.
+// For each host, at most maxExtendedProbesPerHost ports with an unidentified
+// service are eligible for extended protocol probing.
+func (g *BannerGrabber) EnrichHosts(ctx context.Context, targets []BannerTarget) {
+	if len(targets) == 0 {
+		return
+	}
+
+	// Mark which unknown-service ports are within the per-host extended-probe cap.
+	unknownCount := make(map[uuid.UUID]int, len(targets))
+	for i := range targets {
+		for j := range targets[i].Ports {
+			if targets[i].Ports[j].Service == "" {
+				unknownCount[targets[i].HostID]++
+				if unknownCount[targets[i].HostID] <= maxExtendedProbesPerHost {
+					targets[i].Ports[j].AllowExtendedProbe = true
+				}
+			}
+		}
+	}
+
+	sem := make(chan struct{}, bannerConcurrency)
+	var wg sync.WaitGroup
+
+	for _, t := range targets {
+		for _, pi := range t.Ports {
+			wg.Add(1)
+			sem <- struct{}{}
+			go func(target BannerTarget, p PortInfo) {
+				defer wg.Done()
+				defer func() { <-sem }()
+				g.grabOne(ctx, target, p)
+			}(t, pi)
+		}
+	}
+
+	wg.Wait()
+}
+```
+
+- [ ] **Step 4.3: Confirm compilation**
+
+```bash
+go build ./internal/enrichment/...
+```
+
+Expected: no output.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add internal/enrichment/banner.go
+git commit -m "feat(enrichment): add AllowExtendedProbe field and per-host rate cap to EnrichHosts"
+```
+
+---
+
+## Task 5: `probeUnknown` and updated `grabOne`
+
+**Files:**
+- Modify: `internal/enrichment/banner.go`
+
+- [ ] **Step 5.1: Write the failing tests first**
+
+Append to `internal/enrichment/banner_zgrab2_test.go`:
+
+```go
+// ── probeUnknown ─────────────────────────────────────────────────────────────
+
+// TestProbeUnknown_HTTP_StopsAfterSuccess verifies that when an HTTP server
+// responds on the port, probeUnknown does not attempt HTTPS or SSH and sets
+// the extended_probe_done flag.
+func TestProbeUnknown_HTTP_StopsAfterSuccess(t *testing.T) {
+	addr := startHTTPServer(t)
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	var port int
+	parsePort(portStr, &port)
+
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	// HTTP grab stores banner; mark extended probe done.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	target := BannerTarget{HostID: uuid.New(), IP: host}
+	g.probeUnknown(context.Background(), target, port)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestProbeUnknown_NoServer_SetsFlag verifies that probeUnknown sets
+// extended_probe_done even when all probes fail (nothing is listening).
+func TestProbeUnknown_NoServer_SetsFlag(t *testing.T) {
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	// All probes will fail (unreachable port). grabPlain will find nothing to store,
+	// but MarkExtendedProbeDone still runs.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	target := BannerTarget{HostID: uuid.New(), IP: "127.0.0.1"}
+	g.probeUnknown(ctx, target, 19990)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+```
+
+- [ ] **Step 5.2: Run the tests and confirm they fail**
+
+```bash
+go test -tags '!race' ./internal/enrichment/... -run "TestProbeUnknown" -v
+```
+
+Expected: FAIL — `g.probeUnknown undefined`.
+
+- [ ] **Step 5.3: Implement `probeUnknown`**
+
+Add this method to `banner.go` after `grabOne`:
+
+```go
+// probeUnknown tries HTTP → HTTPS → SSH → plain TCP in sequence for a port
+// with no nmap-identified service. Stops after the first probe that succeeds
+// (returns no error). Always calls MarkExtendedProbeDone when finished so the
+// sequence never repeats for this (host, port) pair.
+func (g *BannerGrabber) probeUnknown(ctx context.Context, t BannerTarget, port int) {
+	addr := fmt.Sprintf("%s:%d", t.IP, port)
+
+	if err := g.grabZGrabHTTP(ctx, t, port); err == nil {
+		g.markProbeDone(ctx, t.HostID, port)
+		return
+	}
+	if err := g.grabZGrabHTTPS(ctx, t, port); err == nil {
+		g.markProbeDone(ctx, t.HostID, port)
+		return
+	}
+	if err := g.grabZGrabSSH(ctx, t, port, addr); err == nil {
+		g.markProbeDone(ctx, t.HostID, port)
+		return
+	}
+	g.grabPlain(ctx, t, port, addr)
+	g.markProbeDone(ctx, t.HostID, port)
+}
+
+// markProbeDone calls MarkExtendedProbeDone and logs a warning on failure.
+// Probe results are already stored; this is best-effort bookkeeping.
+func (g *BannerGrabber) markProbeDone(ctx context.Context, hostID uuid.UUID, port int) {
+	if err := g.repo.MarkExtendedProbeDone(ctx, hostID, port); err != nil {
+		g.logger.Warn("failed to mark extended probe done",
+			"host_id", hostID, "port", port, "error", err)
+	}
+}
+```
+
+- [ ] **Step 5.4: Update the `grabOne` default branch**
+
+Replace the `default:` case in `grabOne`:
+
+```go
+default:
+	if pi.Service == "" && pi.AllowExtendedProbe {
+		done, _ := g.repo.IsExtendedProbeDone(ctx, t.HostID, pi.Number)
+		if !done {
+			g.probeUnknown(ctx, t, pi.Number)
+			return
+		}
+	}
+	g.grabPlain(ctx, t, pi.Number, addr)
+```
+
+`BannerRepository.IsExtendedProbeDone` and `MarkExtendedProbeDone` are methods on
+`*db.BannerRepository`. The `repo` field on `BannerGrabber` is already typed as
+`*db.BannerRepository`, so no interface changes are needed.
+
+- [ ] **Step 5.5: Run `probeUnknown` tests**
+
+```bash
+go test -tags '!race' ./internal/enrichment/... -run "TestProbeUnknown" -v
+```
+
+Expected: PASS for both tests.
+
+- [ ] **Step 5.6: Run the full enrichment test suite**
+
+```bash
+go test -tags '!race' ./internal/enrichment/... -count=1
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5.7: Commit**
+
+```bash
+git add internal/enrichment/banner.go internal/enrichment/banner_zgrab2_test.go
+git commit -m "feat(enrichment): add probeUnknown — adaptive protocol detection for unidentified ports"
+```
+
+---
+
+## Task 6: `grabOne` routing tests
+
+**Files:**
+- Modify: `internal/enrichment/banner_zgrab2_test.go`
+
+These tests verify that `grabOne` correctly routes through `probeUnknown` when the service is unknown and `AllowExtendedProbe` is true, and skips it when the flag is false or the probe has already been done.
+
+- [ ] **Step 6.1: Write the failing tests**
+
+Append to `internal/enrichment/banner_zgrab2_test.go`:
+
+```go
+// ── grabOne routing ───────────────────────────────────────────────────────────
+
+// TestGrabOne_UnknownService_AllowedAndNotDone verifies that grabOne runs
+// probeUnknown (extended sequence) when service is empty, AllowExtendedProbe
+// is true, and the DB reports extended_probe_done = false.
+func TestGrabOne_UnknownService_AllowedAndNotDone(t *testing.T) {
+	addr := startHTTPServer(t)
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	var port int
+	parsePort(portStr, &port)
+
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	// IsExtendedProbeDone returns false → probeUnknown runs.
+	mock.ExpectQuery("SELECT extended_probe_done FROM port_banners").
+		WillReturnRows(sqlmock.NewRows([]string{"extended_probe_done"})) // no row = false
+	// HTTP grab succeeds → one banner INSERT.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// MarkExtendedProbeDone → one more INSERT.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	pi := PortInfo{Number: port, Service: "", AllowExtendedProbe: true}
+	g.grabOne(context.Background(), BannerTarget{HostID: uuid.New(), IP: host}, pi)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestGrabOne_UnknownService_AlreadyDone verifies that grabOne falls back to
+// plain TCP when extended_probe_done is already true, without calling probeUnknown.
+func TestGrabOne_UnknownService_AlreadyDone(t *testing.T) {
+	banner := "CUSTOM PROTO 1.0\r\n"
+	addr := startTCPServer(t, banner)
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	var port int
+	parsePort(portStr, &port)
+
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	// IsExtendedProbeDone returns true → skip probeUnknown, go to grabPlain.
+	mock.ExpectQuery("SELECT extended_probe_done FROM port_banners").
+		WillReturnRows(sqlmock.NewRows([]string{"extended_probe_done"}).AddRow(true))
+	// grabPlain stores the banner.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	pi := PortInfo{Number: port, Service: "", AllowExtendedProbe: true}
+	g.grabOne(context.Background(), BannerTarget{HostID: uuid.New(), IP: host}, pi)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestGrabOne_UnknownService_CapExceeded verifies that when AllowExtendedProbe
+// is false (cap exceeded), grabOne goes directly to grabPlain without checking
+// the DB or running probeUnknown.
+func TestGrabOne_UnknownService_CapExceeded(t *testing.T) {
+	banner := "CUSTOM PROTO 1.0\r\n"
+	addr := startTCPServer(t, banner)
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	var port int
+	parsePort(portStr, &port)
+
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	// No DB query expected — cap is exceeded, probeUnknown is skipped entirely.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	pi := PortInfo{Number: port, Service: "", AllowExtendedProbe: false}
+	g.grabOne(context.Background(), BannerTarget{HostID: uuid.New(), IP: host}, pi)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+```
+
+- [ ] **Step 6.2: Run the tests**
+
+```bash
+go test -tags '!race' ./internal/enrichment/... -run "TestGrabOne_UnknownService" -v
+```
+
+Expected: PASS for all three tests.
+
+- [ ] **Step 6.3: Run the full suite one more time**
+
+```bash
+go test -tags '!race' ./internal/enrichment/... -count=1
+go test ./internal/db/... -count=1
+```
+
+Expected: all tests pass in both packages.
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add internal/enrichment/banner_zgrab2_test.go
+git commit -m "test(enrichment): add grabOne routing tests for extended probe logic"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 7.1: Run the fuller backend test suite**
+
+```bash
+go test -race ./internal/... -short
+```
+
+Expected: all tests pass (zgrab2 tests are excluded by the `!race` build tag and will not run here — that's expected).
+
+- [ ] **Step 7.2: Run lint**
+
+```bash
+make lint
+```
+
+Expected: 0 issues. If any `lll` (line-length) violations appear, break the offending lines at a logical point — function argument lists and SQL strings are the most likely culprits.
+
+- [ ] **Step 7.3: Verify swagger is not affected**
+
+```bash
+make docs
+git diff --exit-code docs/swagger/ frontend/src/api/types.ts
+```
+
+Expected: no diff — this feature adds no new API endpoints or response types.

--- a/docs/superpowers/specs/2026-04-15-adaptive-port-probing-design.md
+++ b/docs/superpowers/specs/2026-04-15-adaptive-port-probing-design.md
@@ -1,0 +1,155 @@
+# Adaptive Port Probing — Design Spec
+
+**Issue:** #671 (scoped)
+**Date:** 2026-04-15
+**Status:** Approved
+
+---
+
+## Problem
+
+When nmap finds an open port but cannot identify the service running on it, the
+banner grabber falls back to a plain TCP read. Many services wait for the client
+to speak first (HTTP, HTTPS, SSH), so a raw TCP read returns nothing useful.
+These ports stay permanently unidentified even though zgrab2 could name them
+with a targeted probe.
+
+## Scope
+
+This spec covers the smarter probing step only. The `port_observations`
+aggregate table, UI badges, and Smart Scan profile integration are out of scope
+and will be addressed separately once the probing foundation is in place.
+
+---
+
+## Design
+
+### Overview
+
+When `grabOne` reaches an open port with no nmap-detected service name, it
+checks whether extended probing has already been attempted for that
+(host, port) pair. If not, it runs a fixed probe sequence — HTTP → HTTPS →
+SSH → plain TCP — stopping at the first successful identification, then
+permanently marks the pair as probed. On subsequent scans the extended sequence
+is skipped, preventing redundant network traffic to ports that already have a
+definitive result (or a confirmed non-identification).
+
+### DB migration
+
+New file: `internal/db/024_port_banners_extended_probe.sql`
+
+```sql
+ALTER TABLE port_banners
+    ADD COLUMN IF NOT EXISTS extended_probe_done BOOLEAN NOT NULL DEFAULT FALSE;
+```
+
+The column defaults to `FALSE` so existing rows are unaffected — they will be
+eligible for extended probing on the next scan cycle.
+
+### Repository
+
+`BannerRepository` (`internal/db/repository_banners.go`) gains one method:
+
+```go
+// IsExtendedProbeDone reports whether extended probing has already been
+// attempted for the given host/port pair. Returns false if no banner row
+// exists yet.
+func (r *BannerRepository) IsExtendedProbeDone(
+    ctx context.Context, hostID uuid.UUID, port int,
+) (bool, error)
+```
+
+`UpsertPortBanner` is updated to include `extended_probe_done` in the
+`ON CONFLICT DO UPDATE` clause so callers can set it alongside other fields.
+
+`PortBanner` model gains the corresponding field:
+
+```go
+ExtendedProbeDone bool `db:"extended_probe_done" json:"-"`
+```
+
+### Enrichment logic
+
+In `internal/enrichment/banner.go`, the `default` branch of `grabOne` becomes:
+
+```go
+default:
+    if pi.Service == "" {
+        done, _ := g.repo.IsExtendedProbeDone(ctx, t.HostID, pi.Number)
+        if !done {
+            g.probeUnknown(ctx, t, pi)
+            return
+        }
+    }
+    g.grabPlain(ctx, t, pi.Number, addr)
+```
+
+`probeUnknown` runs the probe sequence:
+
+1. Try `grabZGrabHTTP` — if it stores a banner with a non-empty service, done.
+2. Try `grabZGrabHTTPS` — same check.
+3. Try `grabZGrabSSH` — same check.
+4. Fall back to `grabPlain`.
+
+After the sequence completes (regardless of outcome), upsert a `port_banners`
+row with `extended_probe_done = true`. This ensures the flag is set even when
+no service is identified, preventing repeated probing on future scans.
+
+`probeUnknown` runs within the existing `bannerConcurrency` semaphore — no
+additional concurrency controls are needed.
+
+### Rate limiting
+
+The issue specifies a cap of 20 extended probes per host per scan cycle. This
+is enforced by counting the number of `probeUnknown` calls per host within
+`EnrichHosts` before dispatching goroutines. Ports beyond the cap proceed
+directly to `grabPlain` and are not flagged (`extended_probe_done` remains
+`false`), making them eligible for extended probing in a future cycle.
+
+---
+
+## Error handling
+
+- `IsExtendedProbeDone` errors are treated as `false` (probe proceeds). A DB
+  error should not suppress enrichment.
+- Individual probe attempts within `probeUnknown` follow the existing pattern:
+  log and continue to the next probe in the sequence.
+- If setting `extended_probe_done = true` fails, log a warning. The probe
+  results are still stored.
+
+---
+
+## Testing
+
+### `BannerRepository`
+- `IsExtendedProbeDone`: returns `false` when no row exists; returns the stored
+  value when a row exists. Uses `go-sqlmock`.
+- `UpsertPortBanner` with `ExtendedProbeDone = true`: verify the column is
+  written and survives a conflict update.
+
+### `grabOne` (unit, mock repo)
+- When `pi.Service == ""` and `IsExtendedProbeDone` returns `false`:
+  `probeUnknown` is called, `grabPlain` is not.
+- When `pi.Service == ""` and `IsExtendedProbeDone` returns `true`:
+  `probeUnknown` is not called, `grabPlain` is called.
+- When `pi.Service != ""` (identified by nmap): existing dispatch path,
+  unchanged.
+
+### `probeUnknown` (unit, mock repo)
+- Stops after the first probe that identifies a service (does not attempt
+  subsequent probes).
+- Always upserts with `extended_probe_done = true`, even when no service is
+  identified.
+- Respects the 20-probe-per-host cap: ports beyond the cap skip `probeUnknown`.
+
+---
+
+## Out of scope
+
+- `port_observations` aggregate table
+- "Exploring..." badge in host detail UI
+- "Local" tab in port browser
+- Smart Scan profile suggestion integration
+
+These will be addressed in a follow-up once the probing foundation has shipped
+and its value is validated.

--- a/internal/db/024_port_banners_extended_probe.sql
+++ b/internal/db/024_port_banners_extended_probe.sql
@@ -1,0 +1,5 @@
+-- Migration 024: track whether extended protocol probing has been attempted
+-- for a port. Set once per (host_id, port) combination; never reset.
+
+ALTER TABLE port_banners
+    ADD COLUMN IF NOT EXISTS extended_probe_done BOOLEAN NOT NULL DEFAULT FALSE;

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -745,6 +745,7 @@ type PortBanner struct {
 	HTTPRedirect        *string   `db:"http_redirect"          json:"http_redirect,omitempty"`
 	HTTPResponseHeaders JSONB     `db:"http_response_headers"  json:"http_response_headers,omitempty"`
 	ScannedAt           time.Time `db:"scanned_at"             json:"scanned_at"`
+	ExtendedProbeDone   bool      `db:"extended_probe_done"    json:"-"`
 }
 
 // SNMPInterface describes a single network interface collected via SNMP.

--- a/internal/db/repository_banners.go
+++ b/internal/db/repository_banners.go
@@ -4,6 +4,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	stderrors "errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -328,4 +329,39 @@ func (r *BannerRepository) ListExpiringCertificatesWithHosts(
 		result = []ExpiringCertificate{}
 	}
 	return result, nil
+}
+
+// IsExtendedProbeDone reports whether extended protocol probing has already
+// been attempted for the given host/port pair over TCP.
+// Returns false when no banner row exists yet — caller should proceed with probing.
+func (r *BannerRepository) IsExtendedProbeDone(ctx context.Context, hostID uuid.UUID, port int) (bool, error) {
+	var done bool
+	err := r.db.QueryRowContext(ctx,
+		`SELECT extended_probe_done FROM port_banners
+		 WHERE host_id = $1 AND port = $2 AND protocol = $3`,
+		hostID, port, ProtocolTCP,
+	).Scan(&done)
+	if err != nil {
+		if stderrors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, sanitizeDBError("is extended probe done", err)
+	}
+	return done, nil
+}
+
+// MarkExtendedProbeDone records that extended protocol probing has been
+// attempted for the given host/port pair. Inserts a minimal row if none
+// exists; otherwise sets extended_probe_done = true on the existing row.
+func (r *BannerRepository) MarkExtendedProbeDone(ctx context.Context, hostID uuid.UUID, port int) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO port_banners (id, host_id, port, protocol, extended_probe_done, scanned_at)
+		VALUES ($1, $2, $3, $4, true, $5)
+		ON CONFLICT (host_id, port, protocol) DO UPDATE SET
+			extended_probe_done = true`,
+		uuid.New(), hostID, port, ProtocolTCP, time.Now().UTC())
+	if err != nil {
+		return sanitizeDBError("mark extended probe done", err)
+	}
+	return nil
 }

--- a/internal/db/repository_banners_unit_test.go
+++ b/internal/db/repository_banners_unit_test.go
@@ -623,3 +623,93 @@ func TestBannerRepository_UpsertSSHPortData_DBError(t *testing.T) {
 	require.Error(t, err)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+// ── IsExtendedProbeDone ────────────────────────────────────────────────────
+
+func TestBannerRepository_IsExtendedProbeDone_NoRow(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewBannerRepository(database)
+
+	hostID := uuid.New()
+	mock.ExpectQuery("SELECT extended_probe_done FROM port_banners").
+		WithArgs(hostID, 9999, ProtocolTCP).
+		WillReturnRows(sqlmock.NewRows([]string{"extended_probe_done"}))
+
+	done, err := repo.IsExtendedProbeDone(context.Background(), hostID, 9999)
+	require.NoError(t, err)
+	assert.False(t, done)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBannerRepository_IsExtendedProbeDone_FalseRow(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewBannerRepository(database)
+
+	hostID := uuid.New()
+	mock.ExpectQuery("SELECT extended_probe_done FROM port_banners").
+		WithArgs(hostID, 80, ProtocolTCP).
+		WillReturnRows(sqlmock.NewRows([]string{"extended_probe_done"}).AddRow(false))
+
+	done, err := repo.IsExtendedProbeDone(context.Background(), hostID, 80)
+	require.NoError(t, err)
+	assert.False(t, done)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBannerRepository_IsExtendedProbeDone_TrueRow(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewBannerRepository(database)
+
+	hostID := uuid.New()
+	mock.ExpectQuery("SELECT extended_probe_done FROM port_banners").
+		WithArgs(hostID, 8080, ProtocolTCP).
+		WillReturnRows(sqlmock.NewRows([]string{"extended_probe_done"}).AddRow(true))
+
+	done, err := repo.IsExtendedProbeDone(context.Background(), hostID, 8080)
+	require.NoError(t, err)
+	assert.True(t, done)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBannerRepository_IsExtendedProbeDone_DBError(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewBannerRepository(database)
+
+	hostID := uuid.New()
+	mock.ExpectQuery("SELECT extended_probe_done FROM port_banners").
+		WillReturnError(fmt.Errorf("connection lost"))
+
+	done, err := repo.IsExtendedProbeDone(context.Background(), hostID, 22)
+	require.Error(t, err)
+	assert.False(t, done)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── MarkExtendedProbeDone ─────────────────────────────────────────────────
+
+func TestBannerRepository_MarkExtendedProbeDone_OK(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewBannerRepository(database)
+
+	hostID := uuid.New()
+	mock.ExpectExec("INSERT INTO port_banners").
+		WithArgs(sqlmock.AnyArg(), hostID, 9999, ProtocolTCP, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := repo.MarkExtendedProbeDone(context.Background(), hostID, 9999)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBannerRepository_MarkExtendedProbeDone_DBError(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewBannerRepository(database)
+
+	hostID := uuid.New()
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnError(fmt.Errorf("disk full"))
+
+	err := repo.MarkExtendedProbeDone(context.Background(), hostID, 9999)
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/enrichment/banner.go
+++ b/internal/enrichment/banner.go
@@ -27,10 +27,11 @@ import (
 )
 
 const (
-	bannerReadBytes   = 1024
-	bannerDialTimeout = 5 * time.Second
-	bannerReadTimeout = 3 * time.Second
-	bannerConcurrency = 10
+	bannerReadBytes          = 1024
+	bannerDialTimeout        = 5 * time.Second
+	bannerReadTimeout        = 3 * time.Second
+	bannerConcurrency        = 10
+	maxExtendedProbesPerHost = 20
 
 	zgrabUserAgent    = "Mozilla/5.0 zgrab/0.x"
 	zgrabMaxSizeKB    = 256
@@ -62,8 +63,9 @@ var interestingHTTPHeaders = []string{
 
 // PortInfo carries a port number and its nmap-detected service name.
 type PortInfo struct {
-	Number  int
-	Service string // nmap-detected service name, e.g. "http", "ssh", "ftp"
+	Number             int
+	Service            string // nmap-detected service name, e.g. "http", "ssh", ""
+	AllowExtendedProbe bool   // set by EnrichHosts; true when within per-host extended-probe cap
 }
 
 // BannerTarget describes a host and its open TCP ports to probe.
@@ -93,9 +95,24 @@ func NewBannerGrabber(repo *db.BannerRepository, logger *slog.Logger, extraFinge
 
 // EnrichHosts grabs banners for all targets concurrently.
 // Errors are logged rather than returned — enrichment is best-effort.
+// For each host, at most maxExtendedProbesPerHost ports with an unidentified
+// service are eligible for extended protocol probing.
 func (g *BannerGrabber) EnrichHosts(ctx context.Context, targets []BannerTarget) {
 	if len(targets) == 0 {
 		return
+	}
+
+	// Mark which unknown-service ports are within the per-host extended-probe cap.
+	unknownCount := make(map[uuid.UUID]int, len(targets))
+	for i := range targets {
+		for j := range targets[i].Ports {
+			if targets[i].Ports[j].Service == "" {
+				unknownCount[targets[i].HostID]++
+				if unknownCount[targets[i].HostID] <= maxExtendedProbesPerHost {
+					targets[i].Ports[j].AllowExtendedProbe = true
+				}
+			}
+		}
 	}
 
 	sem := make(chan struct{}, bannerConcurrency)
@@ -147,7 +164,50 @@ func (g *BannerGrabber) grabOne(ctx context.Context, t BannerTarget, pi PortInfo
 		}
 
 	default:
+		if pi.Service == "" && pi.AllowExtendedProbe {
+			done, err := g.repo.IsExtendedProbeDone(ctx, t.HostID, pi.Number)
+			if err != nil {
+				g.logger.Warn("failed to check extended probe status, proceeding with probe",
+					"host_id", t.HostID, "port", pi.Number, "error", err)
+			}
+			if !done {
+				g.probeUnknown(ctx, t, pi.Number)
+				return
+			}
+		}
 		g.grabPlain(ctx, t, pi.Number, addr)
+	}
+}
+
+// probeUnknown tries HTTP → HTTPS → SSH → plain TCP in sequence for a port
+// with no nmap-identified service. Stops after the first probe that succeeds
+// (returns no error). Always calls MarkExtendedProbeDone when finished so the
+// sequence never repeats for this (host, port) pair.
+func (g *BannerGrabber) probeUnknown(ctx context.Context, t BannerTarget, port int) {
+	addr := fmt.Sprintf("%s:%d", t.IP, port)
+
+	if err := g.grabZGrabHTTP(ctx, t, port); err == nil {
+		g.markProbeDone(ctx, t.HostID, port)
+		return
+	}
+	if err := g.grabZGrabHTTPS(ctx, t, port); err == nil {
+		g.markProbeDone(ctx, t.HostID, port)
+		return
+	}
+	if err := g.grabZGrabSSH(ctx, t, port, addr); err == nil {
+		g.markProbeDone(ctx, t.HostID, port)
+		return
+	}
+	g.grabPlain(ctx, t, port, addr)
+	g.markProbeDone(ctx, t.HostID, port)
+}
+
+// markProbeDone calls MarkExtendedProbeDone and logs a warning on failure.
+// Probe results are already stored; this is best-effort bookkeeping.
+func (g *BannerGrabber) markProbeDone(ctx context.Context, hostID uuid.UUID, port int) {
+	if err := g.repo.MarkExtendedProbeDone(ctx, hostID, port); err != nil {
+		g.logger.Warn("failed to mark extended probe done",
+			"host_id", hostID, "port", port, "error", err)
 	}
 }
 

--- a/internal/enrichment/banner.go
+++ b/internal/enrichment/banner.go
@@ -493,8 +493,12 @@ func (g *BannerGrabber) grabZGrabSSH(ctx context.Context, t BannerTarget, port i
 	}
 	// err may be non-nil when DontAuthenticate causes the server to close the
 	// connection after the key exchange — we still got the data we need.
-	if err != nil && capturedFingerprint == "" && connLog.ServerID == nil {
-		return fmt.Errorf("ssh handshake: %w", err)
+	// If neither fingerprint nor serverID were captured, the host is not SSH.
+	if capturedFingerprint == "" && connLog.ServerID == nil {
+		if err != nil {
+			return fmt.Errorf("ssh handshake: %w", err)
+		}
+		return fmt.Errorf("ssh: connected but no SSH evidence captured")
 	}
 
 	var serverVersion string

--- a/internal/enrichment/banner_network_test.go
+++ b/internal/enrichment/banner_network_test.go
@@ -1,5 +1,10 @@
+//go:build !race
+
 // Package enrichment — network-level tests for banner grabbing using
-// in-process test TCP/TLS servers.
+// in-process test TCP/TLS servers. These tests exercise zgrab2-based grabbers
+// (grabZGrabHTTP, grabZGrabHTTPS, grabZGrabSSH) which internally have a known
+// data race in TimeoutConnection.SaturateTimeoutsToReadAndWriteTimeouts that is
+// upstream and not fixable here.
 package enrichment
 
 import (

--- a/internal/enrichment/banner_zgrab2_test.go
+++ b/internal/enrichment/banner_zgrab2_test.go
@@ -209,3 +209,52 @@ func TestGrabZGrabSSH_UnreachableHost(t *testing.T) {
 	require.Error(t, err)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+// ── probeUnknown ─────────────────────────────────────────────────────────────
+
+// TestProbeUnknown_HTTP_StopsAfterSuccess verifies that when an HTTP server
+// responds on the port, probeUnknown does not attempt HTTPS or SSH and sets
+// the extended_probe_done flag.
+func TestProbeUnknown_HTTP_StopsAfterSuccess(t *testing.T) {
+	addr := startHTTPServer(t)
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	var port int
+	parsePort(portStr, &port)
+
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	// HTTP grab stores banner.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// MarkExtendedProbeDone.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	target := BannerTarget{HostID: uuid.New(), IP: host}
+	g.probeUnknown(context.Background(), target, port)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestProbeUnknown_NoServer_SetsFlag verifies that probeUnknown sets
+// extended_probe_done even when all probes fail (nothing is listening).
+func TestProbeUnknown_NoServer_SetsFlag(t *testing.T) {
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	// All probes fail; grabPlain finds nothing to store, but MarkExtendedProbeDone runs.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	target := BannerTarget{HostID: uuid.New(), IP: "127.0.0.1"}
+	g.probeUnknown(ctx, target, 19990)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/enrichment/banner_zgrab2_test.go
+++ b/internal/enrichment/banner_zgrab2_test.go
@@ -12,10 +12,15 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -97,6 +102,132 @@ func startSSHServer(t *testing.T) string {
 
 	return ln.Addr().String()
 }
+
+// startTLSSniffingHTTPServer starts a TCP server that peeks at the first byte of
+// each incoming connection. If the byte is 0x16 (TLS ClientHello record type),
+// it wraps the connection in TLS and serves HTTP; otherwise it drops the
+// connection immediately. This lets grabZGrabHTTP fail (connection reset) while
+// grabZGrabHTTPS succeeds, enabling probeUnknown HTTPS-branch tests.
+func startTLSSniffingHTTPServer(t *testing.T) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test.local"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	require.NoError(t, err)
+
+	tlsCfg := &tls.Config{Certificates: []tls.Certificate{tlsCert}, MinVersion: tls.VersionTLS12}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Server", "TestHTTPSOnly/1.0")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 1)
+				_ = c.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+				n, err := c.Read(buf)
+				_ = c.SetReadDeadline(time.Time{})
+				if err != nil || n == 0 {
+					return // plain HTTP or timeout: drop connection
+				}
+				if buf[0] != 0x16 {
+					return // not a TLS ClientHello: drop connection
+				}
+				// Reconnect as TLS, prepending the peeked byte.
+				tlsConn := tls.Server(&prependByteConn{Conn: c, b: buf[0]}, tlsCfg)
+				if err := tlsConn.Handshake(); err != nil {
+					return
+				}
+				srv := &http.Server{Handler: mux}
+				_ = srv.Serve(newOneConnListener(tlsConn))
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String()
+}
+
+// prependByteConn is a net.Conn that re-emits one peeked byte before delegating
+// further reads to the underlying connection.
+type prependByteConn struct {
+	net.Conn
+	b    byte
+	sent bool
+}
+
+func (p *prependByteConn) Read(b []byte) (int, error) {
+	if !p.sent {
+		p.sent = true
+		b[0] = p.b
+		return 1, nil
+	}
+	return p.Conn.Read(b)
+}
+
+// oneConnListener is a net.Listener that yields exactly one connection and
+// then blocks until Close() is called. This keeps http.Server.Serve alive
+// while the handler goroutine writes its response, without leaking permanently:
+// Close() unblocks Accept() so Serve can return.
+type oneConnListener struct {
+	conn net.Conn
+	addr net.Addr
+	done chan struct{}
+	once sync.Once
+}
+
+func newOneConnListener(conn net.Conn) *oneConnListener {
+	return &oneConnListener{
+		conn: conn,
+		addr: conn.LocalAddr(),
+		done: make(chan struct{}),
+	}
+}
+
+func (o *oneConnListener) Accept() (net.Conn, error) {
+	var c net.Conn
+	o.once.Do(func() { c = o.conn })
+	if c != nil {
+		return c, nil
+	}
+	<-o.done
+	return nil, net.ErrClosed
+}
+
+func (o *oneConnListener) Close() error {
+	select {
+	case <-o.done:
+	default:
+		close(o.done)
+	}
+	return nil
+}
+
+func (o *oneConnListener) Addr() net.Addr { return o.addr }
 
 // ── grabZGrabHTTP ─────────────────────────────────────────────────────────────
 
@@ -239,6 +370,67 @@ func TestProbeUnknown_HTTP_StopsAfterSuccess(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestProbeUnknown_HTTPS_StopsAfterSuccess verifies that when a TLS-only HTTPS
+// server responds on the port, probeUnknown stops after HTTPS succeeds and does
+// not attempt SSH. It uses startTLSSniffingHTTPServer, which drops plain-HTTP
+// connections so that grabZGrabHTTP returns an error, while grabZGrabHTTPS
+// succeeds after a full TLS handshake.
+func TestProbeUnknown_HTTPS_StopsAfterSuccess(t *testing.T) {
+	addr := startTLSSniffingHTTPServer(t)
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	var port int
+	parsePort(portStr, &port)
+
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	// HTTP probe fails (connection reset by sniffing server) → no INSERT.
+	// HTTPS probe succeeds: certificate INSERT + banner INSERT.
+	mock.ExpectExec("INSERT INTO certificates").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// MarkExtendedProbeDone.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	target := BannerTarget{HostID: uuid.New(), IP: host}
+	g.probeUnknown(context.Background(), target, port)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestProbeUnknown_SSH_StopsAfterSuccess verifies that when an SSH server
+// responds on the port, probeUnknown stops after SSH succeeds (HTTP and HTTPS
+// fail first) and does not fall back to plain TCP.
+func TestProbeUnknown_SSH_StopsAfterSuccess(t *testing.T) {
+	addr := startSSHServer(t)
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	var port int
+	parsePort(portStr, &port)
+
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	// HTTP probe fails (SSH server drops non-HTTP traffic) → no INSERT.
+	// HTTPS probe fails (no TLS on an SSH port) → no INSERT.
+	// SSH probe succeeds → banner INSERT.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// MarkExtendedProbeDone → flag INSERT.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	target := BannerTarget{HostID: uuid.New(), IP: host}
+	g.probeUnknown(context.Background(), target, port)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 // TestProbeUnknown_NoServer_SetsFlag verifies that probeUnknown sets
 // extended_probe_done even when all probes fail (nothing is listening).
 func TestProbeUnknown_NoServer_SetsFlag(t *testing.T) {
@@ -253,8 +445,18 @@ func TestProbeUnknown_NoServer_SetsFlag(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
+	// Get a free port then immediately close — ensures no server is listening.
+	ln, lnErr := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, lnErr)
+	freeAddr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	_, portStr, splitErr := net.SplitHostPort(freeAddr)
+	require.NoError(t, splitErr)
+	var port int
+	parsePort(portStr, &port)
+
 	target := BannerTarget{HostID: uuid.New(), IP: "127.0.0.1"}
-	g.probeUnknown(ctx, target, 19990)
+	g.probeUnknown(ctx, target, port)
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/enrichment/banner_zgrab2_test.go
+++ b/internal/enrichment/banner_zgrab2_test.go
@@ -258,3 +258,87 @@ func TestProbeUnknown_NoServer_SetsFlag(t *testing.T) {
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+// ── grabOne routing ───────────────────────────────────────────────────────────
+
+// TestGrabOne_UnknownService_AllowedAndNotDone verifies that grabOne runs
+// probeUnknown (extended sequence) when service is empty, AllowExtendedProbe
+// is true, and the DB reports extended_probe_done = false.
+func TestGrabOne_UnknownService_AllowedAndNotDone(t *testing.T) {
+	addr := startHTTPServer(t)
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	var port int
+	parsePort(portStr, &port)
+
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	// IsExtendedProbeDone returns false (no row) → probeUnknown runs.
+	mock.ExpectQuery("SELECT extended_probe_done FROM port_banners").
+		WillReturnRows(sqlmock.NewRows([]string{"extended_probe_done"}))
+	// HTTP grab succeeds → banner INSERT.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// MarkExtendedProbeDone → flag INSERT.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	pi := PortInfo{Number: port, Service: "", AllowExtendedProbe: true}
+	g.grabOne(context.Background(), BannerTarget{HostID: uuid.New(), IP: host}, pi)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestGrabOne_UnknownService_AlreadyDone verifies that grabOne falls back to
+// plain TCP when extended_probe_done is already true, without calling probeUnknown.
+func TestGrabOne_UnknownService_AlreadyDone(t *testing.T) {
+	banner := "CUSTOM PROTO 1.0\r\n"
+	addr := startTCPServer(t, banner)
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	var port int
+	parsePort(portStr, &port)
+
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	// IsExtendedProbeDone returns true → skip probeUnknown, go to grabPlain.
+	mock.ExpectQuery("SELECT extended_probe_done FROM port_banners").
+		WillReturnRows(sqlmock.NewRows([]string{"extended_probe_done"}).AddRow(true))
+	// grabPlain stores the banner.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	pi := PortInfo{Number: port, Service: "", AllowExtendedProbe: true}
+	g.grabOne(context.Background(), BannerTarget{HostID: uuid.New(), IP: host}, pi)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestGrabOne_UnknownService_CapExceeded verifies that when AllowExtendedProbe
+// is false (cap exceeded), grabOne goes directly to grabPlain without checking
+// the DB or running probeUnknown.
+func TestGrabOne_UnknownService_CapExceeded(t *testing.T) {
+	banner := "CUSTOM PROTO 1.0\r\n"
+	addr := startTCPServer(t, banner)
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	var port int
+	parsePort(portStr, &port)
+
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	// No DB query expected — cap exceeded, probeUnknown skipped entirely.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	pi := PortInfo{Number: port, Service: "", AllowExtendedProbe: false}
+	g.grabOne(context.Background(), BannerTarget{HostID: uuid.New(), IP: host}, pi)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
## Summary

- Adds adaptive protocol probing for open ports where nmap could not identify the service
- Instead of immediately falling back to a plain TCP read, the banner grabber now tries HTTP → HTTPS → SSH → plain TCP in sequence, stopping at first identification
- A new `extended_probe_done` boolean column on `port_banners` ensures the extended sequence runs at most once per (host, port) pair, preventing redundant probing on subsequent scans
- A per-host cap of 20 unknown-service ports per scan cycle bounds the extra network load

## Changes

**DB**
- Migration `024`: `ALTER TABLE port_banners ADD COLUMN extended_probe_done BOOLEAN NOT NULL DEFAULT FALSE`
- `BannerRepository.IsExtendedProbeDone` — returns false when no row exists (never an error)
- `BannerRepository.MarkExtendedProbeDone` — sets flag to true via upsert; never overwrites existing `service`/`version`/`raw_banner`

**Enrichment**
- `PortInfo.AllowExtendedProbe` — set by `EnrichHosts` before dispatch; true for the first 20 unknown-service ports per host
- `probeUnknown` — HTTP → HTTPS → SSH → plain TCP; stops on first nil-error return; always calls `MarkExtendedProbeDone`
- Fixed `grabZGrabSSH` to return an error when TCP connects but no SSH evidence is captured (prevents false-positive stop in the probe sequence)
- `grabOne` default branch updated to route through `probeUnknown` when eligible

## Test plan

- Deploy to a network with devices that have open ports nmap couldn't fingerprint
- Confirm banners are now identified after first scan, and `extended_probe_done` is set
- Confirm second scan does not re-probe those ports (no extra network traffic to them)

Closes #671