### PR TITLE
fix: hostname CIDR storage and JSONB binary-format corruption

### DIFF
--- a/internal/db/database_unit_test.go
+++ b/internal/db/database_unit_test.go
@@ -246,8 +246,10 @@ func TestJSONBExtended(t *testing.T) {
 	t.Run("scan_invalid_json", func(t *testing.T) {
 		var j JSONB
 		err := j.Scan(`{invalid json`)
-		assert.NoError(t, err) // Scan doesn't validate JSON, just stores bytes
-		assert.Equal(t, `{invalid json`, string(j))
+		// Scan validates JSON; invalid bytes must silently produce nil rather
+		// than storing garbage that would later break MarshalJSON.
+		assert.NoError(t, err)
+		assert.Nil(t, []byte(j))
 	})
 
 	t.Run("scan_nil", func(t *testing.T) {
@@ -275,7 +277,9 @@ func TestJSONBExtended(t *testing.T) {
 		j := JSONB(`{"test": true}`)
 		val, err := j.Value()
 		assert.NoError(t, err)
-		assert.Equal(t, []byte(`{"test": true}`), val)
+		// Value() must return a string so pq uses text protocol (not binary
+		// bytea encoding which corrupts JSONB on read-back).
+		assert.Equal(t, `{"test": true}`, val)
 	})
 
 	t.Run("marshal_json", func(t *testing.T) {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -175,30 +175,54 @@ func (mac MACAddr) String() string {
 type JSONB json.RawMessage
 
 // Scan implements sql.Scanner for PostgreSQL JSONB type.
+// When the pq driver uses binary wire protocol for a JSONB column it prepends a
+// one-byte version marker (0x01) before the JSON text.  We strip that prefix
+// so callers always receive well-formed JSON bytes.  If the resulting bytes are
+// not valid JSON (e.g. the column contains unexpected binary data), Scan stores
+// nil rather than propagating garbage that would later cause MarshalJSON to fail.
 func (j *JSONB) Scan(value interface{}) error {
 	if value == nil {
 		*j = nil
 		return nil
 	}
 
+	var raw []byte
 	switch v := value.(type) {
 	case []byte:
-		*j = JSONB(v)
-		return nil
+		// Make a copy so we don't hold a reference to the driver-owned buffer.
+		raw = make([]byte, len(v))
+		copy(raw, v)
 	case string:
-		*j = JSONB([]byte(v))
-		return nil
+		raw = []byte(v)
 	default:
 		return fmt.Errorf("cannot scan %T into JSONB", value)
 	}
+
+	// PostgreSQL JSONB binary format: first byte is version 0x01 followed by
+	// JSON text.  Strip the version byte when present.
+	if len(raw) > 1 && raw[0] == 0x01 {
+		raw = raw[1:]
+	}
+
+	if !json.Valid(raw) {
+		*j = nil
+		return nil
+	}
+
+	*j = JSONB(raw)
+	return nil
 }
 
 // Value implements driver.Valuer for PostgreSQL JSONB type.
+// Returning a string (not []byte) ensures pq uses the text wire protocol when
+// binding this value as a query parameter.  This prevents pq from encoding the
+// value as a PostgreSQL bytea in binary mode, which would corrupt the stored
+// JSONB data.
 func (j JSONB) Value() (driver.Value, error) {
 	if j == nil {
 		return nil, nil
 	}
-	return []byte(j), nil
+	return string(j), nil
 }
 
 // String returns the JSON string.

--- a/internal/db/models_test.go
+++ b/internal/db/models_test.go
@@ -291,10 +291,11 @@ func TestJSONB(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, j.String())
 
-			// Test Value method
+			// Test Value method — must return string, not []byte, so that pq uses
+			// the text wire protocol and avoids binary JSONB format corruption.
 			value, err := j.Value()
 			require.NoError(t, err)
-			assert.Equal(t, []byte(tt.expected), value)
+			assert.Equal(t, tt.expected, value)
 
 			// Test Scan with bytes
 			var j2 JSONB
@@ -339,6 +340,63 @@ func TestJSONBEdgeCases(t *testing.T) {
 	err = j.Scan(123)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot scan")
+}
+
+// TestJSONBBinaryFormat tests that JSONB.Scan handles the PostgreSQL binary
+// wire format correctly.  When pq reads a JSONB column over the binary protocol
+// it prepends a version byte (0x01) before the JSON text.  Scan must strip the
+// prefix and return only valid JSON — so MarshalJSON never emits garbage.
+func TestJSONBBinaryFormat(t *testing.T) {
+	t.Run("binary JSONB with 0x01 version prefix is stripped", func(t *testing.T) {
+		jsonText := `{"Server":"Apache","Content-Type":"text/html"}`
+		binary := append([]byte{0x01}, []byte(jsonText)...)
+
+		var j JSONB
+		require.NoError(t, j.Scan(binary))
+		assert.Equal(t, jsonText, j.String())
+
+		// MarshalJSON must succeed and produce the plain JSON text.
+		out, err := j.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, jsonText, string(out))
+	})
+
+	t.Run("binary JSONB via Scan copies bytes, not aliasing driver buffer", func(t *testing.T) {
+		buf := []byte{0x01, '{', '"', 'k', '"', ':', '1', '}'}
+		var j JSONB
+		require.NoError(t, j.Scan(buf))
+
+		// Mutate the original buffer.
+		buf[2] = 'X'
+
+		// JSONB must still hold the original value.
+		assert.Equal(t, `{"k":1}`, j.String())
+	})
+
+	t.Run("corrupt binary bytes scan to nil without error", func(t *testing.T) {
+		// Simulate the corrupt bytes observed in the wild: not valid JSON,
+		// not a 0x01-prefixed JSONB.
+		corrupt := []byte{0x06, 0x00, 0x00, 0x04, 0xa0, 0x00, 0x08, 0xff}
+
+		var j JSONB
+		require.NoError(t, j.Scan(corrupt), "Scan must not error on invalid JSON")
+		assert.Nil(t, j, "corrupt bytes must produce a nil JSONB")
+
+		// MarshalJSON of nil must be "null", never an error.
+		out, err := j.MarshalJSON()
+		require.NoError(t, err)
+		assert.Equal(t, "null", string(out))
+	})
+
+	t.Run("Value returns string not []byte", func(t *testing.T) {
+		var j JSONB
+		require.NoError(t, j.Scan(`{"x":1}`))
+
+		v, err := j.Value()
+		require.NoError(t, err)
+		_, isString := v.(string)
+		assert.True(t, isString, "Value() must return a string so pq uses text protocol")
+	})
 }
 
 // TestConstantValues checks the actual string values of every constant.

--- a/internal/scanning/scan.go
+++ b/internal/scanning/scan.go
@@ -701,6 +701,39 @@ func storeScanResults(
 	return nil
 }
 
+// normaliseToCIDR converts a raw scan target into a CIDR string suitable for
+// the PostgreSQL inet column.  IP addresses get a /32 (IPv4) or /128 (IPv6)
+// host-route suffix.  Hostnames are resolved via DNS; if the first returned
+// address is an IP, it is used.  Plain CIDR strings are returned unchanged.
+// If no normalisation is possible, the original string is returned and the
+// caller will receive a DB-level error.
+func normaliseToCIDR(target string) string {
+	if ip := net.ParseIP(target); ip != nil {
+		if ip.To4() != nil {
+			return ip.String() + "/32"
+		}
+		return ip.String() + "/128"
+	}
+
+	// Already a CIDR — pass through unchanged.
+	if strings.Contains(target, "/") {
+		return target
+	}
+
+	// Hostname — resolve and use the first address.
+	addrs, err := net.LookupHost(target)
+	if err != nil || len(addrs) == 0 {
+		return target // fallback: DB will reject invalid inet values
+	}
+	if resolved := net.ParseIP(addrs[0]); resolved != nil {
+		if resolved.To4() != nil {
+			return resolved.String() + "/32"
+		}
+		return resolved.String() + "/128"
+	}
+	return target
+}
+
 // findOrCreateNetwork finds an existing network by CIDR or creates a new one
 // for ad-hoc (non-API) scan runs.  Returns the network UUID to store as
 // scan_jobs.network_id.
@@ -712,15 +745,7 @@ func findOrCreateNetwork(ctx context.Context, database *db.DB, config *ScanConfi
 	firstTarget := config.Targets[0]
 
 	// Normalise to a CIDR string.
-	cidr := firstTarget
-	ip := net.ParseIP(firstTarget)
-	if ip != nil {
-		if ip.To4() != nil {
-			cidr = ip.String() + "/32"
-		} else {
-			cidr = ip.String() + "/128"
-		}
-	}
+	cidr := normaliseToCIDR(firstTarget)
 
 	// Reuse the network if this CIDR is already known.
 	var id uuid.UUID

--- a/internal/scanning/scan_db_test.go
+++ b/internal/scanning/scan_db_test.go
@@ -1004,6 +1004,39 @@ func TestFindOrCreateNetwork_NameCollision(t *testing.T) {
 	assert.Equal(t, "10.252.0.1/32", name, "fallback name should be the CIDR itself")
 }
 
+// TestFindOrCreateNetwork_Hostname tests that a hostname target is resolved via
+// DNS and stored as an IP/32 (or IP/128) CIDR.  "localhost" reliably resolves
+// to 127.0.0.1 on any developer or CI machine without requiring network access.
+func TestFindOrCreateNetwork_Hostname(t *testing.T) {
+	database := setupTestDB(t)
+	if database == nil {
+		return
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	// Clean up any pre-existing row so the INSERT branch is exercised.
+	_, _ = database.ExecContext(ctx, `DELETE FROM networks WHERE cidr = '127.0.0.1/32'`)
+
+	config := &ScanConfig{
+		Targets:  []string{"localhost"},
+		ScanType: "connect",
+		Ports:    "80",
+	}
+
+	id, err := findOrCreateNetwork(ctx, database, config)
+	require.NoError(t, err, "hostname target should be accepted after DNS resolution")
+	assert.NotEqual(t, uuid.Nil, id)
+
+	// The stored CIDR must be an IP address, not the raw hostname.
+	var cidr string
+	require.NoError(t, database.QueryRowContext(ctx,
+		`SELECT cidr::text FROM networks WHERE id = $1`, id,
+	).Scan(&cidr))
+	assert.NotEqual(t, "localhost", cidr, "raw hostname must not be stored as a CIDR")
+	assert.NotEmpty(t, cidr)
+}
+
 // TestRunScanWithDB_IntegrationTest is an end-to-end test of scanning with database storage.
 func TestRunScanWithDB_IntegrationTest(t *testing.T) {
 	database := setupTestDB(t)


### PR DESCRIPTION
## Summary

Two bugs found while investigating `hegre.uninett.no` failing to scan end-to-end:

- **`fix(scanning)`**: `findOrCreateNetwork()` passed raw hostname strings to the PostgreSQL `inet` column, which only accepts IP addresses or CIDR notation. Extract `normaliseToCIDR()` that resolves hostnames via `net.LookupHost()` before building the `/32` or `/128` host-route CIDR.
- **`fix(db)`**: When pq uses the binary wire protocol for a JSONB column, it prepends a one-byte version marker (`0x01`). `JSONB.Scan` stored these raw bytes verbatim, so `JSONB.MarshalJSON` later emitted invalid JSON — causing `json.NewEncoder(w).Encode(data)` inside `writeJSON` to fail silently after the 200 header was already written. Result: `GET /hosts/{id}` returned HTTP 200 with an empty body for any host whose port_banners row had non-null `http_response_headers`. Fix strips the version byte, validates with `json.Valid()` (nil on failure), and changes `JSONB.Value()` to return `string` so pq uses the text protocol on writes.

Fixes #717
Fixes #718

## Test plan

- [ ] Run `scanorama scan hegre.uninett.no` from the CLI and confirm the scan completes and stores results
- [ ] Hit `GET /api/v1/hosts/<id>` for a host with HTTP banner data and confirm a full JSON body is returned (not empty)
- [ ] Confirm the host-detail page in the UI loads the banner list for an HTTP-serving host

🤖 Generated with [Claude Code](https://claude.com/claude-code)