### PR TITLE
feat(api): include device suggestions in discovery diff response

### DIFF
--- a/frontend/src/api/hooks/use-discovery.ts
+++ b/frontend/src/api/hooks/use-discovery.ts
@@ -28,12 +28,23 @@ export interface DiscoveryDiffHost {
   first_seen: string;
 }
 
+export interface DeviceSuggestion {
+  id: string;
+  host_id: string;
+  device_id: string;
+  confidence_score: number;
+  confidence_reason?: string;
+  dismissed: boolean;
+  created_at: string;
+}
+
 export interface DiscoveryDiff {
   job_id: string;
   new_hosts: DiscoveryDiffHost[];
   gone_hosts: DiscoveryDiffHost[];
   changed_hosts: DiscoveryDiffHost[];
   unchanged_count: number;
+  suggestions: DeviceSuggestion[];
 }
 
 // ── Queries ──────────────────────────────────────────────────────────────────

--- a/internal/api/handlers/discovery_diff_mock_test.go
+++ b/internal/api/handlers/discovery_diff_mock_test.go
@@ -95,6 +95,7 @@ func TestDiscoveryHandler_GetDiscoveryDiff(t *testing.T) {
 			GoneHosts:      []db.DiffHost{},
 			ChangedHosts:   []db.DiffHost{},
 			UnchangedCount: 3,
+			Suggestions:    make([]db.DeviceSuggestion, 0),
 		}
 
 		store.EXPECT().

--- a/internal/db/discovery_diff_unit_test.go
+++ b/internal/db/discovery_diff_unit_test.go
@@ -21,8 +21,21 @@ var diffHostColumns = []string{
 	"vendor", "mac_address", "last_seen", "first_seen",
 }
 
+// suggestionColumns are the columns returned by the device suggestions query.
+var suggestionColumns = []string{
+	"id", "host_id", "device_id", "confidence_score", "confidence_reason",
+	"dismissed", "created_at",
+}
+
 // diffStrPtr returns a pointer to the given string — test helper for nullable columns.
 func diffStrPtr(s string) *string { return &s }
+
+// expectEmptySuggestions sets up a mock expectation for the suggestions query
+// returning an empty result set (the common case when no matches exist).
+func expectEmptySuggestions(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("device_suggestions").
+		WillReturnRows(sqlmock.NewRows(suggestionColumns))
+}
 
 // ── TestGetDiscoveryDiff_Unit ─────────────────────────────────────────────────
 
@@ -100,6 +113,9 @@ func TestGetDiscoveryDiff_Unit(t *testing.T) {
 		mock.ExpectQuery("COUNT").
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(10))
 
+		// 6. suggestions for new + changed hosts — empty in this case
+		expectEmptySuggestions(mock)
+
 		diff, err := NewDiscoveryRepository(mockDB).GetDiscoveryDiff(ctx, jobID)
 
 		require.NoError(t, err)
@@ -127,6 +143,7 @@ func TestGetDiscoveryDiff_Unit(t *testing.T) {
 		assert.Equal(t, "up", diff.ChangedHosts[0].Status)
 
 		assert.Equal(t, 7, diff.UnchangedCount)
+		assert.Empty(t, diff.Suggestions)
 
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
@@ -156,6 +173,9 @@ func TestGetDiscoveryDiff_Unit(t *testing.T) {
 		mock.ExpectQuery("COUNT").
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(5))
 
+		// 6. no host IDs → suggestions query is skipped entirely
+		// (no mock expectation needed when both new and changed are empty)
+
 		diff, err := NewDiscoveryRepository(mockDB).GetDiscoveryDiff(ctx, jobID)
 
 		require.NoError(t, err)
@@ -165,6 +185,9 @@ func TestGetDiscoveryDiff_Unit(t *testing.T) {
 		assert.Empty(t, diff.GoneHosts)
 		assert.Empty(t, diff.ChangedHosts)
 		assert.Equal(t, 5, diff.UnchangedCount)
+		// Suggestions serializes as [] not null even when empty.
+		require.NotNil(t, diff.Suggestions)
+		assert.Empty(t, diff.Suggestions)
 
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
@@ -201,11 +224,73 @@ func TestGetDiscoveryDiff_Unit(t *testing.T) {
 		mock.ExpectQuery("COUNT").
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
+		// 6. suggestions for new host (hostID1); changed is empty
+		expectEmptySuggestions(mock)
+
 		diff, err := NewDiscoveryRepository(mockDB).GetDiscoveryDiff(ctx, jobID)
 
 		require.NoError(t, err)
 		require.NotNil(t, diff)
 		assert.Equal(t, 0, diff.UnchangedCount, "unchanged count should be clamped to 0, not negative")
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	// ── suggestions populated ─────────────────────────────────────────────────
+
+	t.Run("suggestions returned for new and changed hosts", func(t *testing.T) {
+		mockDB, mock := newMockDB(t)
+
+		hostID1 := uuid.New()
+		hostID2 := uuid.New()
+		deviceID := uuid.New()
+		suggestionID := uuid.New()
+		reason := "MAC:stable"
+
+		// 1. existence check
+		mock.ExpectQuery("EXISTS").
+			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+		// 2. new hosts: 1 row
+		mock.ExpectQuery("first_seen >= dj").
+			WillReturnRows(sqlmock.NewRows(diffHostColumns).AddRow(
+				hostID1, "10.0.0.1", nil, "up", nil, nil, nil, now, now,
+			))
+
+		// 3. gone hosts: empty
+		mock.ExpectQuery("host_timeout_events").
+			WillReturnRows(sqlmock.NewRows(diffHostColumns))
+
+		// 4. changed hosts: 1 row
+		mock.ExpectQuery("DISTINCT ON").
+			WillReturnRows(sqlmock.NewRows(diffHostColumns).AddRow(
+				hostID2, "10.0.0.2", nil, "up", diffStrPtr("down"), nil, nil, now, now,
+			))
+
+		// 5. total count: 5
+		mock.ExpectQuery("COUNT").
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(5))
+
+		// 6. suggestions: 1 row for hostID1
+		mock.ExpectQuery("device_suggestions").
+			WillReturnRows(sqlmock.NewRows(suggestionColumns).AddRow(
+				suggestionID, hostID1, deviceID, 3, &reason, false, now,
+			))
+
+		diff, err := NewDiscoveryRepository(mockDB).GetDiscoveryDiff(ctx, jobID)
+
+		require.NoError(t, err)
+		require.NotNil(t, diff)
+
+		require.Len(t, diff.Suggestions, 1)
+		s := diff.Suggestions[0]
+		assert.Equal(t, suggestionID, s.ID)
+		assert.Equal(t, hostID1, s.HostID)
+		assert.Equal(t, deviceID, s.DeviceID)
+		assert.Equal(t, 3, s.ConfidenceScore)
+		require.NotNil(t, s.ConfidenceReason)
+		assert.Equal(t, reason, *s.ConfidenceReason)
+		assert.False(t, s.Dismissed)
 
 		require.NoError(t, mock.ExpectationsWereMet())
 	})

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -529,6 +529,9 @@ type DiscoveryDiff struct {
 	GoneHosts      []DiffHost `json:"gone_hosts"`
 	ChangedHosts   []DiffHost `json:"changed_hosts"`
 	UnchangedCount int        `json:"unchanged_count"`
+	// Suggestions are non-dismissed device match candidates for new and
+	// changed hosts in this diff, ordered by confidence_score DESC.
+	Suggestions []DeviceSuggestion `json:"suggestions"`
 }
 
 // DiscoveryCompareDiff summarizes what changed between two discovery runs.

--- a/internal/db/repository_discovery.go
+++ b/internal/db/repository_discovery.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 
 	"github.com/anstrom/scanorama/internal/errors"
 )
@@ -448,13 +449,73 @@ func (r *DiscoveryRepository) GetDiscoveryDiff(ctx context.Context, jobID uuid.U
 		unchanged = 0
 	}
 
+	// ── device suggestions for new and changed hosts ────────────────────────
+	suggestions, err := r.queryDiffSuggestions(ctx, newHosts, changedHosts)
+	if err != nil {
+		return nil, err
+	}
+
 	return &DiscoveryDiff{
 		JobID:          jobID,
 		NewHosts:       newHosts,
 		GoneHosts:      goneHosts,
 		ChangedHosts:   changedHosts,
 		UnchangedCount: unchanged,
+		Suggestions:    suggestions,
 	}, nil
+}
+
+// queryDiffSuggestions returns non-dismissed DeviceSuggestion rows for all
+// hosts that appear in newHosts or changedHosts. Returns an empty (non-nil)
+// slice when none of the hosts have suggestions.
+func (r *DiscoveryRepository) queryDiffSuggestions(
+	ctx context.Context, newHosts, changedHosts []DiffHost,
+) ([]DeviceSuggestion, error) {
+	suggestions := make([]DeviceSuggestion, 0)
+
+	hostIDs := make([]uuid.UUID, 0, len(newHosts)+len(changedHosts))
+	for i := range newHosts {
+		hostIDs = append(hostIDs, newHosts[i].ID)
+	}
+	for i := range changedHosts {
+		hostIDs = append(hostIDs, changedHosts[i].ID)
+	}
+	if len(hostIDs) == 0 {
+		return suggestions, nil
+	}
+
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, host_id, device_id, confidence_score, confidence_reason, dismissed, created_at
+		FROM device_suggestions
+		WHERE host_id = ANY($1)
+		  AND dismissed = FALSE
+		ORDER BY confidence_score DESC, created_at ASC`,
+		pq.Array(hostIDs),
+	)
+	if err != nil {
+		return nil, sanitizeDBError("query device suggestions for diff", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Warn("failed to close suggestion rows", "error", err)
+		}
+	}()
+
+	for rows.Next() {
+		var s DeviceSuggestion
+		if err := rows.Scan(
+			&s.ID, &s.HostID, &s.DeviceID,
+			&s.ConfidenceScore, &s.ConfidenceReason,
+			&s.Dismissed, &s.CreatedAt,
+		); err != nil {
+			return nil, sanitizeDBError("scan device suggestion for diff", err)
+		}
+		suggestions = append(suggestions, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate suggestion rows: %w", err)
+	}
+	return suggestions, nil
 }
 
 // queryDiffHosts runs a single diff-host query and scans the results into a


### PR DESCRIPTION
## Summary

- Adds `Suggestions []DeviceSuggestion` field to `DiscoveryDiff` model
- `GetDiscoveryDiff` now queries `device_suggestions` for all new and changed hosts in the diff, returning non-dismissed candidates ordered by `confidence_score DESC`
- Empty suggestions serialize as `[]` not `null`
- Suggestions for gone hosts are excluded (they're already gone — no action needed)

## Test plan

- Verify `GET /api/v1/discovery/{id}/diff` response includes `"suggestions": [...]`
- Verify an empty result returns `"suggestions": []` not `null`

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)