### PR TITLE
fix(api): accept loopback origin aliases in WebSocket CheckOrigin

### DIFF
--- a/internal/api/handlers/websocket.go
+++ b/internal/api/handlers/websocket.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -26,7 +28,37 @@ const (
 	maxMessageSize   = 512                                                // Maximum message size allowed from peer
 	bufferSize       = 256                                                // Size of the broadcast channel buffer
 	logsHistoryBurst = 100                                                // Recent log entries sent on connect
+
+	loopbackHostname = "localhost" // hostname alias for loopback; IPs checked via net.IP.IsLoopback
 )
+
+// checkOrigin returns true if the WebSocket upgrade request should be accepted.
+// It allows same-host origins and treats all loopback addresses as equivalent
+// so that a Vite dev proxy (which rewrites Host but not Origin) works correctly.
+func checkOrigin(origin, host string) bool {
+	if origin == "" {
+		return true // non-browser clients send no Origin
+	}
+	if origin == "http://"+host || origin == "https://"+host {
+		return true
+	}
+	originURL, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	originHost := originURL.Hostname()
+	hostName, _, _ := net.SplitHostPort(host)
+	if hostName == "" {
+		hostName = host
+	}
+	isLoopback := func(h string) bool {
+		if ip := net.ParseIP(h); ip != nil {
+			return ip.IsLoopback()
+		}
+		return h == loopbackHostname
+	}
+	return isLoopback(originHost) && isLoopback(hostName)
+}
 
 // WebSocketHandler handles WebSocket connections for real-time updates.
 type WebSocketHandler struct {
@@ -96,14 +128,7 @@ func NewWebSocketHandler(logger *slog.Logger, metricsManager *metrics.Registry) 
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
 			CheckOrigin: func(r *http.Request) bool {
-				origin := r.Header.Get("Origin")
-				if origin == "" {
-					// Non-browser clients (CLI, API consumers) send no Origin header.
-					return true
-				}
-				// Accept connections from the same host (HTTP or HTTPS).
-				host := r.Host
-				return origin == "http://"+host || origin == "https://"+host
+				return checkOrigin(r.Header.Get("Origin"), r.Host)
 			},
 		},
 		scanClients:        make(map[*websocket.Conn]bool),

--- a/internal/api/handlers/websocket_test.go
+++ b/internal/api/handlers/websocket_test.go
@@ -22,6 +22,52 @@ import (
 	"github.com/anstrom/scanorama/internal/metrics"
 )
 
+func TestCheckOrigin(t *testing.T) {
+	tests := []struct {
+		name   string
+		origin string
+		host   string
+		want   bool
+	}{
+		// No origin — non-browser clients always allowed
+		{name: "empty origin", origin: "", host: "127.0.0.1:8080", want: true},
+
+		// Same-host fast path
+		{name: "http same host", origin: "http://127.0.0.1:8080", host: "127.0.0.1:8080", want: true},
+		{name: "https same host", origin: "https://example.com:443", host: "example.com:443", want: true},
+
+		// Vite dev proxy: Host rewritten to 127.0.0.1 but Origin stays localhost
+		{
+			name:   "loopback alias localhost to 127.0.0.1",
+			origin: "http://localhost:5173", host: "127.0.0.1:8080", want: true,
+		},
+		{
+			name:   "loopback alias 127.0.0.1 to localhost",
+			origin: "http://127.0.0.1:5173", host: "localhost:8080", want: true,
+		},
+		{name: "ipv6 loopback origin", origin: "http://[::1]:5173", host: "127.0.0.1:8080", want: true},
+		{name: "ipv6 loopback host", origin: "http://localhost:5173", host: "::1", want: true},
+
+		// Non-loopback origins must be rejected
+		{name: "external origin", origin: "http://evil.com", host: "127.0.0.1:8080", want: false},
+		{name: "different non-loopback host", origin: "http://app.example.com", host: "api.example.com", want: false},
+
+		// Subdomain spoofing must be rejected
+		{name: "localhost subdomain attack", origin: "http://localhost.evil.com", host: "127.0.0.1:8080", want: false},
+		{name: "ip prefix attack", origin: "http://127.0.0.1.attacker.com", host: "127.0.0.1:8080", want: false},
+
+		// Malformed origin
+		{name: "malformed origin", origin: "://not a url", host: "127.0.0.1:8080", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := checkOrigin(tc.origin, tc.host)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestNewWebSocketHandler(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary

- Vite dev proxy with `changeOrigin: true` rewrites the `Host` header but not `Origin`
- A page at `localhost:5173` proxied to `127.0.0.1:8080` arrives at the backend with `Origin: http://localhost:5173` and `Host: 127.0.0.1:8080`, which the strict string-match rejected with 403
- Fixes `CheckOrigin` to treat `localhost`, `127.0.0.1`, and `::1` as equivalent loopback addresses

## Test plan

- Run `make dev`, open the browser — confirm the WS status indicator shows "Live" with no errors in the backend log

🤖 Generated with [Claude Code](https://claude.com/claude-code)