### PR TITLE
feat(cli): close high-priority API/CLI feature parity gaps

### DIFF
--- a/cmd/cli/api_client.go
+++ b/cmd/cli/api_client.go
@@ -146,6 +146,12 @@ func (c *APIClient) Delete(endpoint string) (*APIResponse, error) {
 	return c.request("DELETE", endpoint, nil)
 }
 
+// DeleteWithBody performs a DELETE request with a JSON payload.
+// Some APIs require a request body on DELETE (e.g. bulk-remove operations).
+func (c *APIClient) DeleteWithBody(endpoint string, payload interface{}) (*APIResponse, error) {
+	return c.request("DELETE", endpoint, payload)
+}
+
 // request performs the actual HTTP request with authentication
 func (c *APIClient) request(method, endpoint string, payload interface{}) (*APIResponse, error) {
 	reqURL := c.baseURL + endpoint
@@ -198,13 +204,7 @@ func (c *APIClient) request(method, endpoint string, payload interface{}) (*APIR
 	}
 
 	// Parse JSON response
-	var apiResp APIResponse
-	if len(bodyBytes) > 0 {
-		if err := json.Unmarshal(bodyBytes, &apiResp); err != nil {
-			// If JSON parsing fails, treat as plain text error
-			apiResp.Error = string(bodyBytes)
-		}
-	}
+	apiResp := parseAPIResponse(bodyBytes)
 
 	// Handle HTTP error status codes
 	if resp.StatusCode >= StatusBadRequest {
@@ -225,6 +225,25 @@ func (c *APIClient) request(method, endpoint string, payload interface{}) (*APIR
 	}
 
 	return &apiResp, nil
+}
+
+// parseAPIResponse decodes raw response bytes into an APIResponse.
+// When the server doesn't use a {"data": ...} envelope (Data==nil after decode),
+// the entire body is stored as json.RawMessage so callers can unmarshal it into
+// their target types regardless of the server's envelope style.
+func parseAPIResponse(bodyBytes []byte) APIResponse {
+	var apiResp APIResponse
+	if len(bodyBytes) == 0 {
+		return apiResp
+	}
+	if err := json.Unmarshal(bodyBytes, &apiResp); err != nil {
+		apiResp.Error = string(bodyBytes)
+		return apiResp
+	}
+	if apiResp.Data == nil && apiResp.Error == "" {
+		apiResp.Data = json.RawMessage(bodyBytes)
+	}
+	return apiResp
 }
 
 // TestConnection tests the API connection and authentication

--- a/cmd/cli/api_client_test.go
+++ b/cmd/cli/api_client_test.go
@@ -599,7 +599,9 @@ func TestGetServerInfo_HTTPError(t *testing.T) {
 
 func TestGetServerInfo_UnexpectedResponseFormat(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Return a string in Data, not a map.
+		// Return a response with no "data" field: parseAPIResponse stores the body
+		// as json.RawMessage, the type assertion in GetServerInfo fails, and
+		// "unexpected response format" is returned.
 		stdJSONResponse(w, http.StatusOK, &APIResponse{
 			Message: "ok but data is wrong shape",
 		})
@@ -746,6 +748,65 @@ func TestHandleAPIError_DefaultCase_WritesStatusAndMessage(t *testing.T) {
 	output := string(buf[:n])
 
 	assert.Contains(t, output, "conflict detected")
+}
+
+// ── parseAPIResponse ──────────────────────────────────────────────────────────
+
+func TestParseAPIResponse_EmptyBody_ReturnsZeroValue(t *testing.T) {
+	resp := parseAPIResponse(nil)
+	assert.Nil(t, resp.Data)
+	assert.Empty(t, resp.Error)
+}
+
+func TestParseAPIResponse_EnvelopedData_SetsDataField(t *testing.T) {
+	// Server response uses a {"data": ...} envelope — Data must be populated
+	// from the "data" key and the fallback must NOT trigger.
+	body := []byte(`{"data":{"groups":[{"id":"abc"}],"total":1}}`)
+	resp := parseAPIResponse(body)
+
+	// Data should be the decoded value of the "data" key, not the whole body.
+	raw, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok, "expected map, got %T", resp.Data)
+	assert.Contains(t, raw, "groups")
+}
+
+func TestParseAPIResponse_NonEnvelopedData_FallsBackToRawBody(t *testing.T) {
+	// Server response has no "data" key (e.g. {"groups": [...], "total": N}).
+	// The fallback must store the entire body so callers can decode it.
+	body := []byte(`{"groups":[{"id":"xyz","name":"prod"}],"total":1}`)
+	resp := parseAPIResponse(body)
+
+	raw, ok := resp.Data.(json.RawMessage)
+	require.True(t, ok, "expected json.RawMessage fallback, got %T", resp.Data)
+
+	// Verify the raw bytes round-trip into the target struct correctly.
+	var parsed struct {
+		Groups []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"groups"`
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+	require.Len(t, parsed.Groups, 1)
+	assert.Equal(t, "xyz", parsed.Groups[0].ID)
+	assert.Equal(t, "prod", parsed.Groups[0].Name)
+	assert.Equal(t, 1, parsed.Total)
+}
+
+func TestParseAPIResponse_InvalidJSON_SetsErrorField(t *testing.T) {
+	body := []byte("not json")
+	resp := parseAPIResponse(body)
+	assert.Equal(t, "not json", resp.Error)
+	assert.Nil(t, resp.Data)
+}
+
+func TestParseAPIResponse_ErrorFieldPresent_DoesNotFallback(t *testing.T) {
+	// When the response has an "error" field, the fallback must not overwrite Data.
+	body := []byte(`{"error":"something went wrong"}`)
+	resp := parseAPIResponse(body)
+	assert.Equal(t, "something went wrong", resp.Error)
+	assert.Nil(t, resp.Data, "fallback must not fire when error field is set")
 }
 
 // ── WithAPIClient ─────────────────────────────────────────────────────────────

--- a/cmd/cli/groups.go
+++ b/cmd/cli/groups.go
@@ -1,0 +1,625 @@
+// Package cli provides command-line interface commands for the Scanorama network scanner.
+// This file implements the groups subcommand with full CRUD and member management.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+// Groups command flag variables.
+const (
+	groupsEndpoint        = "/groups"
+	groupsMembersPath     = "/hosts"
+	groupsNoGroupsFound   = "No groups found."
+	groupsNoMembersFound  = "No members found."
+	groupsOutputFlagUsage = "Output format (table, json)"
+)
+
+var (
+	groupsOutput      string
+	groupsName        string
+	groupsDescription string
+	groupsColor       string
+	groupsHosts       string
+)
+
+// hostGroup mirrors the server-side db.HostGroup for JSON decoding.
+type hostGroup struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Color       string `json:"color,omitempty"`
+	MemberCount int    `json:"member_count"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+// groupMember mirrors the server-side groupMemberResponse for JSON decoding.
+type groupMember struct {
+	ID        string `json:"id"`
+	IPAddress string `json:"ip_address"`
+	Hostname  string `json:"hostname,omitempty"`
+	Status    string `json:"status"`
+	LastSeen  string `json:"last_seen"`
+}
+
+// groupsListResponse is the wire format for GET /groups.
+type groupsListResponse struct {
+	Groups []hostGroup `json:"groups"`
+	Total  int         `json:"total"`
+}
+
+// groupsMemberRequest is the request body for add/remove member operations.
+type groupsMemberRequest struct {
+	HostIDs []string `json:"host_ids"`
+}
+
+// groupsCreateRequest is the request body for POST /groups.
+type groupsCreateRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Color       string `json:"color,omitempty"`
+}
+
+// groupsUpdateRequest is the request body for PUT /groups/{id}.
+type groupsUpdateRequest struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Color       string `json:"color,omitempty"`
+}
+
+// ─── Command definitions ──────────────────────────────────────────────────────
+
+var groupsCmd = &cobra.Command{
+	Use:   "groups",
+	Short: "Manage host groups",
+	Long: `View and manage host groups. Groups allow you to organize discovered hosts
+into logical collections for targeted scanning, dashboards, and reporting.
+
+Examples:
+  scanorama groups list
+  scanorama groups create "Production" --description "Prod servers" --color "#FF0000"
+  scanorama groups show <id>
+  scanorama groups update <id> --name "Staging"
+  scanorama groups delete <id>
+  scanorama groups members <id>
+  scanorama groups add-member <group-id> --hosts h1,h2
+  scanorama groups remove-member <group-id> --hosts h1`,
+	Run: func(cmd *cobra.Command, args []string) {
+		_ = cmd.Help()
+	},
+}
+
+var groupsListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List all host groups",
+	Long: `List all host groups with member counts and metadata.
+
+Examples:
+  scanorama groups list
+  scanorama groups list --output json`,
+	Run: runGroupsList,
+}
+
+var groupsShowCmd = &cobra.Command{
+	Use:   "show <id>",
+	Short: "Show a host group",
+	Long: `Show detailed information about a specific host group.
+
+Examples:
+  scanorama groups show <id>
+  scanorama groups show <id> --output json`,
+	Args: cobra.ExactArgs(1),
+	Run:  runGroupsShow,
+}
+
+var groupsCreateCmd = &cobra.Command{
+	Use:   "create <name>",
+	Short: "Create a host group",
+	Long: `Create a new host group.
+
+Examples:
+  scanorama groups create "Production"
+  scanorama groups create "Staging" --description "Staging servers" --color "#00FF00"
+  scanorama groups create "Lab" --output json`,
+	Args: cobra.ExactArgs(1),
+	Run:  runGroupsCreate,
+}
+
+var groupsUpdateCmd = &cobra.Command{
+	Use:   "update <id>",
+	Short: "Update a host group",
+	Long: `Update an existing host group. At least one of --name, --description,
+or --color must be provided.
+
+Examples:
+  scanorama groups update <id> --name "New Name"
+  scanorama groups update <id> --description "Updated description" --color "#0000FF"`,
+	Args: cobra.ExactArgs(1),
+	Run:  runGroupsUpdate,
+}
+
+var groupsDeleteCmd = &cobra.Command{
+	Use:     "delete <id>",
+	Aliases: []string{"remove", "rm"},
+	Short:   "Delete a host group",
+	Long: `Delete a host group by ID.
+
+Examples:
+  scanorama groups delete <id>`,
+	Args: cobra.ExactArgs(1),
+	Run:  runGroupsDelete,
+}
+
+var groupsMembersCmd = &cobra.Command{
+	Use:   "members <id>",
+	Short: "List members of a host group",
+	Long: `List all hosts that are members of the given group.
+
+Examples:
+  scanorama groups members <id>
+  scanorama groups members <id> --output json`,
+	Args: cobra.ExactArgs(1),
+	Run:  runGroupsMembers,
+}
+
+var groupsAddMemberCmd = &cobra.Command{
+	Use:   "add-member <group-id>",
+	Short: "Add hosts to a group",
+	Long: `Add one or more hosts to a host group.
+
+Examples:
+  scanorama groups add-member <group-id> --hosts <host-id1>,<host-id2>`,
+	Args: cobra.ExactArgs(1),
+	Run:  runGroupsAddMember,
+}
+
+var groupsRemoveMemberCmd = &cobra.Command{
+	Use:   "remove-member <group-id>",
+	Short: "Remove hosts from a group",
+	Long: `Remove one or more hosts from a host group.
+
+Examples:
+  scanorama groups remove-member <group-id> --hosts <host-id1>,<host-id2>`,
+	Args: cobra.ExactArgs(1),
+	Run:  runGroupsRemoveMember,
+}
+
+// ─── Run handlers ─────────────────────────────────────────────────────────────
+
+func runGroupsList(cmd *cobra.Command, args []string) {
+	if err := executeGroupsList(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runGroupsShow(cmd *cobra.Command, args []string) {
+	if err := executeGroupsShow(args[0]); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runGroupsCreate(cmd *cobra.Command, args []string) {
+	if err := executeGroupsCreate(args[0]); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runGroupsUpdate(cmd *cobra.Command, args []string) {
+	if err := executeGroupsUpdate(args[0]); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runGroupsDelete(cmd *cobra.Command, args []string) {
+	if err := executeGroupsDelete(args[0]); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runGroupsMembers(cmd *cobra.Command, args []string) {
+	if err := executeGroupsMembers(args[0]); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runGroupsAddMember(cmd *cobra.Command, args []string) {
+	if err := executeGroupsMemberChange(args[0], true); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runGroupsRemoveMember(cmd *cobra.Command, args []string) {
+	if err := executeGroupsMemberChange(args[0], false); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// ─── Execute helpers ──────────────────────────────────────────────────────────
+
+func executeGroupsList() error {
+	return WithAPIClient("list groups", func(client *APIClient) error {
+		resp, err := client.Get(groupsEndpoint)
+		if err != nil {
+			return err
+		}
+
+		groups, err := decodeGroupsList(resp.Data)
+		if err != nil {
+			return err
+		}
+
+		if groupsOutput == outputFormatJSON {
+			displayGroupsJSON(groups)
+		} else {
+			displayGroupsTable(groups)
+		}
+		return nil
+	})
+}
+
+func executeGroupsShow(id string) error {
+	return WithAPIClient("show group", func(client *APIClient) error {
+		resp, err := client.Get(groupsEndpoint + "/" + id)
+		if err != nil {
+			return err
+		}
+
+		group, err := decodeGroup(resp.Data)
+		if err != nil {
+			return err
+		}
+
+		if groupsOutput == outputFormatJSON {
+			displayGroupsJSON([]hostGroup{group})
+		} else {
+			displayGroupsTable([]hostGroup{group})
+		}
+		return nil
+	})
+}
+
+func executeGroupsCreate(name string) error {
+	return WithAPIClient("create group", func(client *APIClient) error {
+		payload := groupsCreateRequest{
+			Name:        name,
+			Description: groupsDescription,
+			Color:       groupsColor,
+		}
+
+		resp, err := client.Post(groupsEndpoint, payload)
+		if err != nil {
+			return err
+		}
+
+		group, err := decodeGroup(resp.Data)
+		if err != nil {
+			return err
+		}
+
+		if groupsOutput == outputFormatJSON {
+			displayGroupsJSON([]hostGroup{group})
+		} else {
+			fmt.Printf("Group created: %s (%s)\n", group.Name, group.ID)
+		}
+		return nil
+	})
+}
+
+func executeGroupsUpdate(id string) error {
+	return WithAPIClient("update group", func(client *APIClient) error {
+		payload := groupsUpdateRequest{
+			Name:        groupsName,
+			Description: groupsDescription,
+			Color:       groupsColor,
+		}
+
+		if payload.Name == "" && payload.Description == "" && payload.Color == "" {
+			return fmt.Errorf("at least one of --name, --description, or --color must be provided")
+		}
+
+		resp, err := client.Put(groupsEndpoint+"/"+id, payload)
+		if err != nil {
+			return err
+		}
+
+		group, err := decodeGroup(resp.Data)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Group updated: %s (%s)\n", group.Name, group.ID)
+		return nil
+	})
+}
+
+func executeGroupsDelete(id string) error {
+	return WithAPIClient("delete group", func(client *APIClient) error {
+		_, err := client.Delete(groupsEndpoint + "/" + id)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Group %s deleted successfully.\n", id)
+		return nil
+	})
+}
+
+func executeGroupsMembers(id string) error {
+	return WithAPIClient("list group members", func(client *APIClient) error {
+		resp, err := client.Get(groupsEndpoint + "/" + id + groupsMembersPath)
+		if err != nil {
+			return err
+		}
+
+		members, err := decodeMembersList(resp.Data)
+		if err != nil {
+			return err
+		}
+
+		if groupsOutput == outputFormatJSON {
+			displayGroupMembersJSON(members)
+		} else {
+			displayGroupMembersTable(members)
+		}
+		return nil
+	})
+}
+
+func executeGroupsMemberChange(groupID string, add bool) error {
+	if groupsHosts == "" {
+		return fmt.Errorf("--hosts flag is required")
+	}
+
+	hostIDs := splitHosts(groupsHosts)
+
+	operation := "remove hosts from group"
+	if add {
+		operation = "add hosts to group"
+	}
+
+	return WithAPIClient(operation, func(client *APIClient) error {
+		endpoint := groupsEndpoint + "/" + groupID + groupsMembersPath
+		payload := groupsMemberRequest{HostIDs: hostIDs}
+
+		var err error
+		if add {
+			_, err = client.Post(endpoint, payload)
+		} else {
+			_, err = client.DeleteWithBody(endpoint, payload)
+		}
+		if err != nil {
+			return err
+		}
+
+		verb := "removed from"
+		if add {
+			verb = "added to"
+		}
+		fmt.Printf("%d host(s) %s group %s.\n", len(hostIDs), verb, groupID)
+		return nil
+	})
+}
+
+// splitHosts parses a comma-separated list of host IDs.
+func splitHosts(s string) []string {
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+// ─── Decode helpers ───────────────────────────────────────────────────────────
+
+func decodeGroupsList(data interface{}) ([]hostGroup, error) {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode response: %w", err)
+	}
+
+	var resp groupsListResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("failed to decode groups list: %w", err)
+	}
+
+	if resp.Groups == nil {
+		return make([]hostGroup, 0), nil
+	}
+	return resp.Groups, nil
+}
+
+func decodeGroup(data interface{}) (hostGroup, error) {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return hostGroup{}, fmt.Errorf("failed to encode response: %w", err)
+	}
+
+	var g hostGroup
+	if err := json.Unmarshal(raw, &g); err != nil {
+		return hostGroup{}, fmt.Errorf("failed to decode group: %w", err)
+	}
+	return g, nil
+}
+
+func decodeMembersList(data interface{}) ([]groupMember, error) {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode response: %w", err)
+	}
+
+	// apiResp.Data holds the value of the "data" key from the paginated envelope
+	// — an array, not the envelope struct. Unmarshal directly into []groupMember.
+	var members []groupMember
+	if err := json.Unmarshal(raw, &members); err != nil {
+		return nil, fmt.Errorf("failed to decode members list: %w", err)
+	}
+
+	if members == nil {
+		return make([]groupMember, 0), nil
+	}
+	return members, nil
+}
+
+// ─── Display helpers ──────────────────────────────────────────────────────────
+
+// displayGroupsTable renders groups in a tabular format.
+func displayGroupsTable(groups []hostGroup) {
+	if len(groups) == 0 {
+		fmt.Println(groupsNoGroupsFound)
+		return
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.Header("ID", "NAME", "DESCRIPTION", "COLOR", "MEMBERS", "CREATED")
+
+	for i := range groups {
+		g := &groups[i]
+		desc := g.Description
+		if len(desc) > maxDescriptionLength {
+			desc = desc[:maxDescriptionLength] + "..."
+		}
+		_ = table.Append([]string{
+			g.ID,
+			g.Name,
+			desc,
+			g.Color,
+			fmt.Sprintf("%d", g.MemberCount),
+			g.CreatedAt,
+		})
+	}
+
+	_ = table.Render()
+}
+
+// displayGroupsJSON renders groups as a JSON object with a count field.
+func displayGroupsJSON(groups []hostGroup) {
+	if groups == nil {
+		groups = make([]hostGroup, 0)
+	}
+
+	output := struct {
+		Groups []hostGroup `json:"groups"`
+		Count  int         `json:"count"`
+	}{
+		Groups: groups,
+		Count:  len(groups),
+	}
+
+	jsonData, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling JSON: %v\n", err)
+		return
+	}
+
+	fmt.Println(string(jsonData))
+}
+
+// displayGroupMembersTable renders group members in a tabular format.
+func displayGroupMembersTable(members []groupMember) {
+	if len(members) == 0 {
+		fmt.Println(groupsNoMembersFound)
+		return
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.Header("ID", "IP ADDRESS", "HOSTNAME", "STATUS", "LAST SEEN")
+
+	for i := range members {
+		m := &members[i]
+		_ = table.Append([]string{
+			m.ID,
+			m.IPAddress,
+			m.Hostname,
+			m.Status,
+			m.LastSeen,
+		})
+	}
+
+	_ = table.Render()
+}
+
+// displayGroupMembersJSON renders group members as a JSON object with a count field.
+func displayGroupMembersJSON(members []groupMember) {
+	if members == nil {
+		members = make([]groupMember, 0)
+	}
+
+	output := struct {
+		Members []groupMember `json:"members"`
+		Count   int           `json:"count"`
+	}{
+		Members: members,
+		Count:   len(members),
+	}
+
+	jsonData, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling JSON: %v\n", err)
+		return
+	}
+
+	fmt.Println(string(jsonData))
+}
+
+// ─── Init ─────────────────────────────────────────────────────────────────────
+
+func init() {
+	rootCmd.AddCommand(groupsCmd)
+
+	groupsCmd.AddCommand(groupsListCmd)
+	groupsCmd.AddCommand(groupsShowCmd)
+	groupsCmd.AddCommand(groupsCreateCmd)
+	groupsCmd.AddCommand(groupsUpdateCmd)
+	groupsCmd.AddCommand(groupsDeleteCmd)
+	groupsCmd.AddCommand(groupsMembersCmd)
+	groupsCmd.AddCommand(groupsAddMemberCmd)
+	groupsCmd.AddCommand(groupsRemoveMemberCmd)
+
+	// list flags
+	groupsListCmd.Flags().StringVarP(&groupsOutput, "output", "o", "table", groupsOutputFlagUsage)
+
+	// show flags
+	groupsShowCmd.Flags().StringVarP(&groupsOutput, "output", "o", "table", groupsOutputFlagUsage)
+
+	// create flags
+	groupsCreateCmd.Flags().StringVar(&groupsDescription, "description", "", "Group description")
+	groupsCreateCmd.Flags().StringVar(&groupsColor, "color", "", "Group color as a hex value (e.g. #FF0000)")
+	groupsCreateCmd.Flags().StringVarP(&groupsOutput, "output", "o", "table", groupsOutputFlagUsage)
+
+	// update flags
+	groupsUpdateCmd.Flags().StringVar(&groupsName, "name", "", "New group name")
+	groupsUpdateCmd.Flags().StringVar(&groupsDescription, "description", "", "New group description")
+	groupsUpdateCmd.Flags().StringVar(&groupsColor, "color", "", "New group color as a hex value")
+
+	// members flags
+	groupsMembersCmd.Flags().StringVarP(&groupsOutput, "output", "o", "table", groupsOutputFlagUsage)
+
+	// add-member / remove-member flags
+	groupsAddMemberCmd.Flags().StringVar(&groupsHosts, "hosts", "", "Comma-separated list of host IDs (required)")
+	groupsRemoveMemberCmd.Flags().StringVar(&groupsHosts, "hosts", "", "Comma-separated list of host IDs (required)")
+
+	if err := groupsAddMemberCmd.MarkFlagRequired("hosts"); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to mark hosts flag as required: %v\n", err)
+	}
+	if err := groupsRemoveMemberCmd.MarkFlagRequired("hosts"); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to mark hosts flag as required: %v\n", err)
+	}
+}

--- a/cmd/cli/groups_test.go
+++ b/cmd/cli/groups_test.go
@@ -1,0 +1,542 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── displayGroupsTable ───────────────────────────────────────────────────────
+
+func TestDisplayGroupsTable(t *testing.T) {
+	tests := []struct {
+		name            string
+		groups          []hostGroup
+		expectedHeaders []string
+		expectedRows    int
+		expectNoRows    bool
+	}{
+		{
+			name:            "empty_list",
+			groups:          []hostGroup{},
+			expectedHeaders: []string{},
+			expectedRows:    0,
+			expectNoRows:    true,
+		},
+		{
+			name: "single_group",
+			groups: []hostGroup{
+				{
+					ID:          "aaa-111",
+					Name:        "Production",
+					Description: "Prod servers",
+					Color:       "#FF0000",
+					MemberCount: 5,
+					CreatedAt:   "2024-01-01T00:00:00Z",
+					UpdatedAt:   "2024-01-02T00:00:00Z",
+				},
+			},
+			expectedHeaders: []string{"ID", "NAME", "DESCRIPTION", "COLOR", "MEMBERS", "CREATED"},
+			expectedRows:    1,
+			expectNoRows:    false,
+		},
+		{
+			name: "multiple_groups",
+			groups: []hostGroup{
+				{
+					ID:          "aaa-111",
+					Name:        "Production",
+					Description: "Prod servers",
+					Color:       "#FF0000",
+					MemberCount: 10,
+					CreatedAt:   "2024-01-01T00:00:00Z",
+					UpdatedAt:   "2024-01-01T00:00:00Z",
+				},
+				{
+					ID:          "bbb-222",
+					Name:        "Staging",
+					Description: "Staging environment",
+					Color:       "#00FF00",
+					MemberCount: 3,
+					CreatedAt:   "2024-02-01T00:00:00Z",
+					UpdatedAt:   "2024-02-02T00:00:00Z",
+				},
+				{
+					ID:          "ccc-333",
+					Name:        "Lab",
+					Description: "",
+					Color:       "",
+					MemberCount: 0,
+					CreatedAt:   "2024-03-01T00:00:00Z",
+					UpdatedAt:   "2024-03-01T00:00:00Z",
+				},
+			},
+			expectedHeaders: []string{"ID", "NAME", "DESCRIPTION", "COLOR", "MEMBERS", "CREATED"},
+			expectedRows:    3,
+			expectNoRows:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldStdout := os.Stdout
+			r, w, err := os.Pipe()
+			require.NoError(t, err)
+			os.Stdout = w
+
+			displayGroupsTable(tt.groups)
+
+			w.Close()
+			os.Stdout = oldStdout
+
+			var buf bytes.Buffer
+			_, err = buf.ReadFrom(r)
+			require.NoError(t, err)
+
+			output := buf.String()
+
+			if tt.expectNoRows {
+				assert.Contains(t, output, groupsNoGroupsFound)
+				return
+			}
+
+			for _, header := range tt.expectedHeaders {
+				assert.Contains(t, output, header, "Table should contain header: %s", header)
+			}
+
+			// Count data rows: lines with pipe separators that are not borders,
+			// separators, or the header row (which contains "NAME" in all caps).
+			lines := strings.Split(output, "\n")
+			dataRows := 0
+			for _, line := range lines {
+				trimmed := strings.TrimSpace(line)
+				if trimmed == "" {
+					continue
+				}
+				isBorder := strings.ContainsAny(trimmed[:1], "┌└├")
+				isSeparator := strings.Contains(line, "─")
+				isHeader := strings.Contains(line, "NAME") && strings.Contains(line, "MEMBERS")
+				if !isBorder && !isSeparator && !isHeader && strings.Count(line, "│") >= 2 {
+					dataRows++
+				}
+			}
+			assert.Equal(t, tt.expectedRows, dataRows,
+				"expected %d data rows, got %d\n%s", tt.expectedRows, dataRows, output)
+
+			for _, g := range tt.groups {
+				assert.Contains(t, output, g.ID)
+				assert.Contains(t, output, g.Name)
+			}
+		})
+	}
+}
+
+// ─── displayGroupsJSON ────────────────────────────────────────────────────────
+
+func TestDisplayGroupsJSON(t *testing.T) {
+	tests := []struct {
+		name   string
+		groups []hostGroup
+		count  int
+	}{
+		{
+			name:   "empty_list",
+			groups: []hostGroup{},
+			count:  0,
+		},
+		{
+			name: "single_group",
+			groups: []hostGroup{
+				{
+					ID:          "aaa-111",
+					Name:        "Production",
+					Description: "Prod servers",
+					Color:       "#FF0000",
+					MemberCount: 5,
+					CreatedAt:   "2024-01-01T00:00:00Z",
+					UpdatedAt:   "2024-01-02T00:00:00Z",
+				},
+			},
+			count: 1,
+		},
+		{
+			name: "multiple_groups",
+			groups: []hostGroup{
+				{
+					ID:   "aaa-111",
+					Name: "Production",
+				},
+				{
+					ID:   "bbb-222",
+					Name: "Staging",
+				},
+			},
+			count: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldStdout := os.Stdout
+			r, w, err := os.Pipe()
+			require.NoError(t, err)
+			os.Stdout = w
+
+			displayGroupsJSON(tt.groups)
+
+			w.Close()
+			os.Stdout = oldStdout
+
+			var buf bytes.Buffer
+			_, err = buf.ReadFrom(r)
+			require.NoError(t, err)
+
+			output := buf.String()
+			require.NotEmpty(t, output)
+
+			// Must be valid JSON.
+			var raw map[string]interface{}
+			require.NoError(t, json.Unmarshal([]byte(output), &raw),
+				"output must be valid JSON: %s", output)
+
+			// Top-level keys must be present.
+			assert.Contains(t, raw, "groups", "JSON should have 'groups' key")
+			assert.Contains(t, raw, "count", "JSON should have 'count' key")
+
+			count, ok := raw["count"].(float64)
+			require.True(t, ok, "'count' should be a number")
+			assert.Equal(t, float64(tt.count), count)
+
+			groups, ok := raw["groups"].([]interface{})
+			require.True(t, ok, "'groups' should be an array")
+			assert.Len(t, groups, tt.count)
+
+			// Verify indentation is present (pretty-printed).
+			assert.Contains(t, output, "  ")
+		})
+	}
+}
+
+func TestDisplayGroupsJSON_NilSlice(t *testing.T) {
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	displayGroupsJSON(nil)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+
+	output := buf.String()
+	require.NotEmpty(t, output)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &raw))
+
+	groups, ok := raw["groups"].([]interface{})
+	require.True(t, ok, "'groups' should be an array even when nil was passed")
+	assert.Len(t, groups, 0)
+
+	count, ok := raw["count"].(float64)
+	require.True(t, ok)
+	assert.Equal(t, float64(0), count)
+}
+
+// ─── displayGroupMembersJSON ──────────────────────────────────────────────────
+
+func TestDisplayGroupMembersJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		members []groupMember
+		count   int
+	}{
+		{
+			name:    "empty_list",
+			members: []groupMember{},
+			count:   0,
+		},
+		{
+			name: "single_member",
+			members: []groupMember{
+				{
+					ID:        "host-aaa",
+					IPAddress: "10.0.0.1",
+					Hostname:  "web-01",
+					Status:    "up",
+					LastSeen:  "2024-06-01T12:00:00Z",
+				},
+			},
+			count: 1,
+		},
+		{
+			name: "multiple_members",
+			members: []groupMember{
+				{
+					ID:        "host-aaa",
+					IPAddress: "10.0.0.1",
+					Status:    "up",
+					LastSeen:  "2024-06-01T12:00:00Z",
+				},
+				{
+					ID:        "host-bbb",
+					IPAddress: "10.0.0.2",
+					Hostname:  "db-01",
+					Status:    "down",
+					LastSeen:  "2024-05-31T00:00:00Z",
+				},
+			},
+			count: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldStdout := os.Stdout
+			r, w, err := os.Pipe()
+			require.NoError(t, err)
+			os.Stdout = w
+
+			displayGroupMembersJSON(tt.members)
+
+			w.Close()
+			os.Stdout = oldStdout
+
+			var buf bytes.Buffer
+			_, err = buf.ReadFrom(r)
+			require.NoError(t, err)
+
+			output := buf.String()
+			require.NotEmpty(t, output)
+
+			// Must be valid JSON.
+			var raw map[string]interface{}
+			require.NoError(t, json.Unmarshal([]byte(output), &raw),
+				"output must be valid JSON: %s", output)
+
+			// Top-level keys must be present.
+			assert.Contains(t, raw, "members", "JSON should have 'members' key")
+			assert.Contains(t, raw, "count", "JSON should have 'count' key")
+
+			count, ok := raw["count"].(float64)
+			require.True(t, ok, "'count' should be a number")
+			assert.Equal(t, float64(tt.count), count)
+
+			members, ok := raw["members"].([]interface{})
+			require.True(t, ok, "'members' should be an array")
+			assert.Len(t, members, tt.count)
+
+			// Verify indentation is present (pretty-printed).
+			assert.Contains(t, output, "  ")
+		})
+	}
+}
+
+func TestDisplayGroupMembersJSON_NilSlice(t *testing.T) {
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	displayGroupMembersJSON(nil)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+
+	output := buf.String()
+	require.NotEmpty(t, output)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &raw))
+
+	members, ok := raw["members"].([]interface{})
+	require.True(t, ok, "'members' should be an array even when nil was passed")
+	assert.Len(t, members, 0)
+
+	count, ok := raw["count"].(float64)
+	require.True(t, ok)
+	assert.Equal(t, float64(0), count)
+}
+
+// ─── Command structure ────────────────────────────────────────────────────────
+
+func TestGroupsCommandStructure(t *testing.T) {
+	t.Run("groups help lists subcommands", func(t *testing.T) {
+		out, errOut, err := executeCommand("groups", "--help")
+
+		require.NoError(t, err)
+		all := combined(out, errOut)
+		assert.Contains(t, all, "list", "groups help should list the list subcommand")
+		assert.Contains(t, all, "show", "groups help should list the show subcommand")
+		assert.Contains(t, all, "create", "groups help should list the create subcommand")
+		assert.Contains(t, all, "update", "groups help should list the update subcommand")
+		assert.Contains(t, all, "delete", "groups help should list the delete subcommand")
+		assert.Contains(t, all, "members", "groups help should list the members subcommand")
+		assert.Contains(t, all, "add-member", "groups help should list the add-member subcommand")
+		assert.Contains(t, all, "remove-member", "groups help should list the remove-member subcommand")
+	})
+
+	t.Run("groups show requires exactly one arg", func(t *testing.T) {
+		_, _, err := executeCommand("groups", "show")
+		assert.Error(t, err, "groups show with no args should fail")
+	})
+
+	t.Run("groups delete requires exactly one arg", func(t *testing.T) {
+		_, _, err := executeCommand("groups", "delete")
+		assert.Error(t, err, "groups delete with no args should fail")
+	})
+
+	t.Run("groups members requires exactly one arg", func(t *testing.T) {
+		_, _, err := executeCommand("groups", "members")
+		assert.Error(t, err, "groups members with no args should fail")
+	})
+
+	t.Run("groups add-member requires exactly one arg", func(t *testing.T) {
+		_, _, err := executeCommand("groups", "add-member")
+		assert.Error(t, err, "groups add-member with no args should fail")
+	})
+
+	t.Run("groups create requires exactly one arg", func(t *testing.T) {
+		_, _, err := executeCommand("groups", "create")
+		assert.Error(t, err, "groups create with no args should fail")
+	})
+
+	t.Run("groups create help shows flags", func(t *testing.T) {
+		out, errOut, err := executeCommand("groups", "create", "--help")
+
+		require.NoError(t, err)
+		all := combined(out, errOut)
+		assert.Contains(t, all, "--description", "groups create help should show --description flag")
+		assert.Contains(t, all, "--color", "groups create help should show --color flag")
+		assert.Contains(t, all, "--output", "groups create help should show --output flag")
+	})
+
+	t.Run("groups update help shows flags", func(t *testing.T) {
+		out, errOut, err := executeCommand("groups", "update", "--help")
+
+		require.NoError(t, err)
+		all := combined(out, errOut)
+		assert.Contains(t, all, "--name", "groups update help should show --name flag")
+		assert.Contains(t, all, "--description", "groups update help should show --description flag")
+		assert.Contains(t, all, "--color", "groups update help should show --color flag")
+	})
+
+	t.Run("groups add-member help shows hosts flag", func(t *testing.T) {
+		out, errOut, err := executeCommand("groups", "add-member", "--help")
+
+		require.NoError(t, err)
+		all := combined(out, errOut)
+		assert.Contains(t, all, "--hosts", "groups add-member help should show --hosts flag")
+	})
+
+	t.Run("groups remove-member help shows hosts flag", func(t *testing.T) {
+		out, errOut, err := executeCommand("groups", "remove-member", "--help")
+
+		require.NoError(t, err)
+		all := combined(out, errOut)
+		assert.Contains(t, all, "--hosts", "groups remove-member help should show --hosts flag")
+	})
+}
+
+// ─── splitHosts ───────────────────────────────────────────────────────────────
+
+func TestSplitHosts(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "single host",
+			input:    "host-aaa",
+			expected: []string{"host-aaa"},
+		},
+		{
+			name:     "multiple hosts",
+			input:    "host-aaa,host-bbb,host-ccc",
+			expected: []string{"host-aaa", "host-bbb", "host-ccc"},
+		},
+		{
+			name:     "hosts with spaces",
+			input:    " host-aaa , host-bbb ",
+			expected: []string{"host-aaa", "host-bbb"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "only commas",
+			input:    ",,,",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := splitHosts(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// ─── decodeMembersList ────────────────────────────────────────────────────────
+
+func TestDecodeMembersList(t *testing.T) {
+	t.Run("non-empty array returns members", func(t *testing.T) {
+		// Simulate apiResp.Data holding the decoded value of the "data" key from
+		// a paginated envelope: a []interface{} containing the member objects.
+		data := []interface{}{
+			map[string]interface{}{
+				"id":         "host-1",
+				"ip_address": "192.168.1.1",
+				"hostname":   "web01",
+				"status":     "up",
+				"last_seen":  "2024-01-15T10:00:00Z",
+			},
+			map[string]interface{}{
+				"id":         "host-2",
+				"ip_address": "192.168.1.2",
+				"hostname":   "",
+				"status":     "down",
+				"last_seen":  "2024-01-14T09:00:00Z",
+			},
+		}
+
+		members, err := decodeMembersList(data)
+		require.NoError(t, err)
+		require.Len(t, members, 2)
+		assert.Equal(t, "host-1", members[0].ID)
+		assert.Equal(t, "192.168.1.1", members[0].IPAddress)
+		assert.Equal(t, "web01", members[0].Hostname)
+		assert.Equal(t, "host-2", members[1].ID)
+	})
+
+	t.Run("empty array returns empty non-nil slice", func(t *testing.T) {
+		members, err := decodeMembersList([]interface{}{})
+		require.NoError(t, err)
+		assert.NotNil(t, members)
+		assert.Empty(t, members)
+	})
+
+	t.Run("nil data returns empty non-nil slice", func(t *testing.T) {
+		members, err := decodeMembersList(nil)
+		require.NoError(t, err)
+		assert.NotNil(t, members)
+		assert.Empty(t, members)
+	})
+}

--- a/cmd/cli/schedule.go
+++ b/cmd/cli/schedule.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -24,7 +25,10 @@ const (
 	maxJobNameLength        = 20  // max job name length before truncation
 	maxPortsDisplay         = 5   // max ports to show before truncation
 	// Display text constants
-	yesText = "Yes"
+	yesText          = "Yes"
+	outputFormatJSON = "json"
+	// API endpoint for server-computed next-run.
+	nextRunEndpoint = "/schedules/%s/next-run"
 )
 
 // scheduleCmd represents the schedule command.
@@ -112,6 +116,10 @@ var (
 	// Flags for add-discovery command.
 	scheduleDetectOS bool
 	scheduleMethod   string
+
+	// Output format flags.
+	scheduleListOutput string
+	scheduleShowOutput string
 )
 
 func init() {
@@ -143,6 +151,10 @@ func init() {
 	scheduleAddScanCmd.Flags().Lookup("live-hosts").Usage = "Scan all discovered live hosts in scheduled job"
 	scheduleAddScanCmd.Flags().Lookup("type").Usage = "Scan type: connect, syn, version, " +
 		"comprehensive, aggressive, stealth"
+
+	// Output format flags
+	scheduleListCmd.Flags().StringVarP(&scheduleListOutput, "output", "o", "table", "Output format (table, json)")
+	scheduleShowCmd.Flags().StringVarP(&scheduleShowOutput, "output", "o", "table", "Output format (table, json)")
 }
 
 func runScheduleList(_ *cobra.Command, _ []string) {
@@ -153,6 +165,10 @@ func runScheduleList(_ *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 
+		if scheduleListOutput == outputFormatJSON {
+			displayScheduledJobsJSON(jobs)
+			return
+		}
 		displayScheduledJobs(jobs)
 	})
 }
@@ -275,6 +291,11 @@ func runScheduleShow(_ *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 
+		if scheduleShowOutput == outputFormatJSON {
+			serverNextRun := fetchServerNextRun(job.ID)
+			displayScheduledJobDetailsJSON(job, serverNextRun)
+			return
+		}
 		displayScheduledJobDetails(job)
 	})
 }
@@ -531,4 +552,106 @@ func truncateString(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen-3] + "..."
+}
+
+// fetchServerNextRun calls GET /schedules/{id}/next-run and returns the
+// server-computed next run time. Returns nil on any error (best-effort).
+func fetchServerNextRun(jobID string) *time.Time {
+	client, err := NewAPIClient()
+	if err != nil {
+		return nil
+	}
+
+	endpoint := fmt.Sprintf(nextRunEndpoint, jobID)
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return nil
+	}
+
+	data, ok := resp.Data.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	nextRunStr, ok := data["next_run"].(string)
+	if !ok {
+		return nil
+	}
+
+	t, err := time.Parse(time.RFC3339, nextRunStr)
+	if err != nil {
+		return nil
+	}
+
+	return &t
+}
+
+// scheduledJobJSON is the wire representation of a scheduled job for JSON output.
+type scheduledJobJSON struct {
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
+	JobType   string     `json:"job_type"`
+	CronExpr  string     `json:"cron_expr"`
+	IsActive  bool       `json:"is_active"`
+	CreatedAt time.Time  `json:"created_at"`
+	LastRun   *time.Time `json:"last_run"`
+	NextRun   time.Time  `json:"next_run"`
+	RunCount  int        `json:"run_count"`
+}
+
+func toScheduledJobJSON(job *ScheduledJob, serverNextRun *time.Time) scheduledJobJSON {
+	nextRun := job.NextRun
+	if serverNextRun != nil {
+		nextRun = *serverNextRun
+	}
+
+	return scheduledJobJSON{
+		ID:        job.ID,
+		Name:      job.Name,
+		JobType:   job.JobType,
+		CronExpr:  job.CronExpr,
+		IsActive:  job.IsActive,
+		CreatedAt: job.CreatedAt,
+		LastRun:   job.LastRun,
+		NextRun:   nextRun,
+		RunCount:  job.RunCount,
+	}
+}
+
+// displayScheduledJobsJSON emits the job list as JSON: {"jobs":[...],"count":N}.
+func displayScheduledJobsJSON(jobs []ScheduledJob) {
+	items := make([]scheduledJobJSON, len(jobs))
+	for i := range jobs {
+		items[i] = toScheduledJobJSON(&jobs[i], nil)
+	}
+
+	output := struct {
+		Jobs  []scheduledJobJSON `json:"jobs"`
+		Count int                `json:"count"`
+	}{
+		Jobs:  items,
+		Count: len(items),
+	}
+
+	jsonData, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling JSON: %v\n", err)
+		return
+	}
+
+	fmt.Println(string(jsonData))
+}
+
+// displayScheduledJobDetailsJSON emits a single job as JSON. When serverNextRun
+// is non-nil, the server-computed value overrides the locally computed NextRun.
+func displayScheduledJobDetailsJSON(job *ScheduledJob, serverNextRun *time.Time) {
+	item := toScheduledJobJSON(job, serverNextRun)
+
+	jsonData, err := json.MarshalIndent(item, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling JSON: %v\n", err)
+		return
+	}
+
+	fmt.Println(string(jsonData))
 }

--- a/cmd/cli/schedule_test.go
+++ b/cmd/cli/schedule_test.go
@@ -2,6 +2,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -124,4 +125,247 @@ func TestGetNextRunTime_Idempotent(t *testing.T) {
 	}
 	assert.True(t, diff <= 5*time.Minute,
 		"two consecutive calls should agree on the same or adjacent boundary")
+}
+
+// TestDisplayScheduledJobsJSON verifies that displayScheduledJobsJSON emits
+// valid JSON with the expected top-level "jobs" array and "count" field.
+func TestDisplayScheduledJobsJSON(t *testing.T) {
+	fixedTime := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	nextRun := time.Date(2024, 6, 2, 0, 0, 0, 0, time.UTC)
+	lastRun := time.Date(2024, 5, 31, 0, 0, 0, 0, time.UTC)
+
+	t.Run("empty list produces valid JSON with count zero", func(t *testing.T) {
+		output := captureStdout(t, func() {
+			displayScheduledJobsJSON([]ScheduledJob{})
+		})
+
+		require.NotEmpty(t, output)
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(output), &result), "output must be valid JSON")
+
+		assert.Contains(t, result, "jobs")
+		assert.Contains(t, result, "count")
+		assert.Equal(t, float64(0), result["count"])
+
+		jobs, ok := result["jobs"].([]interface{})
+		require.True(t, ok, "jobs must be an array")
+		assert.Empty(t, jobs)
+	})
+
+	t.Run("single job produces correct JSON fields", func(t *testing.T) {
+		jobs := []ScheduledJob{
+			{
+				ID:        "abc-123",
+				Name:      "weekly-sweep",
+				JobType:   "discovery",
+				CronExpr:  "0 2 * * 0",
+				IsActive:  true,
+				CreatedAt: fixedTime,
+				LastRun:   &lastRun,
+				NextRun:   nextRun,
+				RunCount:  1,
+			},
+		}
+
+		output := captureStdout(t, func() {
+			displayScheduledJobsJSON(jobs)
+		})
+
+		require.NotEmpty(t, output)
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(output), &result), "output must be valid JSON")
+
+		assert.Equal(t, float64(1), result["count"])
+
+		jobsArr, ok := result["jobs"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, jobsArr, 1)
+
+		job := jobsArr[0].(map[string]interface{})
+		assert.Equal(t, "abc-123", job["id"])
+		assert.Equal(t, "weekly-sweep", job["name"])
+		assert.Equal(t, "discovery", job["job_type"])
+		assert.Equal(t, "0 2 * * 0", job["cron_expr"])
+		assert.Equal(t, true, job["is_active"])
+		assert.Contains(t, job, "created_at")
+		assert.Contains(t, job, "last_run")
+		assert.Contains(t, job, "next_run")
+		assert.Equal(t, float64(1), job["run_count"])
+	})
+
+	t.Run("multiple jobs produce correct count", func(t *testing.T) {
+		jobs := []ScheduledJob{
+			{
+				ID: "id-1", Name: "job-one", JobType: "discovery",
+				CronExpr: "0 1 * * *", CreatedAt: fixedTime, NextRun: nextRun,
+			},
+			{
+				ID: "id-2", Name: "job-two", JobType: "scan",
+				CronExpr: "0 2 * * *", CreatedAt: fixedTime, NextRun: nextRun,
+			},
+		}
+
+		output := captureStdout(t, func() {
+			displayScheduledJobsJSON(jobs)
+		})
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+
+		assert.Equal(t, float64(2), result["count"])
+
+		jobsArr, ok := result["jobs"].([]interface{})
+		require.True(t, ok)
+		assert.Len(t, jobsArr, 2)
+	})
+
+	t.Run("output contains indentation", func(t *testing.T) {
+		output := captureStdout(t, func() {
+			displayScheduledJobsJSON([]ScheduledJob{})
+		})
+		assert.Contains(t, output, "  ", "JSON output should be indented")
+	})
+
+	t.Run("job with nil last_run serializes as null", func(t *testing.T) {
+		jobs := []ScheduledJob{
+			{
+				ID: "no-run", Name: "never-run", JobType: "scan",
+				CronExpr: "0 3 * * *", CreatedAt: fixedTime, NextRun: nextRun,
+				LastRun: nil,
+			},
+		}
+
+		output := captureStdout(t, func() {
+			displayScheduledJobsJSON(jobs)
+		})
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+
+		jobsArr := result["jobs"].([]interface{})
+		job := jobsArr[0].(map[string]interface{})
+		assert.Nil(t, job["last_run"])
+	})
+}
+
+// TestDisplayScheduledJobDetailsJSON verifies that displayScheduledJobDetailsJSON
+// emits a single-job JSON object with all expected fields, including next_run.
+func TestDisplayScheduledJobDetailsJSON(t *testing.T) {
+	fixedTime := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	localNext := time.Date(2024, 6, 2, 0, 0, 0, 0, time.UTC)
+	lastRun := time.Date(2024, 5, 31, 8, 0, 0, 0, time.UTC)
+
+	baseJob := &ScheduledJob{
+		ID:        "job-xyz",
+		Name:      "daily-scan",
+		JobType:   "scan",
+		CronExpr:  "0 0 * * *",
+		IsActive:  true,
+		CreatedAt: fixedTime,
+		LastRun:   &lastRun,
+		NextRun:   localNext,
+		RunCount:  5,
+	}
+
+	t.Run("all expected fields are present", func(t *testing.T) {
+		output := captureStdout(t, func() {
+			displayScheduledJobDetailsJSON(baseJob, nil)
+		})
+
+		require.NotEmpty(t, output)
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(output), &result), "output must be valid JSON")
+
+		expectedFields := []string{
+			"id", "name", "job_type", "cron_expr",
+			"is_active", "created_at", "last_run", "next_run", "run_count",
+		}
+		for _, field := range expectedFields {
+			assert.Contains(t, result, field, "JSON should contain field: %s", field)
+		}
+	})
+
+	t.Run("field values match job struct", func(t *testing.T) {
+		output := captureStdout(t, func() {
+			displayScheduledJobDetailsJSON(baseJob, nil)
+		})
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+
+		assert.Equal(t, "job-xyz", result["id"])
+		assert.Equal(t, "daily-scan", result["name"])
+		assert.Equal(t, "scan", result["job_type"])
+		assert.Equal(t, "0 0 * * *", result["cron_expr"])
+		assert.Equal(t, true, result["is_active"])
+		assert.Equal(t, float64(5), result["run_count"])
+	})
+
+	t.Run("server next_run overrides locally computed value", func(t *testing.T) {
+		serverTime := time.Date(2024, 6, 3, 6, 0, 0, 0, time.UTC)
+
+		output := captureStdout(t, func() {
+			displayScheduledJobDetailsJSON(baseJob, &serverTime)
+		})
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+
+		nextRunStr, ok := result["next_run"].(string)
+		require.True(t, ok, "next_run must be a string")
+
+		parsed, err := time.Parse(time.RFC3339, nextRunStr)
+		require.NoError(t, err)
+		assert.True(t, serverTime.Equal(parsed),
+			"next_run should reflect the server-provided time, got %s", nextRunStr)
+	})
+
+	t.Run("nil server next_run uses locally computed value", func(t *testing.T) {
+		output := captureStdout(t, func() {
+			displayScheduledJobDetailsJSON(baseJob, nil)
+		})
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+
+		nextRunStr, ok := result["next_run"].(string)
+		require.True(t, ok, "next_run must be a string")
+
+		parsed, err := time.Parse(time.RFC3339, nextRunStr)
+		require.NoError(t, err)
+		assert.True(t, localNext.Equal(parsed),
+			"next_run should reflect the local NextRun value when server is unavailable")
+	})
+
+	t.Run("job with nil last_run serializes last_run as null", func(t *testing.T) {
+		jobNoLastRun := &ScheduledJob{
+			ID:        "no-run",
+			Name:      "fresh-job",
+			JobType:   "discovery",
+			CronExpr:  "0 1 * * *",
+			IsActive:  false,
+			CreatedAt: fixedTime,
+			LastRun:   nil,
+			NextRun:   localNext,
+		}
+
+		output := captureStdout(t, func() {
+			displayScheduledJobDetailsJSON(jobNoLastRun, nil)
+		})
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+
+		assert.Nil(t, result["last_run"])
+	})
+
+	t.Run("output contains indentation", func(t *testing.T) {
+		output := captureStdout(t, func() {
+			displayScheduledJobDetailsJSON(baseJob, nil)
+		})
+		assert.Contains(t, output, "  ", "JSON output should be indented")
+	})
 }

--- a/cmd/cli/settings.go
+++ b/cmd/cli/settings.go
@@ -1,0 +1,256 @@
+// Package cli provides command-line interface commands for the Scanorama network scanner.
+// This file implements settings management commands for reading and updating
+// server configuration via the admin API.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+const (
+	settingsMaxValueLen = 40
+)
+
+var (
+	settingsKey    string
+	settingsValue  string
+	settingsOutput string
+)
+
+// Setting represents a single server configuration entry returned by the API.
+type Setting struct {
+	Key         string `json:"key"`
+	Value       string `json:"value"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+// settingsCmd is the parent command for all settings subcommands.
+var settingsCmd = &cobra.Command{
+	Use:   "settings",
+	Short: "Manage server configuration settings",
+	Long: `View and update server configuration settings via the admin API.
+
+Settings are key-value pairs that control server behavior at runtime.
+Values must be valid JSON — use quoted strings for text values.
+
+Examples:
+  # List all settings as a table
+  scanorama settings get
+
+  # List all settings as JSON
+  scanorama settings get --output json
+
+  # Update a boolean setting
+  scanorama settings update --key some.feature.enabled --value true
+
+  # Update a numeric setting
+  scanorama settings update --key scan.timeout --value 30
+
+  # Update a string setting (value must be a JSON string literal)
+  scanorama settings update --key log.level --value '"debug"'`,
+	Run: func(cmd *cobra.Command, args []string) {
+		_ = cmd.Help()
+	},
+}
+
+// settingsGetCmd retrieves all server settings.
+var settingsGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get all server settings",
+	Long: `Retrieve all server configuration settings from the admin API.
+
+Use --output json to get machine-readable output.
+
+Examples:
+  scanorama settings get
+  scanorama settings get --output json`,
+	Run: runSettingsGet,
+}
+
+// settingsUpdateCmd updates a single server setting.
+var settingsUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update a server setting",
+	Long: `Update a single server configuration setting via the admin API.
+
+The --value flag must be a valid JSON value:
+  - Boolean:  --value true
+  - Number:   --value 42
+  - String:   --value '"text"'   (note the inner quotes)
+
+Examples:
+  scanorama settings update --key scan.timeout --value 30
+  scanorama settings update --key log.level --value '"debug"'
+  scanorama settings update --key feature.enabled --value true`,
+	Run: runSettingsUpdate,
+}
+
+func runSettingsGet(cmd *cobra.Command, args []string) {
+	err := WithAPIClient("get settings", executeSettingsGet)
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func runSettingsUpdate(cmd *cobra.Command, args []string) {
+	err := WithAPIClient("update setting", executeSettingsUpdate)
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func executeSettingsGet(client *APIClient) error {
+	resp, err := client.Get("/admin/settings")
+	if err != nil {
+		return fmt.Errorf("failed to get settings: %w", err)
+	}
+
+	settings, err := parseSettingsResponse(resp.Data)
+	if err != nil {
+		return fmt.Errorf("failed to parse settings response: %w", err)
+	}
+
+	if settingsOutput == outputFormatJSON {
+		displaySettingsJSON(settings)
+	} else {
+		displaySettingsTable(settings)
+	}
+
+	return nil
+}
+
+func executeSettingsUpdate(client *APIClient) error {
+	payload := map[string]string{
+		"key":   settingsKey,
+		"value": settingsValue,
+	}
+
+	resp, err := client.Put("/admin/settings", payload)
+	if err != nil {
+		return fmt.Errorf("failed to update setting: %w", err)
+	}
+
+	result, err := parseUpdateResponse(resp.Data)
+	if err != nil {
+		return fmt.Errorf("failed to parse update response: %w", err)
+	}
+
+	if updated, ok := result["updated"].(bool); ok && updated {
+		fmt.Printf("Setting %q updated successfully.\n", settingsKey)
+	} else {
+		fmt.Printf("Setting %q update response received (key: %v).\n",
+			settingsKey, result["key"])
+	}
+
+	return nil
+}
+
+// parseSettingsResponse re-marshals the untyped API response data into a
+// typed []Setting slice via JSON round-trip.
+func parseSettingsResponse(data interface{}) ([]Setting, error) {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+
+	var wrapper struct {
+		Settings []Setting `json:"settings"`
+	}
+	if err := json.Unmarshal(raw, &wrapper); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+
+	if wrapper.Settings == nil {
+		return make([]Setting, 0), nil
+	}
+
+	return wrapper.Settings, nil
+}
+
+// parseUpdateResponse re-marshals the untyped API response data into a
+// map[string]interface{} for flexible field access.
+func parseUpdateResponse(data interface{}) (map[string]interface{}, error) {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+
+	return result, nil
+}
+
+// truncateValue shortens a string to at most maxLen characters, appending "..."
+// if truncation occurred.
+func truncateValue(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// displaySettingsTable renders settings as an ASCII table to stdout.
+func displaySettingsTable(settings []Setting) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.Header("Key", "Type", "Value", "Description", "Updated")
+
+	for i := range settings {
+		s := &settings[i]
+		_ = table.Append([]string{
+			s.Key,
+			s.Type,
+			truncateValue(s.Value, settingsMaxValueLen),
+			s.Description,
+			s.UpdatedAt,
+		})
+	}
+
+	_ = table.Render()
+}
+
+// displaySettingsJSON renders settings as indented JSON to stdout.
+func displaySettingsJSON(settings []Setting) {
+	output := struct {
+		Settings []Setting `json:"settings"`
+		Count    int       `json:"count"`
+	}{
+		Settings: settings,
+		Count:    len(settings),
+	}
+
+	jsonData, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling JSON: %v\n", err)
+		return
+	}
+
+	fmt.Println(string(jsonData))
+}
+
+func init() {
+	rootCmd.AddCommand(settingsCmd)
+	settingsCmd.AddCommand(settingsGetCmd)
+	settingsCmd.AddCommand(settingsUpdateCmd)
+
+	// get flags
+	settingsGetCmd.Flags().StringVarP(&settingsOutput, "output", "o", "table",
+		"Output format (table, json)")
+
+	// update flags
+	settingsUpdateCmd.Flags().StringVar(&settingsKey, "key", "",
+		"Setting key to update (required)")
+	settingsUpdateCmd.Flags().StringVar(&settingsValue, "value", "",
+		"New value as valid JSON (required) — e.g. true, 42, or '\"text\"'")
+	_ = settingsUpdateCmd.MarkFlagRequired("key")
+	_ = settingsUpdateCmd.MarkFlagRequired("value")
+}

--- a/cmd/cli/settings_test.go
+++ b/cmd/cli/settings_test.go
@@ -1,0 +1,335 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── displaySettingsTable ────────────────────────────────────────────────────
+
+func TestDisplaySettingsTable(t *testing.T) {
+	tests := []struct {
+		name             string
+		settings         []Setting
+		expectedHeaders  []string
+		expectedRowCount int
+		expectedContains []string
+	}{
+		{
+			name:             "empty_list",
+			settings:         []Setting{},
+			expectedHeaders:  []string{"KEY", "TYPE", "VALUE", "DESCRIPTION", "UPDATED"},
+			expectedRowCount: 0,
+		},
+		{
+			name: "single_setting",
+			settings: []Setting{
+				{
+					Key:         "scan.timeout",
+					Value:       "30",
+					Description: "Scan timeout in seconds",
+					Type:        "int",
+					UpdatedAt:   "2024-01-15T10:00:00Z",
+				},
+			},
+			expectedHeaders:  []string{"KEY", "TYPE", "VALUE", "DESCRIPTION", "UPDATED"},
+			expectedRowCount: 1,
+			expectedContains: []string{"scan.timeout", "30", "int", "Scan timeout in seconds"},
+		},
+		{
+			name: "multiple_settings",
+			settings: []Setting{
+				{
+					Key:         "log.level",
+					Value:       `"info"`,
+					Description: "Logging level",
+					Type:        "string",
+					UpdatedAt:   "2024-01-10T08:00:00Z",
+				},
+				{
+					Key:         "feature.enabled",
+					Value:       "true",
+					Description: "Feature flag",
+					Type:        "bool",
+					UpdatedAt:   "2024-01-12T09:30:00Z",
+				},
+				{
+					Key:         "scan.timeout",
+					Value:       "30",
+					Description: "Scan timeout in seconds",
+					Type:        "int",
+					UpdatedAt:   "2024-01-14T11:45:00Z",
+				},
+			},
+			expectedHeaders:  []string{"KEY", "TYPE", "VALUE", "DESCRIPTION", "UPDATED"},
+			expectedRowCount: 3,
+			expectedContains: []string{
+				"log.level", "feature.enabled", "scan.timeout",
+				"string", "bool", "int",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := captureStdout(t, func() {
+				displaySettingsTable(tt.settings)
+			})
+
+			for _, hdr := range tt.expectedHeaders {
+				assert.Contains(t, output, hdr,
+					"table should contain header %q", hdr)
+			}
+
+			for _, want := range tt.expectedContains {
+				assert.Contains(t, output, want,
+					"table should contain %q", want)
+			}
+
+			// Count data rows (lines with at least two │ separators, excluding
+			// the header row which contains the column name "KEY").
+			lines := strings.Split(output, "\n")
+			dataRows := 0
+			for _, line := range lines {
+				if strings.TrimSpace(line) == "" {
+					continue
+				}
+				if strings.Contains(line, "─") ||
+					strings.Contains(line, "┼") ||
+					strings.Contains(line, "┌") ||
+					strings.Contains(line, "└") ||
+					strings.Contains(line, "KEY") {
+					continue
+				}
+				if strings.Count(line, "│") >= 2 {
+					dataRows++
+				}
+			}
+
+			assert.Equal(t, tt.expectedRowCount, dataRows,
+				"expected %d data rows, got %d; output:\n%s",
+				tt.expectedRowCount, dataRows, output)
+		})
+	}
+}
+
+// ─── displaySettingsTable — value truncation ─────────────────────────────────
+
+func TestDisplaySettingsTableTruncatesLongValues(t *testing.T) {
+	longValue := strings.Repeat("x", 60) // 60 chars > settingsMaxValueLen (40)
+
+	settings := []Setting{
+		{
+			Key:         "some.key",
+			Value:       longValue,
+			Description: "desc",
+			Type:        "string",
+			UpdatedAt:   "2024-01-01T00:00:00Z",
+		},
+	}
+
+	output := captureStdout(t, func() {
+		displaySettingsTable(settings)
+	})
+
+	// The full 60-char value must not appear verbatim.
+	assert.NotContains(t, output, longValue,
+		"long value should be truncated in table output")
+
+	// An ellipsis must be present to signal truncation.
+	assert.Contains(t, output, "...",
+		"truncated value should end with '...'")
+}
+
+// ─── displaySettingsJSON ──────────────────────────────────────────────────────
+
+func TestDisplaySettingsJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings []Setting
+	}{
+		{
+			name:     "empty_list",
+			settings: []Setting{},
+		},
+		{
+			name: "single_setting",
+			settings: []Setting{
+				{
+					Key:         "scan.timeout",
+					Value:       "30",
+					Description: "Scan timeout in seconds",
+					Type:        "int",
+					UpdatedAt:   "2024-01-15T10:00:00Z",
+				},
+			},
+		},
+		{
+			name: "multiple_settings",
+			settings: []Setting{
+				{
+					Key:         "log.level",
+					Value:       `"info"`,
+					Description: "Logging level",
+					Type:        "string",
+					UpdatedAt:   "2024-01-10T08:00:00Z",
+				},
+				{
+					Key:         "feature.enabled",
+					Value:       "true",
+					Description: "Feature flag",
+					Type:        "bool",
+					UpdatedAt:   "2024-01-12T09:30:00Z",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := captureStdout(t, func() {
+				displaySettingsJSON(tt.settings)
+			})
+
+			require.NotEmpty(t, output, "JSON output must not be empty")
+
+			// Must be valid JSON.
+			var raw map[string]interface{}
+			require.NoError(t, json.Unmarshal([]byte(output), &raw),
+				"output must be valid JSON; got:\n%s", output)
+
+			// Top-level keys must be present.
+			assert.Contains(t, raw, "settings", "JSON must contain 'settings' key")
+			assert.Contains(t, raw, "count", "JSON must contain 'count' key")
+
+			// 'count' must equal len(settings).
+			count, ok := raw["count"].(float64)
+			require.True(t, ok, "'count' must be a number")
+			assert.Equal(t, float64(len(tt.settings)), count)
+
+			// 'settings' must be an array of the correct length.
+			arr, ok := raw["settings"].([]interface{})
+			require.True(t, ok, "'settings' must be an array")
+			assert.Len(t, arr, len(tt.settings))
+
+			// Each element must carry the expected field names.
+			for i, elem := range arr {
+				obj, ok := elem.(map[string]interface{})
+				require.True(t, ok, "settings[%d] must be an object", i)
+
+				for _, field := range []string{"key", "value", "description", "type", "updated_at"} {
+					assert.Contains(t, obj, field,
+						"settings[%d] must contain field %q", i, field)
+				}
+
+				// Verify the key value matches.
+				assert.Equal(t, tt.settings[i].Key, obj["key"],
+					"settings[%d].key mismatch", i)
+			}
+
+			// Output must be indented (pretty-printed).
+			assert.Contains(t, output, "  ",
+				"JSON output should be indented")
+		})
+	}
+}
+
+// ─── Command structure ────────────────────────────────────────────────────────
+
+func TestSettingsCommandStructure(t *testing.T) {
+	t.Run("settings help lists subcommands", func(t *testing.T) {
+		out, errOut, err := executeCommand("settings", "--help")
+
+		require.NoError(t, err)
+		all := combined(out, errOut)
+		assert.Contains(t, all, "get",
+			"settings help should list the 'get' subcommand")
+		assert.Contains(t, all, "update",
+			"settings help should list the 'update' subcommand")
+	})
+
+	t.Run("settings get help shows output flag", func(t *testing.T) {
+		out, errOut, err := executeCommand("settings", "get", "--help")
+
+		require.NoError(t, err)
+		all := combined(out, errOut)
+		assert.Contains(t, all, "--output",
+			"settings get help should document the --output flag")
+	})
+
+	t.Run("settings update help shows key and value flags", func(t *testing.T) {
+		out, errOut, err := executeCommand("settings", "update", "--help")
+
+		require.NoError(t, err)
+		all := combined(out, errOut)
+		assert.Contains(t, all, "--key",
+			"settings update help should document the --key flag")
+		assert.Contains(t, all, "--value",
+			"settings update help should document the --value flag")
+	})
+
+	t.Run("settings update with no flags returns error", func(t *testing.T) {
+		_, _, err := executeCommand("settings", "update")
+		assert.Error(t, err,
+			"settings update without --key and --value must fail")
+	})
+
+	t.Run("settings update with only --key returns error", func(t *testing.T) {
+		_, _, err := executeCommand("settings", "update", "--key", "some.key")
+		assert.Error(t, err,
+			"settings update without --value must fail")
+	})
+
+	t.Run("settings update with only --value returns error", func(t *testing.T) {
+		_, _, err := executeCommand("settings", "update", "--value", "true")
+		assert.Error(t, err,
+			"settings update without --key must fail")
+	})
+}
+
+// ─── truncateValue unit tests ─────────────────────────────────────────────────
+
+func TestTruncateValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxLen   int
+		expected string
+	}{
+		{
+			name:     "short_value_unchanged",
+			input:    "hello",
+			maxLen:   10,
+			expected: "hello",
+		},
+		{
+			name:     "exact_length_unchanged",
+			input:    "hello",
+			maxLen:   5,
+			expected: "hello",
+		},
+		{
+			name:     "long_value_truncated",
+			input:    "hello world this is a very long value",
+			maxLen:   10,
+			expected: "hello w...",
+		},
+		{
+			name:     "empty_string",
+			input:    "",
+			maxLen:   10,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateValue(tt.input, tt.maxLen)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/cmd/cli/smart_scan.go
+++ b/cmd/cli/smart_scan.go
@@ -1,0 +1,410 @@
+// Package cli provides command-line interface commands for the Scanorama network scanner.
+// This file implements the smart-scan subcommand group for adaptive scanning operations.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+// Smart-scan endpoint paths.
+const (
+	smartScanSuggestionsPath  = "/smart-scan/suggestions"
+	smartScanProfileRecsPath  = "/smart-scan/profile-recommendations"
+	smartScanHostsBasePath    = "/smart-scan/hosts/"
+	smartScanTriggerBatchPath = "/smart-scan/trigger-batch"
+	smartScanStageSuffix      = "/stage"
+	smartScanTriggerSuffix    = "/trigger"
+)
+
+// SuggestionGroup describes a category of smart-scan suggestions.
+type SuggestionGroup struct {
+	Count       int    `json:"count"`
+	Description string `json:"description"`
+	Action      string `json:"action"`
+}
+
+// SuggestionSummary is the response shape for GET /smart-scan/suggestions.
+type SuggestionSummary struct {
+	NoOSInfo    SuggestionGroup `json:"no_os_info"`
+	NoPorts     SuggestionGroup `json:"no_ports"`
+	NoServices  SuggestionGroup `json:"no_services"`
+	Stale       SuggestionGroup `json:"stale"`
+	WellKnown   SuggestionGroup `json:"well_known"`
+	TotalHosts  int             `json:"total_hosts"`
+	GeneratedAt string          `json:"generated_at"`
+}
+
+// ProfileRecommendation is one element of the GET /smart-scan/profile-recommendations array.
+type ProfileRecommendation struct {
+	OSFamily    string `json:"os_family"`
+	HostCount   int    `json:"host_count"`
+	ProfileID   string `json:"profile_id"`
+	ProfileName string `json:"profile_name"`
+	Action      string `json:"action"`
+}
+
+// ScanStage is the response shape for GET /smart-scan/hosts/{id}/stage.
+type ScanStage struct {
+	Stage       string  `json:"stage"`
+	ScanType    string  `json:"scan_type"`
+	Ports       string  `json:"ports"`
+	OSDetection bool    `json:"os_detection"`
+	ProfileID   *string `json:"profile_id,omitempty"`
+	Reason      string  `json:"reason"`
+}
+
+var (
+	smartScanOutput       string
+	smartScanTriggerStage string
+	smartScanTriggerLimit int
+)
+
+// smartScanCmd is the root of the smart-scan command group.
+var smartScanCmd = &cobra.Command{
+	Use:   "smart-scan",
+	Short: "Adaptive smart-scan operations",
+	Long: `Interact with the Scanorama smart-scan subsystem.
+
+Smart-scan analyses the current state of discovered hosts and recommends
+the most appropriate next scan action for each host based on what data is
+already present.
+
+Examples:
+  # View suggestions for which hosts need additional scanning
+  scanorama smart-scan suggestions
+
+  # View profile recommendations grouped by OS family
+  scanorama smart-scan profile-recommendations
+
+  # Show the recommended scan stage for a specific host
+  scanorama smart-scan stage <host-id>
+
+  # Trigger the next recommended scan for a host
+  scanorama smart-scan trigger <host-id>
+
+  # Batch-trigger scans for eligible hosts
+  scanorama smart-scan trigger-batch --stage initial --limit 50`,
+	Run: func(cmd *cobra.Command, args []string) {
+		_ = cmd.Help()
+	},
+}
+
+// smartScanSuggestionsCmd handles smart-scan suggestions.
+var smartScanSuggestionsCmd = &cobra.Command{
+	Use:   "suggestions",
+	Short: "Show smart-scan suggestions",
+	Long:  `Retrieve a summary of hosts that would benefit from additional scanning.`,
+	Run:   runSmartScanSuggestions,
+}
+
+// smartScanProfileRecsCmd handles smart-scan profile-recommendations.
+var smartScanProfileRecsCmd = &cobra.Command{
+	Use:   "profile-recommendations",
+	Short: "Show per-OS profile recommendations",
+	Long:  `Retrieve profile recommendations for each OS family present in the inventory.`,
+	Run:   runSmartScanProfileRecs,
+}
+
+// smartScanStageCmd handles smart-scan stage <host-id>.
+var smartScanStageCmd = &cobra.Command{
+	Use:   "stage <host-id>",
+	Short: "Show the recommended scan stage for a host",
+	Long:  `Retrieve the recommended next scan stage for the specified host UUID.`,
+	Args:  cobra.ExactArgs(1),
+	Run:   runSmartScanStage,
+}
+
+// smartScanTriggerCmd handles smart-scan trigger <host-id>.
+var smartScanTriggerCmd = &cobra.Command{
+	Use:   "trigger <host-id>",
+	Short: "Trigger the next recommended scan for a host",
+	Long:  `Enqueue the next recommended scan for the specified host UUID.`,
+	Args:  cobra.ExactArgs(1),
+	Run:   runSmartScanTrigger,
+}
+
+// smartScanTriggerBatchCmd handles smart-scan trigger-batch.
+var smartScanTriggerBatchCmd = &cobra.Command{
+	Use:   "trigger-batch",
+	Short: "Batch-trigger smart scans for eligible hosts",
+	Long: `Enqueue smart scans for multiple eligible hosts in one call.
+
+Use --stage to restrict the batch to a specific scan stage.
+Use --limit to cap the number of hosts queued (0 = service default).`,
+	Run: runSmartScanTriggerBatch,
+}
+
+func init() {
+	rootCmd.AddCommand(smartScanCmd)
+
+	smartScanCmd.AddCommand(smartScanSuggestionsCmd)
+	smartScanCmd.AddCommand(smartScanProfileRecsCmd)
+	smartScanCmd.AddCommand(smartScanStageCmd)
+	smartScanCmd.AddCommand(smartScanTriggerCmd)
+	smartScanCmd.AddCommand(smartScanTriggerBatchCmd)
+
+	smartScanSuggestionsCmd.Flags().StringVarP(
+		&smartScanOutput, "output", "o", "table", "Output format (table, json)")
+	smartScanProfileRecsCmd.Flags().StringVarP(
+		&smartScanOutput, "output", "o", "table", "Output format (table, json)")
+	smartScanStageCmd.Flags().StringVarP(
+		&smartScanOutput, "output", "o", "table", "Output format (table, json)")
+
+	smartScanTriggerBatchCmd.Flags().StringVar(
+		&smartScanTriggerStage, "stage", "", "Restrict batch to this scan stage (optional)")
+	smartScanTriggerBatchCmd.Flags().IntVar(
+		&smartScanTriggerLimit, "limit", 0, "Maximum hosts to queue (0 = service default)")
+	smartScanTriggerBatchCmd.Flags().StringVarP(
+		&smartScanOutput, "output", "o", "table", "Output format (table, json)")
+}
+
+// --- run functions ---
+
+func runSmartScanSuggestions(_ *cobra.Command, _ []string) {
+	if err := WithAPIClient("smart-scan suggestions", func(client *APIClient) error {
+		resp, err := client.Get(smartScanSuggestionsPath)
+		if err != nil {
+			return err
+		}
+		summary, err := unmarshalAs[SuggestionSummary](resp.Data)
+		if err != nil {
+			return fmt.Errorf("unexpected response format: %w", err)
+		}
+		if smartScanOutput == outputFormatJSON {
+			displaySuggestionsJSON(summary)
+		} else {
+			displaySuggestionsTable(summary)
+		}
+		return nil
+	}); err != nil {
+		os.Exit(1)
+	}
+}
+
+func runSmartScanProfileRecs(_ *cobra.Command, _ []string) {
+	if err := WithAPIClient("smart-scan profile-recommendations", func(client *APIClient) error {
+		resp, err := client.Get(smartScanProfileRecsPath)
+		if err != nil {
+			return err
+		}
+		recs, err := unmarshalAs[[]ProfileRecommendation](resp.Data)
+		if err != nil {
+			return fmt.Errorf("unexpected response format: %w", err)
+		}
+		if smartScanOutput == outputFormatJSON {
+			displayProfileRecommendationsJSON(recs)
+		} else {
+			displayProfileRecommendationsTable(recs)
+		}
+		return nil
+	}); err != nil {
+		os.Exit(1)
+	}
+}
+
+func runSmartScanStage(_ *cobra.Command, args []string) {
+	hostID := args[0]
+	endpoint := smartScanHostsBasePath + hostID + smartScanStageSuffix
+	if err := WithAPIClient("smart-scan stage", func(client *APIClient) error {
+		resp, err := client.Get(endpoint)
+		if err != nil {
+			return err
+		}
+		stage, err := unmarshalAs[ScanStage](resp.Data)
+		if err != nil {
+			return fmt.Errorf("unexpected response format: %w", err)
+		}
+		if smartScanOutput == outputFormatJSON {
+			displayScanStageJSON(stage)
+		} else {
+			displayScanStageTable(stage)
+		}
+		return nil
+	}); err != nil {
+		os.Exit(1)
+	}
+}
+
+func runSmartScanTrigger(_ *cobra.Command, args []string) {
+	hostID := args[0]
+	endpoint := smartScanHostsBasePath + hostID + smartScanTriggerSuffix
+	if err := WithAPIClient("smart-scan trigger", func(client *APIClient) error {
+		resp, err := client.Post(endpoint, nil)
+		if err != nil {
+			return err
+		}
+		return printTriggerResult(resp.Data)
+	}); err != nil {
+		os.Exit(1)
+	}
+}
+
+// printTriggerResult handles the two valid outcomes of POST /smart-scan/hosts/{id}/trigger:
+//   - queued=true  (202): print the scan_id
+//   - queued=false (200): host is already up-to-date; print the message field
+func printTriggerResult(data interface{}) error {
+	m, err := unmarshalAs[map[string]interface{}](data)
+	if err != nil {
+		return fmt.Errorf("unexpected response format: %w", err)
+	}
+
+	queued, _ := m["queued"].(bool)
+	if !queued {
+		msg, _ := m["message"].(string)
+		if msg == "" {
+			msg = "no scan queued (host knowledge is already sufficient)"
+		}
+		fmt.Println(msg)
+		return nil
+	}
+
+	scanID, ok := m["scan_id"].(string)
+	if !ok || scanID == "" {
+		return fmt.Errorf("queued=true but scan_id missing in response")
+	}
+	fmt.Println(scanID)
+	return nil
+}
+
+func runSmartScanTriggerBatch(_ *cobra.Command, _ []string) {
+	payload := map[string]interface{}{
+		"stage": smartScanTriggerStage,
+		"limit": smartScanTriggerLimit,
+	}
+	if err := WithAPIClient("smart-scan trigger-batch", func(client *APIClient) error {
+		resp, err := client.Post(smartScanTriggerBatchPath, payload)
+		if err != nil {
+			return err
+		}
+		result, err := unmarshalAs[map[string]interface{}](resp.Data)
+		if err != nil {
+			return fmt.Errorf("unexpected response format: %w", err)
+		}
+		if smartScanOutput == outputFormatJSON {
+			displayTriggerBatchJSON(result)
+		} else {
+			displayTriggerBatchTable(result)
+		}
+		return nil
+	}); err != nil {
+		os.Exit(1)
+	}
+}
+
+// --- display functions ---
+
+func displaySuggestionsJSON(s SuggestionSummary) {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling JSON: %v\n", err)
+		return
+	}
+	fmt.Println(string(data))
+}
+
+func displaySuggestionsTable(s SuggestionSummary) {
+	fmt.Printf("Smart-scan suggestions (total hosts: %d, generated: %s)\n\n",
+		s.TotalHosts, s.GeneratedAt)
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.Header("Category", "Count", "Description", "Action")
+
+	rows := [][]string{
+		{"no_os_info", fmt.Sprintf("%d", s.NoOSInfo.Count), s.NoOSInfo.Description, s.NoOSInfo.Action},
+		{"no_ports", fmt.Sprintf("%d", s.NoPorts.Count), s.NoPorts.Description, s.NoPorts.Action},
+		{"no_services", fmt.Sprintf("%d", s.NoServices.Count), s.NoServices.Description, s.NoServices.Action},
+		{"stale", fmt.Sprintf("%d", s.Stale.Count), s.Stale.Description, s.Stale.Action},
+		{"well_known", fmt.Sprintf("%d", s.WellKnown.Count), s.WellKnown.Description, s.WellKnown.Action},
+	}
+	for _, row := range rows {
+		_ = table.Append(row)
+	}
+	_ = table.Render()
+}
+
+func displayProfileRecommendationsJSON(recs []ProfileRecommendation) {
+	data, err := json.MarshalIndent(recs, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling JSON: %v\n", err)
+		return
+	}
+	fmt.Println(string(data))
+}
+
+func displayProfileRecommendationsTable(recs []ProfileRecommendation) {
+	if len(recs) == 0 {
+		fmt.Println("No profile recommendations available.")
+		return
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.Header("OS Family", "Host Count", "Profile ID", "Profile Name", "Action")
+
+	for i := range recs {
+		r := &recs[i]
+		_ = table.Append([]string{
+			r.OSFamily,
+			fmt.Sprintf("%d", r.HostCount),
+			r.ProfileID,
+			r.ProfileName,
+			r.Action,
+		})
+	}
+	_ = table.Render()
+}
+
+func displayScanStageJSON(s ScanStage) {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling JSON: %v\n", err)
+		return
+	}
+	fmt.Println(string(data))
+}
+
+func displayScanStageTable(s ScanStage) {
+	fmt.Printf("Stage:        %s\n", s.Stage)
+	fmt.Printf("Scan type:    %s\n", s.ScanType)
+	fmt.Printf("Ports:        %s\n", s.Ports)
+	fmt.Printf("OS detection: %t\n", s.OSDetection)
+	if s.ProfileID != nil {
+		fmt.Printf("Profile ID:   %s\n", *s.ProfileID)
+	}
+	fmt.Printf("Reason:       %s\n", s.Reason)
+}
+
+func displayTriggerBatchJSON(result map[string]interface{}) {
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling JSON: %v\n", err)
+		return
+	}
+	fmt.Println(string(data))
+}
+
+func displayTriggerBatchTable(result map[string]interface{}) {
+	fmt.Printf("Queued:  %v\n", result["queued"])
+	fmt.Printf("Skipped: %v\n", result["skipped"])
+}
+
+// --- helpers ---
+
+// unmarshalAs round-trips v (the raw interface{} from APIResponse.Data) through
+// JSON encoding to produce a strongly-typed value of T.
+func unmarshalAs[T any](v interface{}) (T, error) {
+	var zero T
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return zero, fmt.Errorf("marshal: %w", err)
+	}
+	var result T
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return zero, fmt.Errorf("unmarshal: %w", err)
+	}
+	return result, nil
+}

--- a/cmd/cli/smart_scan_test.go
+++ b/cmd/cli/smart_scan_test.go
@@ -1,0 +1,301 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDisplaySuggestionsJSON verifies that the JSON output contains all
+// expected top-level keys and correct values.
+func TestDisplaySuggestionsJSON(t *testing.T) {
+	summary := SuggestionSummary{
+		NoOSInfo: SuggestionGroup{
+			Count:       3,
+			Description: "Hosts without OS info",
+			Action:      "run OS detection",
+		},
+		NoPorts: SuggestionGroup{
+			Count:       5,
+			Description: "Hosts without port data",
+			Action:      "run port scan",
+		},
+		NoServices: SuggestionGroup{
+			Count:       2,
+			Description: "Hosts without service banners",
+			Action:      "run service scan",
+		},
+		Stale: SuggestionGroup{
+			Count:       7,
+			Description: "Stale hosts",
+			Action:      "re-scan",
+		},
+		WellKnown: SuggestionGroup{
+			Count:       1,
+			Description: "Well-known hosts",
+			Action:      "verify",
+		},
+		TotalHosts:  18,
+		GeneratedAt: "2026-04-15T10:00:00Z",
+	}
+
+	out := captureStdout(t, func() { displaySuggestionsJSON(summary) })
+
+	require.NotEmpty(t, out)
+
+	var raw map[string]interface{}
+	err := json.Unmarshal([]byte(out), &raw)
+	require.NoError(t, err, "output should be valid JSON")
+
+	assert.Contains(t, raw, "no_os_info")
+	assert.Contains(t, raw, "no_ports")
+	assert.Contains(t, raw, "no_services")
+	assert.Contains(t, raw, "stale")
+	assert.Contains(t, raw, "well_known")
+	assert.Contains(t, raw, "total_hosts")
+	assert.Contains(t, raw, "generated_at")
+
+	assert.Equal(t, float64(18), raw["total_hosts"])
+	assert.Equal(t, "2026-04-15T10:00:00Z", raw["generated_at"])
+
+	// JSON output must be indented.
+	assert.Contains(t, out, "  ", "JSON output should be indented")
+}
+
+// TestDisplayProfileRecommendationsTable verifies table output for empty and
+// populated recommendation slices.
+func TestDisplayProfileRecommendationsTable(t *testing.T) {
+	t.Run("empty list", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			displayProfileRecommendationsTable([]ProfileRecommendation{})
+		})
+		assert.Contains(t, out, "No profile recommendations available.")
+	})
+
+	t.Run("populated list", func(t *testing.T) {
+		recs := []ProfileRecommendation{
+			{
+				OSFamily:    "linux",
+				HostCount:   10,
+				ProfileID:   "prof-abc123",
+				ProfileName: "linux-default",
+				Action:      "run version scan",
+			},
+			{
+				OSFamily:    "windows",
+				HostCount:   4,
+				ProfileID:   "prof-def456",
+				ProfileName: "windows-standard",
+				Action:      "run smb scan",
+			},
+		}
+
+		out := captureStdout(t, func() {
+			displayProfileRecommendationsTable(recs)
+		})
+
+		assert.Contains(t, out, "linux")
+		assert.Contains(t, out, "windows")
+		assert.Contains(t, out, "linux-default")
+		assert.Contains(t, out, "windows-standard")
+		assert.Contains(t, out, "run version scan")
+		assert.Contains(t, out, "run smb scan")
+		assert.Contains(t, out, "10")
+		assert.Contains(t, out, "4")
+	})
+}
+
+// TestDisplayScanStageTable verifies that stage and reason appear in output.
+func TestDisplayScanStageTable(t *testing.T) {
+	profileID := "prof-xyz789"
+	stage := ScanStage{
+		Stage:       "service_detection",
+		ScanType:    "version",
+		Ports:       "22,80,443",
+		OSDetection: true,
+		ProfileID:   &profileID,
+		Reason:      "no service data present",
+	}
+
+	out := captureStdout(t, func() { displayScanStageTable(stage) })
+
+	assert.Contains(t, out, "service_detection", "output should contain stage name")
+	assert.Contains(t, out, "no service data present", "output should contain reason")
+	assert.Contains(t, out, "version", "output should contain scan type")
+	assert.Contains(t, out, "22,80,443", "output should contain ports")
+	assert.Contains(t, out, "prof-xyz789", "output should contain profile ID")
+}
+
+func TestDisplayScanStageTable_NoProfileID(t *testing.T) {
+	stage := ScanStage{
+		Stage:       "initial",
+		ScanType:    "connect",
+		Ports:       "1-1024",
+		OSDetection: false,
+		ProfileID:   nil,
+		Reason:      "first scan for host",
+	}
+
+	out := captureStdout(t, func() { displayScanStageTable(stage) })
+
+	assert.Contains(t, out, "initial")
+	assert.Contains(t, out, "first scan for host")
+	assert.NotContains(t, out, "Profile ID", "profile ID line should be absent when nil")
+}
+
+// TestSmartScanCommandStructure verifies the command tree is registered correctly.
+func TestSmartScanCommandStructure(t *testing.T) {
+	t.Run("smart-scan --help is registered", func(t *testing.T) {
+		out, errOut, err := executeCommand("smart-scan", "--help")
+		require.NoError(t, err)
+		all := combined(out, errOut)
+		assert.Contains(t, all, "suggestions",
+			"smart-scan help should list the suggestions subcommand")
+		assert.Contains(t, all, "profile-recommendations",
+			"smart-scan help should list the profile-recommendations subcommand")
+		assert.Contains(t, all, "stage",
+			"smart-scan help should list the stage subcommand")
+		assert.Contains(t, all, "trigger",
+			"smart-scan help should list the trigger subcommand")
+		assert.Contains(t, all, "trigger-batch",
+			"smart-scan help should list the trigger-batch subcommand")
+	})
+
+	t.Run("smart-scan stage requires exactly one arg", func(t *testing.T) {
+		_, _, err := executeCommand("smart-scan", "stage")
+		assert.Error(t, err, "stage with no args should fail")
+	})
+
+	t.Run("smart-scan trigger requires exactly one arg", func(t *testing.T) {
+		_, _, err := executeCommand("smart-scan", "trigger")
+		assert.Error(t, err, "trigger with no args should fail")
+	})
+
+	t.Run("trigger-batch --help shows flags", func(t *testing.T) {
+		out, errOut, err := executeCommand("smart-scan", "trigger-batch", "--help")
+		require.NoError(t, err)
+		all := combined(out, errOut)
+		assert.Contains(t, all, "--stage",
+			"trigger-batch help should document the --stage flag")
+		assert.Contains(t, all, "--limit",
+			"trigger-batch help should document the --limit flag")
+	})
+}
+
+// TestUnmarshalAs verifies the generic round-trip helper.
+func TestUnmarshalAs(t *testing.T) {
+	t.Run("struct round-trip", func(t *testing.T) {
+		input := map[string]interface{}{
+			"stage":        "initial",
+			"scan_type":    "connect",
+			"ports":        "80,443",
+			"os_detection": false,
+			"reason":       "first time",
+		}
+		got, err := unmarshalAs[ScanStage](input)
+		require.NoError(t, err)
+		assert.Equal(t, "initial", got.Stage)
+		assert.Equal(t, "first time", got.Reason)
+	})
+
+	t.Run("slice round-trip", func(t *testing.T) {
+		input := []interface{}{
+			map[string]interface{}{
+				"os_family":    "linux",
+				"host_count":   float64(3),
+				"profile_id":   "p1",
+				"profile_name": "linux-default",
+				"action":       "scan",
+			},
+		}
+		got, err := unmarshalAs[[]ProfileRecommendation](input)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "linux", got[0].OSFamily)
+		assert.Equal(t, 3, got[0].HostCount)
+	})
+}
+
+// TestPrintTriggerResult verifies the trigger response handling:
+// queued=true prints the scan_id; queued=false prints the message.
+func TestPrintTriggerResult(t *testing.T) {
+	t.Run("queued=true prints scan_id", func(t *testing.T) {
+		data := map[string]interface{}{
+			"host_id": "host-abc",
+			"queued":  true,
+			"scan_id": "uuid-abc-123",
+			"message": "",
+		}
+		out := captureStdout(t, func() {
+			err := printTriggerResult(data)
+			require.NoError(t, err)
+		})
+		assert.Contains(t, out, "uuid-abc-123")
+	})
+
+	t.Run("queued=false prints message", func(t *testing.T) {
+		data := map[string]interface{}{
+			"host_id": "host-abc",
+			"queued":  false,
+			"message": "host knowledge is already sufficient",
+		}
+		out := captureStdout(t, func() {
+			err := printTriggerResult(data)
+			require.NoError(t, err)
+		})
+		assert.Contains(t, out, "host knowledge is already sufficient")
+	})
+
+	t.Run("queued=false with no message uses default", func(t *testing.T) {
+		data := map[string]interface{}{"host_id": "host-abc", "queued": false}
+		out := captureStdout(t, func() {
+			err := printTriggerResult(data)
+			require.NoError(t, err)
+		})
+		assert.Contains(t, out, "no scan queued")
+	})
+
+	t.Run("queued=true but scan_id missing returns error", func(t *testing.T) {
+		data := map[string]interface{}{"host_id": "host-abc", "queued": true}
+		err := printTriggerResult(data)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "scan_id missing")
+	})
+}
+
+// TestDisplayTriggerBatchTable verifies queued and skipped counts are printed.
+func TestDisplayTriggerBatchTable(t *testing.T) {
+	result := map[string]interface{}{
+		"queued":  float64(12),
+		"skipped": float64(3),
+		"details": []interface{}{},
+	}
+	out := captureStdout(t, func() { displayTriggerBatchTable(result) })
+	assert.Contains(t, out, "12")
+	assert.Contains(t, out, "3")
+}
+
+// TestDisplayProfileRecommendationsJSON verifies JSON output for recommendations.
+func TestDisplayProfileRecommendationsJSON(t *testing.T) {
+	recs := []ProfileRecommendation{
+		{
+			OSFamily:    "linux",
+			HostCount:   5,
+			ProfileID:   "prof-1",
+			ProfileName: "linux-default",
+			Action:      "scan",
+		},
+	}
+	out := captureStdout(t, func() { displayProfileRecommendationsJSON(recs) })
+
+	require.NotEmpty(t, out)
+	var raw []map[string]interface{}
+	err := json.Unmarshal([]byte(strings.TrimSpace(out)), &raw)
+	require.NoError(t, err, "output should be valid JSON array")
+	require.Len(t, raw, 1)
+	assert.Equal(t, "linux", raw[0]["os_family"])
+	assert.Equal(t, float64(5), raw[0]["host_count"])
+}

--- a/docs/superpowers/specs/2026-04-15-cli-api-parity-design.md
+++ b/docs/superpowers/specs/2026-04-15-cli-api-parity-design.md
@@ -1,0 +1,101 @@
+# CLI/API Parity — High-Priority Gaps (issue #711)
+
+## Scope
+
+Four gaps from the "High priority" tier in issue #711, addressed in a single PR:
+
+1. `groups` subcommand — full CRUD + member management
+2. `settings` subcommand — view and update runtime config
+3. `smart-scan` subcommand — suggestions, profile-recommendations, stage, trigger
+4. `schedule show/list` — add `--output json`; surface next-run from server API
+
+Medium and lower priority items are deferred to a follow-up issue.
+
+---
+
+## Architecture
+
+All four additions follow the same API-client pattern already used by `apikeys.go`:
+- `mustCreateAPIClient()` / `WithAPIClient()` for auth
+- `--output json` → `json.MarshalIndent` to stdout; default → tablewriter table
+- Error handling via `handleAPIError()`
+- One new `.go` file per subcommand; tests in matching `_test.go`
+
+---
+
+## groups subcommand (`cmd/cli/groups.go`)
+
+```
+groups list               [--output json]
+groups show <id>          [--output json]
+groups create <name>      [--description TEXT] [--color HEX] [--output json]
+groups update <id>        [--name NAME] [--description TEXT] [--color HEX]
+groups delete <id>
+groups members <id>       [--output json]
+groups add-member <id>    --hosts <h1,h2,...>
+groups remove-member <id> --hosts <h1,h2,...>
+```
+
+Endpoints: `GET/POST /groups`, `GET/PUT/DELETE /groups/{id}`,
+`GET/POST/DELETE /groups/{id}/hosts`.
+
+Response fields used for display:
+- Group: `id`, `name`, `description`, `color`, `created_at`, `member_count`
+- Member: `id`, `ip_address`, `hostname`, `status`, `last_seen`
+
+---
+
+## settings subcommand (`cmd/cli/settings.go`)
+
+```
+settings get              [--output json]
+settings update           --key KEY --value VALUE
+```
+
+Endpoints: `GET /admin/settings`, `PUT /admin/settings`.
+
+`settings update` sends a partial JSON body `{ "<key>": "<value>" }`. The API
+accepts a partial object and merges; CLI maps `--key`/`--value` to a
+`map[string]string` for the request body.
+
+---
+
+## smart-scan subcommand (`cmd/cli/smart_scan.go`)
+
+```
+smart-scan suggestions                [--output json]
+smart-scan profile-recommendations    [--output json]
+smart-scan stage <host-id>            [--output json]
+smart-scan trigger <host-id>
+smart-scan trigger-batch              [--stage STAGE] [--limit N]
+```
+
+Endpoints: `GET /smart-scan/suggestions`, `GET /smart-scan/profile-recommendations`,
+`GET /smart-scan/hosts/{id}/stage`, `POST /smart-scan/hosts/{id}/trigger`,
+`POST /smart-scan/trigger-batch`.
+
+For `trigger-batch`, `--stage` maps to the `BatchFilter.Stage` field;
+`--limit` maps to `BatchFilter.MaxHosts`.
+
+---
+
+## schedule changes (`cmd/cli/schedule.go`)
+
+- Add `scheduleOutput string` flag to `list` and `show` commands (`--output json`, default `table`).
+- `schedule show` with `--output json`: after loading the job from DB, additionally
+  call `GET /schedules/{id}/next-run` via the API client (best-effort; skip if API
+  unavailable) and include the server-computed next-run in JSON output.
+- Table display is unchanged.
+
+---
+
+## Testing
+
+Each new file gets a `_test.go` covering:
+- Command registration and help text (Cobra structure)
+- Happy-path API mock (success response → expected table/JSON output)
+- Error path (API returns 404 or 500 → error message to stderr, non-zero exit)
+- `--output json` → valid JSON with expected top-level keys
+
+Tests use `httptest.NewServer` to serve mock API responses, setting
+`SCANORAMA_API_KEY` and pointing `baseURL` at the test server.


### PR DESCRIPTION
Closes #711

## Summary

- **`groups`**: Full CRUD subcommand (`list`, `show`, `create`, `update`, `delete`) plus `members`, `add-member`, `remove-member`. Supports `--output json`.
- **`settings`**: `get` and `update` subcommands for runtime configuration via the admin API. Supports `--output json`.
- **`smart-scan`**: `suggestions`, `profile-recommendations`, `stage`, `trigger`, `trigger-batch` subcommands. Supports `--output json`.
- **`schedule list/show`**: Added `--output json` output mode; `show --output json` fetches server-computed next-run via `GET /schedules/{id}/next-run`.
- **`api_client`**: Added `DeleteWithBody` for DELETE with request body. Added `parseAPIResponse` helper that falls back to storing the raw response body as `json.RawMessage` when the server response doesn't use a `{"data": ...}` envelope — fixes silent empty output across all new commands.

## Test plan

- `scanorama groups list` — verify table output lists groups; `--output json` returns `{"groups": [...], "count": N}`
- `scanorama groups members <id>` — verify member list is populated (not empty)
- `scanorama smart-scan trigger <host-id>` — verify prints `scan_id` on 202 and message on 200
- `scanorama settings get` — verify settings table/JSON is non-empty