### PR TITLE
test(handlers): fix network list test isolation against shared DB

### DIFF
--- a/internal/api/handlers/networks_test.go
+++ b/internal/api/handlers/networks_test.go
@@ -136,13 +136,13 @@ func TestNetworkHandler_ListNetworks(t *testing.T) {
 	}{
 		{
 			name:             "list all active networks",
-			queryParams:      map[string]string{},
+			queryParams:      map[string]string{"name": "HandlerTest"},
 			expectedCount:    2,
 			expectedContains: []string{activeNetworkName, anotherActiveNetworkName},
 		},
 		{
 			name:             "list all networks including inactive",
-			queryParams:      map[string]string{"show_inactive": "true"},
+			queryParams:      map[string]string{"name": "HandlerTest", "show_inactive": "true"},
 			expectedCount:    3,
 			expectedContains: []string{activeNetworkName, inactiveNetworkName, anotherActiveNetworkName},
 		},


### PR DESCRIPTION
## Summary

- The two list-all subtests in `TestNetworkHandler_ListNetworks` asserted exact row counts against a shared test database that retains networks from other test runs (e.g. `backfill-test`, `corp`, `dmz`)
- Added a `name: "HandlerTest"` filter to scope each subtest to only the rows it created — matching the approach already used by the passing `filter_by_name` subtests
- No test logic changed; the cleanup pattern (`HandlerTest%`) already deletes these rows before/after each test

## Test plan

- CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)