### PR TITLE
ci(release): drop darwin from goreleaser build matrix

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,11 +5,13 @@ before:
     - go mod tidy
 
 builds:
+  # darwin builds are disabled until the zgrab2 → zmap/zcrypto/ct/x509
+  # no-cgo darwin/arm64 gap is resolved (missing loadSystemRoots). Mac users
+  # can `go install ./cmd/scanorama` locally where CGO defaults to on.
   - main: ./cmd/scanorama
     binary: scanorama
     goos:
       - linux
-      - darwin
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
## Summary

- Remove `darwin` from `.goreleaser.yml` `goos`; the release pipeline now ships linux/amd64 and linux/arm64 binaries plus the existing multi-arch Docker manifest.
- Add an inline comment capturing why darwin is disabled so a future maintainer doesn't re-enable it and hit the same wall.

## Why

Releases v0.25.0 and v0.25.1 both failed — last published tag is v0.24.0. GoReleaser cross-compiles with `CGO_ENABLED=0` (needed for static Linux binaries), but `zmap/zcrypto/ct/x509` — reached via `zgrab2` (added in v0.25.0 for banner enrichment) — has no no-cgo `loadSystemRoots` for darwin/arm64. The gap exists in the latest upstream zcrypto too; bumping the dep does not fix it. See #720 for the full analysis.

Mac users can still `go install ./cmd/scanorama@latest` locally where CGO defaults to on and the build resolves via `root_darwin_armx.go`.

## Out of scope (follow-ups)

- Restore darwin binaries by either (a) running darwin builds on a `macos-latest` runner with CGO=1, or (b) switching the workflow to `goreleaser-cross` so the ubuntu runner has osxcross available.
- The `needs: ci` gate in `release.yml` was satisfied when path filters in `main.yml` skipped all real test jobs on tag pushes; worth tightening so a silent CI-skip can't green-light a release.

Fixes #720

## Test plan

- [ ] Tag v0.25.2 after merge; verify the Release workflow succeeds and publishes the linux binaries + Docker images.
- [ ] Verify `ghcr.io/anstrom/scanorama:v0.25.2` and `:latest` both exist with linux/amd64 + linux/arm64 platforms.
- [ ] Confirm `go install github.com/anstrom/scanorama/cmd/scanorama@v0.25.2` still works on darwin/arm64.