### PR TITLE
feat: host identity resolution & Identity tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,5 +90,8 @@ act-*
 .claude/HANDOFF.md
 HANDOFF.md
 
+# ── Superpowers brainstorm session artifacts ─────────────────────────────────
+.superpowers/
+
 # ── Misc ──────────────────────────────────────────────────────────────────────
 config/environments/*.working.yaml

--- a/docs/superpowers/specs/2026-04-16-host-identity-design.md
+++ b/docs/superpowers/specs/2026-04-16-host-identity-design.md
@@ -1,0 +1,128 @@
+# Host Identity Resolution & UI Surfacing
+
+Date: 2026-04-16
+Status: approved (brainstormed live, sections 1–7 confirmed by user)
+
+## Context
+
+Scanorama collects multiple name-like signals for every host (mDNS `.local`, SNMP `sys_name`, DNS PTR, TLS cert CN/SAN, HTTP banners, and manual edits), but there is no canonical "display name" per host. The dashboard shows `hosts.hostname` when present and the IP otherwise, which leaves many hosts labeled by IP even when richer signals exist. SmartScan's stage machine (`os_detection → port_expansion → service_scan → refresh`) treats absent names as unremarkable, so hosts with open ports and services — but no name — never get enriched further.
+
+## Goals
+
+1. One canonical `display_name` per host, surfaced everywhere in the UI, with IP as a final fallback.
+2. Every name source (automatic and user-defined) is inspectable and promotable.
+3. SmartScan actively fills in missing names instead of considering "has ports+services" sufficient.
+4. User-defined names live in a dedicated column so they are never clobbered by auto-enrichment.
+
+## Non-goals
+
+- Changes to the `devices` model (orthogonal to identity for now).
+- Denormalized candidate lists (compute on read).
+- HTTP `Server`/`<title>` as a name source (too weak; skip).
+
+## Data model
+
+Single migration `027_host_identity.sql`:
+
+- `hosts.custom_name VARCHAR(255) NULL` — user-defined override. Set only through the UI's custom-name input. Always wins when non-null.
+- `hosts.hostname_source VARCHAR(32) NULL` — provenance tag for the existing `hosts.hostname` value. Migration seeds all existing non-null hostnames with `'ptr'`. The legacy inline-edit path continues writing `hosts.hostname` but will tag it `'manual'` until that affordance is removed from the UI.
+- `identity_rank_order` setting stored as a JSONB array on either the existing settings table (to verify during implementation) or a new single-row `identity_settings` table. Default `["mdns","snmp","ptr","cert"]`.
+
+No new tables for candidates — the Identity tab computes them from existing data on every read.
+
+## Resolver (internal/services/identity.go)
+
+```
+ResolveDisplayName(host, cfg) -> { name, source, confidence }
+  if host.custom_name != null:
+    return (custom_name, "custom", 1.0)
+  for source in cfg.identity_rank_order:
+    if c := lookupCandidate(host, source); c != nil:
+      return c
+  return (host.ip_address, "ip", 0)
+```
+
+`ListCandidates(host) -> []Candidate` reuses the same per-source lookup and returns every value (usable or not) with `{ name, source, usable, not_usable_reason, observed_at }`.
+
+Per-source rules:
+
+- **mdns** — `hosts.mdns_name` non-null and ending in `.local`.
+- **snmp** — `host_snmp_data.sys_name` non-empty, printable ASCII, ≤253 chars.
+- **ptr** — most recent PTR in `host_dns_records` that passes `DNSNameIsUsable`. Rejected entries keep their row but are marked `usable: false` with `not_usable_reason: "ISP pattern"` (or whichever rule fired).
+- **cert** — `subject_cn` or first `sans[]` entry whose forward A/AAAA lookup resolves back to this host's IP. Unmatched certs appear unusable with `not_usable_reason: "no reverse-match"`.
+
+Unknown sources in the config array are logged and skipped — no panic.
+
+## SmartScan stage
+
+New stage `identity_enrichment` slots between `os_detection` and `port_expansion`:
+
+```
+if host.status == 'up' && ResolveDisplayName(host).source == "ip":
+  return ScanStage{Stage: "identity_enrichment", …}
+```
+
+Runs three enrichers in parallel with independent timeouts:
+
+- mDNS unicast probe (existing `MDNSEnricher`).
+- SNMP walk (only if `:161` observed open in a prior scan; uses configured communities).
+- Fresh DNS lookup — PTR via `DNSEnricher` with the quality filter, plus forward A/AAAA for any candidate cert CNs to establish reverse-match.
+
+Stage succeeds if at least one new usable candidate lands. The existing auto-progression rate limits apply unchanged.
+
+## API
+
+Extend `HostResponse`:
+
+- `display_name` (string, always present — IP when nothing else)
+- `display_name_source` (string enum: `custom`, `mdns`, `snmp`, `ptr`, `cert`, `ip`)
+- `custom_name` (string, omitempty)
+- `name_candidates` — array, always present, `make([]NameCandidateResponse, 0)` when empty
+
+Two new endpoints:
+
+- `PATCH /hosts/{id}/custom-name` — body `{ "custom_name": "..." | null }`. Null clears the override. 400 on empty string, over 255 chars, or disallowed characters. 404 on unknown host id.
+- `POST /hosts/{id}/refresh-identity` — enqueues a one-off identity_enrichment run. Returns 202 + scan-job id. 409 if the host has a refresh already in progress.
+
+Swagger regen via `make docs` is required for frontend type sync.
+
+## UI (frontend/src/routes/hosts.tsx)
+
+Two surfaces:
+
+1. **Overview tab — chevron quick-peek.** `▾` next to the name opens a compact read-only panel with the top 3–4 ranked candidates (source + last-observed). Link "Manage in Identity tab →" at the bottom. No edit controls.
+2. **Identity tab — full management.** New tab between Overview and Ports. Contents:
+   - Custom-name text input + Save (empty clears the override).
+   - Full ranked candidate table including unusable rows with their `not_usable_reason` in muted red.
+   - "use" link per usable row: one-click promotion to `custom_name`.
+   - "Refresh identity now" button calling `POST /hosts/{id}/refresh-identity`; polls the job status.
+   - Helper line: "Last refresh: X ago · auto-runs via SmartScan when host lacks a name".
+3. **Host list** — primary label becomes `display_name`. Source badge shown on hover.
+
+Components:
+
+- `<HostIdentityPanel mode="compact" | "full">` — one component, two layouts.
+- `useHostIdentity(hostId)` — wraps `useHost`, exposes `display_name`, `name_candidates`, and a `setCustomName` mutation.
+- `useRefreshIdentity(hostId)` — wraps the POST endpoint.
+
+The existing inline-edit of `hosts.hostname` is removed from Overview; all user edits now go through the Identity tab's `custom_name` input.
+
+## Backfill & rollout
+
+- Migration seeds `hostname_source='ptr'` for existing non-null hostnames; `custom_name` starts null.
+- No big-bang enrichment job. SmartScan drains unnamed hosts on its normal cadence. For targeted acceleration operators can use the per-host refresh button or the existing `POST /smart-scan/batch` endpoint.
+- Ranking config changes take effect immediately because `display_name` is computed on read.
+
+## Testing
+
+Backend:
+- `internal/services/identity_test.go` — table-driven resolver: every rank order, custom override, filtered PTR, unmatched cert, unknown-source-in-config, empty inputs, fallback to IP.
+- `internal/services/smartscan_test.go` — new cases for `identity_enrichment` stage selection.
+- `internal/api/handlers/host_test.go` — PATCH custom-name (200 / 400 / 404) and POST refresh-identity (202 / 404 / 409).
+
+Frontend:
+- `HostIdentityPanel.test.tsx` — compact + full modes, promote-candidate flow, filtered-row reason rendering.
+- `use-hosts.test.ts` — extend with `useHostIdentity` and `useRefreshIdentity` (loading/success/error).
+- `hosts.test.tsx` — new hooks mocked per the dashboard-test-mocks pattern; Identity tab renders.
+
+All tests assert observable behavior (returned candidate, rendered text, API call body) — no tautological assertions.

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1616,6 +1616,78 @@ const docTemplate = `{
                 }
             }
         },
+        "/hosts/{id}/custom-name": {
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "PATCH the user-defined display-name override. Pass {\"custom_name\": null} or empty string to clear.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Hosts"
+                ],
+                "summary": "Set or clear a host's custom display name",
+                "operationId": "updateHostCustomName",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Host UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Custom name payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/docs.CustomNameRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.HostResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/liveness": {
             "get": {
                 "description": "Returns simple liveness status without dependency checks",
@@ -4064,6 +4136,72 @@ const docTemplate = `{
                 }
             }
         },
+        "/smart-scan/hosts/{id}/refresh-identity": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Queues an identity_enrichment scan for a host, probing mDNS/SNMP/DNS/TLS surfaces so post-scan enrichment can fill in name signals. Runs even when the host already has a usable name.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Smart Scan"
+                ],
+                "summary": "Refresh host identity",
+                "operationId": "refreshHostIdentity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Host UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/docs.RefreshIdentityResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/smart-scan/hosts/{id}/stage": {
             "get": {
                 "security": [
@@ -4760,6 +4898,15 @@ const docTemplate = `{
                         "discovery"
                     ],
                     "example": "scan"
+                }
+            }
+        },
+        "docs.CustomNameRequest": {
+            "type": "object",
+            "properties": {
+                "custom_name": {
+                    "type": "string",
+                    "example": "office-router"
                 }
             }
         },
@@ -5786,6 +5933,23 @@ const docTemplate = `{
                 "unique_hosts": {
                     "type": "integer",
                     "example": 7
+                }
+            }
+        },
+        "docs.RefreshIdentityResponse": {
+            "type": "object",
+            "properties": {
+                "host_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440002"
+                },
+                "queued": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "scan_id": {
+                    "type": "string",
+                    "example": "7c9e6679-7425-40de-944b-e07fc1f90ae7"
                 }
             }
         },

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -5129,9 +5129,32 @@ const docTemplate = `{
                         "$ref": "#/definitions/docs.CertificateResponse"
                     }
                 },
+                "custom_name": {
+                    "description": "CustomName is the user-defined display-name override (null when unset).",
+                    "type": "string",
+                    "example": "office-router"
+                },
                 "description": {
                     "type": "string",
                     "example": "Primary web server"
+                },
+                "display_name": {
+                    "description": "DisplayName is the winning display name chosen by the identity resolver.\nAlways set; falls back to IPAddress when no source produced a usable name.",
+                    "type": "string",
+                    "example": "sams-macbook.local"
+                },
+                "display_name_source": {
+                    "description": "DisplayNameSource tags where DisplayName came from: custom|mdns|snmp|ptr|cert|ip.",
+                    "type": "string",
+                    "enum": [
+                        "custom",
+                        "mdns",
+                        "snmp",
+                        "ptr",
+                        "cert",
+                        "ip"
+                    ],
+                    "example": "mdns"
                 },
                 "dns_records": {
                     "description": "DNSRecords are populated when DNS enrichment has run for this host.",
@@ -5146,6 +5169,18 @@ const docTemplate = `{
                 "hostname": {
                     "type": "string",
                     "example": "server01.local"
+                },
+                "hostname_source": {
+                    "description": "HostnameSource is the provenance tag for Hostname: manual|ptr|mdns|snmp|cert.",
+                    "type": "string",
+                    "enum": [
+                        "manual",
+                        "ptr",
+                        "mdns",
+                        "snmp",
+                        "cert"
+                    ],
+                    "example": "ptr"
                 },
                 "id": {
                     "type": "string",
@@ -5166,6 +5201,13 @@ const docTemplate = `{
                 "mac_address": {
                     "type": "string",
                     "example": "00:1B:44:11:3A:B7"
+                },
+                "name_candidates": {
+                    "description": "NameCandidates enumerates every automatic name candidate observed for this\nhost (usable or not). Only populated on GET /hosts/{id}; list responses\nleave it as an empty array.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/docs.NameCandidateResponse"
+                    }
                 },
                 "network_id": {
                     "description": "NetworkID is the network this host belongs to, if any.",
@@ -5254,6 +5296,37 @@ const docTemplate = `{
                 "uptime": {
                     "type": "string",
                     "example": "2h30m45s"
+                }
+            }
+        },
+        "docs.NameCandidateResponse": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "example": "sams-macbook.local"
+                },
+                "not_usable_reason": {
+                    "type": "string",
+                    "example": "filtered: unusable PTR pattern"
+                },
+                "observed_at": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string",
+                    "enum": [
+                        "custom",
+                        "mdns",
+                        "snmp",
+                        "ptr",
+                        "cert"
+                    ],
+                    "example": "mdns"
+                },
+                "usable": {
+                    "type": "boolean",
+                    "example": true
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1610,6 +1610,78 @@
                 }
             }
         },
+        "/hosts/{id}/custom-name": {
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "PATCH the user-defined display-name override. Pass {\"custom_name\": null} or empty string to clear.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Hosts"
+                ],
+                "summary": "Set or clear a host's custom display name",
+                "operationId": "updateHostCustomName",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Host UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Custom name payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/docs.CustomNameRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.HostResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/liveness": {
             "get": {
                 "description": "Returns simple liveness status without dependency checks",
@@ -4058,6 +4130,72 @@
                 }
             }
         },
+        "/smart-scan/hosts/{id}/refresh-identity": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Queues an identity_enrichment scan for a host, probing mDNS/SNMP/DNS/TLS surfaces so post-scan enrichment can fill in name signals. Runs even when the host already has a usable name.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Smart Scan"
+                ],
+                "summary": "Refresh host identity",
+                "operationId": "refreshHostIdentity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Host UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/docs.RefreshIdentityResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/smart-scan/hosts/{id}/stage": {
             "get": {
                 "security": [
@@ -4754,6 +4892,15 @@
                         "discovery"
                     ],
                     "example": "scan"
+                }
+            }
+        },
+        "docs.CustomNameRequest": {
+            "type": "object",
+            "properties": {
+                "custom_name": {
+                    "type": "string",
+                    "example": "office-router"
                 }
             }
         },
@@ -5780,6 +5927,23 @@
                 "unique_hosts": {
                     "type": "integer",
                     "example": 7
+                }
+            }
+        },
+        "docs.RefreshIdentityResponse": {
+            "type": "object",
+            "properties": {
+                "host_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440002"
+                },
+                "queued": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "scan_id": {
+                    "type": "string",
+                    "example": "7c9e6679-7425-40de-944b-e07fc1f90ae7"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -5123,9 +5123,32 @@
                         "$ref": "#/definitions/docs.CertificateResponse"
                     }
                 },
+                "custom_name": {
+                    "description": "CustomName is the user-defined display-name override (null when unset).",
+                    "type": "string",
+                    "example": "office-router"
+                },
                 "description": {
                     "type": "string",
                     "example": "Primary web server"
+                },
+                "display_name": {
+                    "description": "DisplayName is the winning display name chosen by the identity resolver.\nAlways set; falls back to IPAddress when no source produced a usable name.",
+                    "type": "string",
+                    "example": "sams-macbook.local"
+                },
+                "display_name_source": {
+                    "description": "DisplayNameSource tags where DisplayName came from: custom|mdns|snmp|ptr|cert|ip.",
+                    "type": "string",
+                    "enum": [
+                        "custom",
+                        "mdns",
+                        "snmp",
+                        "ptr",
+                        "cert",
+                        "ip"
+                    ],
+                    "example": "mdns"
                 },
                 "dns_records": {
                     "description": "DNSRecords are populated when DNS enrichment has run for this host.",
@@ -5140,6 +5163,18 @@
                 "hostname": {
                     "type": "string",
                     "example": "server01.local"
+                },
+                "hostname_source": {
+                    "description": "HostnameSource is the provenance tag for Hostname: manual|ptr|mdns|snmp|cert.",
+                    "type": "string",
+                    "enum": [
+                        "manual",
+                        "ptr",
+                        "mdns",
+                        "snmp",
+                        "cert"
+                    ],
+                    "example": "ptr"
                 },
                 "id": {
                     "type": "string",
@@ -5160,6 +5195,13 @@
                 "mac_address": {
                     "type": "string",
                     "example": "00:1B:44:11:3A:B7"
+                },
+                "name_candidates": {
+                    "description": "NameCandidates enumerates every automatic name candidate observed for this\nhost (usable or not). Only populated on GET /hosts/{id}; list responses\nleave it as an empty array.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/docs.NameCandidateResponse"
+                    }
                 },
                 "network_id": {
                     "description": "NetworkID is the network this host belongs to, if any.",
@@ -5248,6 +5290,37 @@
                 "uptime": {
                     "type": "string",
                     "example": "2h30m45s"
+                }
+            }
+        },
+        "docs.NameCandidateResponse": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "example": "sams-macbook.local"
+                },
+                "not_usable_reason": {
+                    "type": "string",
+                    "example": "filtered: unusable PTR pattern"
+                },
+                "observed_at": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string",
+                    "enum": [
+                        "custom",
+                        "mdns",
+                        "snmp",
+                        "ptr",
+                        "cert"
+                    ],
+                    "example": "mdns"
+                },
+                "usable": {
+                    "type": "boolean",
+                    "example": true
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -519,8 +519,30 @@ definitions:
         items:
           $ref: '#/definitions/docs.CertificateResponse'
         type: array
+      custom_name:
+        description: CustomName is the user-defined display-name override (null when
+          unset).
+        example: office-router
+        type: string
       description:
         example: Primary web server
+        type: string
+      display_name:
+        description: |-
+          DisplayName is the winning display name chosen by the identity resolver.
+          Always set; falls back to IPAddress when no source produced a usable name.
+        example: sams-macbook.local
+        type: string
+      display_name_source:
+        description: 'DisplayNameSource tags where DisplayName came from: custom|mdns|snmp|ptr|cert|ip.'
+        enum:
+        - custom
+        - mdns
+        - snmp
+        - ptr
+        - cert
+        - ip
+        example: mdns
         type: string
       dns_records:
         description: DNSRecords are populated when DNS enrichment has run for this
@@ -532,6 +554,16 @@ definitions:
         type: string
       hostname:
         example: server01.local
+        type: string
+      hostname_source:
+        description: 'HostnameSource is the provenance tag for Hostname: manual|ptr|mdns|snmp|cert.'
+        enum:
+        - manual
+        - ptr
+        - mdns
+        - snmp
+        - cert
+        example: ptr
         type: string
       id:
         example: 550e8400-e29b-41d4-a716-446655440002
@@ -549,6 +581,14 @@ definitions:
       mac_address:
         example: 00:1B:44:11:3A:B7
         type: string
+      name_candidates:
+        description: |-
+          NameCandidates enumerates every automatic name candidate observed for this
+          host (usable or not). Only populated on GET /hosts/{id}; list responses
+          leave it as an empty array.
+        items:
+          $ref: '#/definitions/docs.NameCandidateResponse'
+        type: array
       network_id:
         description: NetworkID is the network this host belongs to, if any.
         type: string
@@ -613,6 +653,29 @@ definitions:
       uptime:
         example: 2h30m45s
         type: string
+    type: object
+  docs.NameCandidateResponse:
+    properties:
+      name:
+        example: sams-macbook.local
+        type: string
+      not_usable_reason:
+        example: 'filtered: unusable PTR pattern'
+        type: string
+      observed_at:
+        type: string
+      source:
+        enum:
+        - custom
+        - mdns
+        - snmp
+        - ptr
+        - cert
+        example: mdns
+        type: string
+      usable:
+        example: true
+        type: boolean
     type: object
   docs.NetworkExclusionResponse:
     properties:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -260,6 +260,12 @@ definitions:
         example: scan
         type: string
     type: object
+  docs.CustomNameRequest:
+    properties:
+      custom_name:
+        example: office-router
+        type: string
+    type: object
   docs.DNSRecordResponse:
     properties:
       host_id:
@@ -1001,6 +1007,18 @@ definitions:
       unique_hosts:
         example: 7
         type: integer
+    type: object
+  docs.RefreshIdentityResponse:
+    properties:
+      host_id:
+        example: 550e8400-e29b-41d4-a716-446655440002
+        type: string
+      queued:
+        example: true
+        type: boolean
+      scan_id:
+        example: 7c9e6679-7425-40de-944b-e07fc1f90ae7
+        type: string
     type: object
   docs.RenameNetworkRequest:
     properties:
@@ -2485,6 +2503,54 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Get host scans
+      tags:
+      - Hosts
+  /hosts/{id}/custom-name:
+    patch:
+      consumes:
+      - application/json
+      description: 'PATCH the user-defined display-name override. Pass {"custom_name":
+        null} or empty string to clear.'
+      operationId: updateHostCustomName
+      parameters:
+      - description: Host UUID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Custom name payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/docs.CustomNameRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/docs.HostResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Set or clear a host's custom display name
       tags:
       - Hosts
   /liveness:
@@ -4092,6 +4158,51 @@ paths:
       summary: Enable schedule
       tags:
       - Schedules
+  /smart-scan/hosts/{id}/refresh-identity:
+    post:
+      description: Queues an identity_enrichment scan for a host, probing mDNS/SNMP/DNS/TLS
+        surfaces so post-scan enrichment can fill in name signals. Runs even when
+        the host already has a usable name.
+      operationId: refreshHostIdentity
+      parameters:
+      - description: Host UUID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/docs.RefreshIdentityResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "429":
+          description: Too Many Requests
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Refresh host identity
+      tags:
+      - Smart Scan
   /smart-scan/hosts/{id}/stage:
     get:
       description: Returns the recommended next scan stage for the specified host.

--- a/docs/swagger_docs.go
+++ b/docs/swagger_docs.go
@@ -250,6 +250,22 @@ type NameCandidateResponse struct {
 	ObservedAt      *time.Time `json:"observed_at,omitempty"`
 }
 
+// CustomNameRequest is the body of PATCH /hosts/{id}/custom-name. Pass null
+// or an empty/whitespace-only string to clear the override.
+type CustomNameRequest struct {
+	CustomName *string `json:"custom_name" example:"office-router"`
+}
+
+// RefreshIdentityResponse is the 202 response body for
+// POST /smart-scan/hosts/{id}/refresh-identity. Mirrors TriggerHostResponse
+// but documented separately so the endpoint's semantics are clearer in the
+// generated OpenAPI.
+type RefreshIdentityResponse struct {
+	HostID string `json:"host_id" example:"550e8400-e29b-41d4-a716-446655440002"`
+	Queued bool   `json:"queued" example:"true"`
+	ScanID string `json:"scan_id,omitempty" example:"7c9e6679-7425-40de-944b-e07fc1f90ae7"`
+}
+
 // ProfileResponse represents a scan profile
 type ProfileResponse struct {
 	ID          string            `json:"id" example:"550e8400-e29b-41d4-a716-446655440003"`
@@ -1419,6 +1435,41 @@ func EvaluateHostStage(_ http.ResponseWriter, _ *http.Request) {}
 // @Router /smart-scan/hosts/{id}/trigger [post]
 // @ID triggerSmartScan
 func TriggerSmartScan(_ http.ResponseWriter, _ *http.Request) {}
+
+// RefreshHostIdentity godoc
+// @Summary Refresh host identity
+// @Description Queues an identity_enrichment scan for a host, probing mDNS/SNMP/DNS/TLS surfaces so post-scan enrichment can fill in name signals. Runs even when the host already has a usable name.
+// @Tags Smart Scan
+// @Produce json
+// @Param id path string true "Host UUID" format(uuid)
+// @Success 202 {object} RefreshIdentityResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 429 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Security ApiKeyAuth
+// @Router /smart-scan/hosts/{id}/refresh-identity [post]
+// @ID refreshHostIdentity
+func RefreshHostIdentity(_ http.ResponseWriter, _ *http.Request) {}
+
+// UpdateHostCustomName godoc
+// @Summary Set or clear a host's custom display name
+// @Description PATCH the user-defined display-name override. Pass {"custom_name": null} or empty string to clear.
+// @Tags Hosts
+// @Accept json
+// @Produce json
+// @Param id path string true "Host UUID" format(uuid)
+// @Param body body CustomNameRequest true "Custom name payload"
+// @Success 200 {object} HostResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Security ApiKeyAuth
+// @Router /hosts/{id}/custom-name [patch]
+// @ID updateHostCustomName
+func UpdateHostCustomName(_ http.ResponseWriter, _ *http.Request) {}
 
 // TriggerSmartScanBatch godoc
 // @Summary Batch trigger Smart Scan

--- a/docs/swagger_docs.go
+++ b/docs/swagger_docs.go
@@ -224,6 +224,30 @@ type HostResponse struct {
 	SNMPData *SNMPDataResponse `json:"snmp_data,omitempty"`
 	// KnowledgeScore is a 0-100 integer indicating how much is known about this host.
 	KnowledgeScore int `json:"knowledge_score" example:"60"`
+	// DisplayName is the winning display name chosen by the identity resolver.
+	// Always set; falls back to IPAddress when no source produced a usable name.
+	DisplayName string `json:"display_name" example:"sams-macbook.local"`
+	// DisplayNameSource tags where DisplayName came from: custom|mdns|snmp|ptr|cert|ip.
+	DisplayNameSource string `json:"display_name_source" example:"mdns" enums:"custom,mdns,snmp,ptr,cert,ip"`
+	// CustomName is the user-defined display-name override (null when unset).
+	CustomName *string `json:"custom_name,omitempty" example:"office-router"`
+	// HostnameSource is the provenance tag for Hostname: manual|ptr|mdns|snmp|cert.
+	HostnameSource *string `json:"hostname_source,omitempty" example:"ptr" enums:"manual,ptr,mdns,snmp,cert"`
+	// NameCandidates enumerates every automatic name candidate observed for this
+	// host (usable or not). Only populated on GET /hosts/{id}; list responses
+	// leave it as an empty array.
+	NameCandidates []NameCandidateResponse `json:"name_candidates"`
+}
+
+// NameCandidateResponse is one row of the Identity tab's candidate table —
+// a name observed for a host from one source, with whether the resolver
+// considered it usable and, if not, a short reason.
+type NameCandidateResponse struct {
+	Name            string     `json:"name" example:"sams-macbook.local"`
+	Source          string     `json:"source" example:"mdns" enums:"custom,mdns,snmp,ptr,cert"`
+	Usable          bool       `json:"usable" example:"true"`
+	NotUsableReason string     `json:"not_usable_reason,omitempty" example:"filtered: unusable PTR pattern"`
+	ObservedAt      *time.Time `json:"observed_at,omitempty"`
 }
 
 // ProfileResponse represents a scan profile

--- a/frontend/src/api/hooks/use-hosts.test.ts
+++ b/frontend/src/api/hooks/use-hosts.test.ts
@@ -8,6 +8,8 @@ import {
   useHostScans,
   useUpdateHost,
   useDeleteHost,
+  useUpdateCustomName,
+  useRefreshIdentity,
 } from "./use-hosts";
 
 vi.mock("../client", () => ({
@@ -15,6 +17,7 @@ vi.mock("../client", () => ({
     GET: vi.fn(),
     POST: vi.fn(),
     PUT: vi.fn(),
+    PATCH: vi.fn(),
     DELETE: vi.fn(),
   },
 }));
@@ -23,6 +26,11 @@ import { api } from "../client";
 const mockGet = vi.mocked(api.GET);
 const mockPut = vi.mocked(api.PUT);
 const mockDelete = vi.mocked(api.DELETE);
+// PATCH is not declared on the openapi-fetch client type until the generated
+// types are regenerated — cast here to keep the tests typed.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPatch = vi.mocked((api as any).PATCH);
+const mockPost = vi.mocked(api.POST);
 
 const ok = (data: unknown): ReturnType<typeof mockGet> =>
   Promise.resolve({
@@ -518,6 +526,176 @@ describe("useDeleteHost", () => {
     await expect(
       actHook(async () => {
         await result.current.mutateAsync("host-1");
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+// ── useUpdateCustomName ───────────────────────────────────────────────────────
+
+describe("useUpdateCustomName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in idle state", () => {
+    const { result } = renderHookWithQuery(() => useUpdateCustomName());
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("calls PATCH /hosts/{hostId}/custom-name with the provided name", async () => {
+    mockPatch.mockResolvedValue({
+      data: { ...mockHost, custom_name: "office-router" },
+      error: undefined,
+      response: new Response(),
+    });
+
+    const { result, actHook } = renderHookWithQuery(() => useUpdateCustomName());
+
+    await actHook(async () => {
+      await result.current.mutateAsync({
+        hostId: "host-1",
+        customName: "office-router",
+      });
+    });
+
+    expect(mockPatch).toHaveBeenCalledWith(
+      "/hosts/{hostId}/custom-name",
+      expect.objectContaining({
+        params: { path: { hostId: "host-1" } },
+        body: { custom_name: "office-router" },
+      }),
+    );
+  });
+
+  it("sends null in body when clearing the override", async () => {
+    mockPatch.mockResolvedValue({
+      data: mockHost,
+      error: undefined,
+      response: new Response(),
+    });
+
+    const { result, actHook } = renderHookWithQuery(() => useUpdateCustomName());
+
+    await actHook(async () => {
+      await result.current.mutateAsync({ hostId: "host-1", customName: null });
+    });
+
+    expect(mockPatch).toHaveBeenCalledWith(
+      "/hosts/{hostId}/custom-name",
+      expect.objectContaining({
+        body: { custom_name: null },
+      }),
+    );
+  });
+
+  it("invalidates ['hosts'] queries on success", async () => {
+    mockPatch.mockResolvedValue({
+      data: mockHost,
+      error: undefined,
+      response: new Response(),
+    });
+
+    const { result, actHook, queryClient } = renderHookWithQuery(() =>
+      useUpdateCustomName(),
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    await actHook(async () => {
+      await result.current.mutateAsync({ hostId: "host-1", customName: "x" });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["hosts"] }),
+    );
+  });
+
+  it("throws ApiError when the PATCH request fails", async () => {
+    mockPatch.mockResolvedValue({
+      data: undefined,
+      error: { message: "too long" },
+      response: new Response(null, { status: 400 }),
+    });
+
+    const { result, actHook } = renderHookWithQuery(() => useUpdateCustomName());
+
+    await expect(
+      actHook(async () => {
+        await result.current.mutateAsync({
+          hostId: "host-1",
+          customName: "nope",
+        });
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+// ── useRefreshIdentity ────────────────────────────────────────────────────────
+
+describe("useRefreshIdentity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in idle state", () => {
+    const { result } = renderHookWithQuery(() => useRefreshIdentity());
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("calls POST /smart-scan/hosts/{hostId}/refresh-identity", async () => {
+    mockPost.mockResolvedValue({
+      data: { host_id: "host-1", queued: true, scan_id: "scan-42" },
+      error: undefined,
+      response: new Response(),
+    } as unknown as ReturnType<typeof mockPost>);
+
+    const { result, actHook } = renderHookWithQuery(() => useRefreshIdentity());
+
+    await actHook(async () => {
+      await result.current.mutateAsync("host-1");
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/smart-scan/hosts/{hostId}/refresh-identity",
+      expect.objectContaining({
+        params: { path: { hostId: "host-1" } },
+      }),
+    );
+  });
+
+  it("invalidates ['hosts', hostId] on success so the Identity tab refetches", async () => {
+    mockPost.mockResolvedValue({
+      data: { host_id: "host-1", queued: true, scan_id: "scan-42" },
+      error: undefined,
+      response: new Response(),
+    } as unknown as ReturnType<typeof mockPost>);
+
+    const { result, actHook, queryClient } = renderHookWithQuery(() =>
+      useRefreshIdentity(),
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    await actHook(async () => {
+      await result.current.mutateAsync("host-1");
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["hosts", "host-1"] }),
+    );
+  });
+
+  it("throws ApiError when the POST request fails", async () => {
+    mockPost.mockResolvedValue({
+      data: undefined,
+      error: { message: "host not found" },
+      response: new Response(null, { status: 404 }),
+    } as unknown as ReturnType<typeof mockPost>);
+
+    const { result, actHook } = renderHookWithQuery(() => useRefreshIdentity());
+
+    await expect(
+      actHook(async () => {
+        await result.current.mutateAsync("host-missing");
       }),
     ).rejects.toThrow();
   });

--- a/frontend/src/api/hooks/use-hosts.ts
+++ b/frontend/src/api/hooks/use-hosts.ts
@@ -116,6 +116,65 @@ export function useDeleteHost() {
   });
 }
 
+// useUpdateCustomName sets or clears the user-defined display-name override
+// for a host via PATCH /hosts/{hostId}/custom-name. Pass null in the body to
+// clear the override; the backend also treats whitespace-only strings as a
+// clear. Invalidates the ["hosts"] cache so the list + detail views both pick
+// up the new display_name on next render.
+export function useUpdateCustomName() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      hostId,
+      customName,
+    }: {
+      hostId: string;
+      customName: string | null;
+    }) => {
+      // openapi-fetch exposes PATCH but the generated types haven't picked up
+      // the new endpoint on this build in every environment. Cast narrowly so
+      // we stay type-safe on hostId while tolerating a brief type lag.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error, response } = await (api as any).PATCH(
+        "/hosts/{hostId}/custom-name",
+        {
+          params: { path: { hostId } },
+          body: { custom_name: customName },
+        },
+      );
+      if (error) throw new ApiError(response.status, error);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["hosts"] });
+    },
+  });
+}
+
+// useRefreshIdentity enqueues an identity_enrichment scan for the host via
+// POST /smart-scan/hosts/{hostId}/refresh-identity. The backend runs this
+// unconditionally — the button exists for users who want to poke a host
+// right now, not for the orchestrator's decision logic. Returns the scan id
+// so callers can poll job status if they want.
+export function useRefreshIdentity() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (hostId: string) => {
+      const { data, error, response } = await api.POST(
+        "/smart-scan/hosts/{hostId}/refresh-identity",
+        { params: { path: { hostId } } },
+      );
+      if (error) throw new ApiError(response.status, error);
+      return data;
+    },
+    onSuccess: (_data, hostId) => {
+      // Name candidates live on the host detail response; invalidate so the
+      // Identity tab refetches after the scan lands.
+      queryClient.invalidateQueries({ queryKey: ["hosts", hostId] });
+    },
+  });
+}
+
 export function useBulkDeleteHosts() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -401,6 +401,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/hosts/{id}/custom-name": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Set or clear a host's custom display name
+         * @description PATCH the user-defined display-name override. Pass {"custom_name": null} or empty string to clear.
+         */
+        patch: operations["updateHostCustomName"];
+        trace?: never;
+    };
     "/liveness": {
         parameters: {
             query?: never;
@@ -996,6 +1016,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/smart-scan/hosts/{id}/refresh-identity": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Refresh host identity
+         * @description Queues an identity_enrichment scan for a host, probing mDNS/SNMP/DNS/TLS surfaces so post-scan enrichment can fill in name signals. Runs even when the host already has a usable name.
+         */
+        post: operations["refreshHostIdentity"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/smart-scan/hosts/{id}/stage": {
         parameters: {
             query?: never;
@@ -1310,6 +1350,10 @@ export interface components {
              * @enum {string}
              */
             type?: "scan" | "discovery";
+        };
+        "docs.CustomNameRequest": {
+            /** @example office-router */
+            custom_name?: string;
         };
         "docs.DNSRecordResponse": {
             host_id?: string;
@@ -1776,6 +1820,14 @@ export interface components {
             total_scans?: number;
             /** @example 7 */
             unique_hosts?: number;
+        };
+        "docs.RefreshIdentityResponse": {
+            /** @example 550e8400-e29b-41d4-a716-446655440002 */
+            host_id?: string;
+            /** @example true */
+            queued?: boolean;
+            /** @example 7c9e6679-7425-40de-944b-e07fc1f90ae7 */
+            scan_id?: string;
         };
         "docs.RenameNetworkRequest": {
             /** @example New Office Network */
@@ -3550,6 +3602,70 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["docs.PaginatedScansResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateHostCustomName: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Host UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Custom name payload */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.CustomNameRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.HostResponse"];
                 };
             };
             /** @description Bad Request */
@@ -5903,6 +6019,74 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    refreshHostIdentity: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Host UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.RefreshIdentityResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1461,13 +1461,36 @@ export interface components {
             banners?: components["schemas"]["docs.PortBannerResponse"][];
             /** @description Certificates are populated when TLS banner grabbing has run for this host. */
             certificates?: components["schemas"]["docs.CertificateResponse"][];
+            /**
+             * @description CustomName is the user-defined display-name override (null when unset).
+             * @example office-router
+             */
+            custom_name?: string;
             /** @example Primary web server */
             description?: string;
+            /**
+             * @description DisplayName is the winning display name chosen by the identity resolver.
+             *     Always set; falls back to IPAddress when no source produced a usable name.
+             * @example sams-macbook.local
+             */
+            display_name?: string;
+            /**
+             * @description DisplayNameSource tags where DisplayName came from: custom|mdns|snmp|ptr|cert|ip.
+             * @example mdns
+             * @enum {string}
+             */
+            display_name_source?: "custom" | "mdns" | "snmp" | "ptr" | "cert" | "ip";
             /** @description DNSRecords are populated when DNS enrichment has run for this host. */
             dns_records?: components["schemas"]["docs.DNSRecordResponse"][];
             first_seen?: string;
             /** @example server01.local */
             hostname?: string;
+            /**
+             * @description HostnameSource is the provenance tag for Hostname: manual|ptr|mdns|snmp|cert.
+             * @example ptr
+             * @enum {string}
+             */
+            hostname_source?: "manual" | "ptr" | "mdns" | "snmp" | "cert";
             /** @example 550e8400-e29b-41d4-a716-446655440002 */
             id?: string;
             /** @example 192.168.1.100 */
@@ -1480,6 +1503,12 @@ export interface components {
             last_seen?: string;
             /** @example 00:1B:44:11:3A:B7 */
             mac_address?: string;
+            /**
+             * @description NameCandidates enumerates every automatic name candidate observed for this
+             *     host (usable or not). Only populated on GET /hosts/{id}; list responses
+             *     leave it as an empty array.
+             */
+            name_candidates?: components["schemas"]["docs.NameCandidateResponse"][];
             /** @description NetworkID is the network this host belongs to, if any. */
             network_id?: string;
             /**
@@ -1531,6 +1560,20 @@ export interface components {
             timestamp?: string;
             /** @example 2h30m45s */
             uptime?: string;
+        };
+        "docs.NameCandidateResponse": {
+            /** @example sams-macbook.local */
+            name?: string;
+            /** @example filtered: unusable PTR pattern */
+            not_usable_reason?: string;
+            observed_at?: string;
+            /**
+             * @example mdns
+             * @enum {string}
+             */
+            source?: "custom" | "mdns" | "snmp" | "ptr" | "cert";
+            /** @example true */
+            usable?: boolean;
         };
         "docs.NetworkExclusionResponse": {
             created_at?: string;

--- a/frontend/src/components/host-identity-panel.tsx
+++ b/frontend/src/components/host-identity-panel.tsx
@@ -1,0 +1,367 @@
+import { useState, useEffect } from "react";
+import { RefreshCw, Info } from "lucide-react";
+
+import { cn } from "../lib/utils";
+import { Button } from "./button";
+import { useUpdateCustomName, useRefreshIdentity } from "../api/hooks/use-hosts";
+import { useToast } from "./toast-provider";
+import type { components } from "../api/types";
+
+type HostResponse = components["schemas"]["docs.HostResponse"];
+type NameCandidate = components["schemas"]["docs.NameCandidateResponse"];
+
+type Mode = "compact" | "full";
+
+interface HostIdentityPanelProps {
+  host: HostResponse;
+  mode: Mode;
+  // Compact mode shows a "Manage in Identity tab" link; full mode renders
+  // the custom-name editor + refresh button. onManageClick is only consulted
+  // in compact mode.
+  onManageClick?: () => void;
+}
+
+// HostIdentityPanel renders either the compact read-only "top candidates"
+// panel used by the Overview tab's chevron expand, or the full management
+// surface used by the Identity tab. One component, two layouts — the mode
+// prop gates the write controls.
+export function HostIdentityPanel({
+  host,
+  mode,
+  onManageClick,
+}: HostIdentityPanelProps) {
+  const candidates = host.name_candidates ?? [];
+  const displayName = host.display_name ?? host.ip_address ?? "—";
+  const source = host.display_name_source ?? "ip";
+
+  if (mode === "compact") {
+    return (
+      <CompactPanel
+        displayName={displayName}
+        source={source}
+        candidates={candidates}
+        onManageClick={onManageClick}
+      />
+    );
+  }
+
+  return (
+    <FullPanel
+      host={host}
+      candidates={candidates}
+      displayName={displayName}
+      source={source}
+    />
+  );
+}
+
+function CompactPanel({
+  displayName,
+  source,
+  candidates,
+  onManageClick,
+}: {
+  displayName: string;
+  source: string;
+  candidates: NameCandidate[];
+  onManageClick?: () => void;
+}) {
+  // Show at most 4 rows; keep usable candidates first so the best signals
+  // are visible without scrolling. Unusable rows with reasons are still
+  // included so users see why a cert/PTR isn't winning.
+  const top = [...candidates]
+    .sort((a, b) => Number(b.usable ?? false) - Number(a.usable ?? false))
+    .slice(0, 4);
+
+  return (
+    <div className="rounded-md border border-border bg-surface-raised p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] uppercase tracking-wide text-text-muted">
+          Chosen: <SourceBadge source={source} /> {displayName}
+        </span>
+        {onManageClick ? (
+          <button
+            type="button"
+            onClick={onManageClick}
+            className="text-[11px] text-accent hover:underline"
+          >
+            Manage in Identity tab →
+          </button>
+        ) : null}
+      </div>
+      {top.length === 0 ? (
+        <p className="text-[11px] text-text-muted">
+          No alternative names observed yet.
+        </p>
+      ) : (
+        <table className="w-full text-[11px]">
+          <tbody>
+            {top.map((c, i) => (
+              <tr
+                key={`${c.source ?? "src"}-${c.name ?? ""}-${i}`}
+                className={cn(!c.usable && "text-text-muted")}
+              >
+                <td className="py-0.5 pr-2 break-all">
+                  {c.name ?? "—"}
+                  {c.usable === false && c.not_usable_reason ? (
+                    <span className="ml-1 text-danger/70">
+                      ({c.not_usable_reason})
+                    </span>
+                  ) : null}
+                </td>
+                <td className="py-0.5 text-right text-text-muted whitespace-nowrap">
+                  <SourceBadge source={c.source ?? ""} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+function FullPanel({
+  host,
+  candidates,
+  displayName,
+  source,
+}: {
+  host: HostResponse;
+  candidates: NameCandidate[];
+  displayName: string;
+  source: string;
+}) {
+  const [input, setInput] = useState(host.custom_name ?? "");
+  const { toast } = useToast();
+  const update = useUpdateCustomName();
+  const refresh = useRefreshIdentity();
+
+  // Keep the input in sync when the host prop changes underneath us (e.g.
+  // the refresh-identity mutation invalidates the query and fetches fresh
+  // data with a new custom_name).
+  useEffect(() => {
+    setInput(host.custom_name ?? "");
+  }, [host.id, host.custom_name]);
+
+  const hostId = host.id ?? "";
+
+  async function save(name: string | null) {
+    if (!hostId) return;
+    try {
+      await update.mutateAsync({ hostId, customName: name });
+      toast.success(name == null ? "Custom name cleared" : "Custom name saved");
+    } catch (e) {
+      toast.error(
+        e instanceof Error
+          ? `Failed to save custom name: ${e.message}`
+          : "Failed to save custom name",
+      );
+    }
+  }
+
+  async function onSave() {
+    const trimmed = input.trim();
+    await save(trimmed === "" ? null : trimmed);
+  }
+
+  async function onClear() {
+    setInput("");
+    await save(null);
+  }
+
+  async function onRefresh() {
+    if (!hostId) return;
+    try {
+      await refresh.mutateAsync(hostId);
+      toast.success(
+        "Identity refresh queued — candidates update when the scan completes.",
+      );
+    } catch (e) {
+      toast.error(
+        e instanceof Error
+          ? `Failed to queue identity refresh: ${e.message}`
+          : "Failed to queue identity refresh",
+      );
+    }
+  }
+
+  async function onUseCandidate(candidate: NameCandidate) {
+    if (!candidate.name) return;
+    setInput(candidate.name);
+    await save(candidate.name);
+  }
+
+  return (
+    <div className="space-y-5">
+      <section>
+        <h4 className="text-[10px] uppercase tracking-wide text-text-muted mb-2">
+          Custom name (user override)
+        </h4>
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="e.g. office-router"
+            maxLength={255}
+            aria-label="Custom name"
+            className="flex-1 px-2 py-1 text-xs rounded border border-border bg-surface text-text-primary focus:outline-none focus:ring-1 focus:ring-border min-w-0"
+          />
+          <Button
+            size="sm"
+            onClick={() => void onSave()}
+            loading={update.isPending}
+          >
+            Save
+          </Button>
+          {host.custom_name ? (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => void onClear()}
+              loading={update.isPending}
+            >
+              Clear
+            </Button>
+          ) : null}
+        </div>
+      </section>
+
+      <section>
+        <h4 className="text-[10px] uppercase tracking-wide text-text-muted mb-2">
+          Name sources (ranked)
+        </h4>
+        <div className="rounded-md border border-border overflow-hidden">
+          <table className="w-full text-xs">
+            <thead className="bg-surface-raised text-[10px] uppercase text-text-muted">
+              <tr>
+                <th className="text-left px-3 py-1.5 font-medium">Name</th>
+                <th className="text-left px-3 py-1.5 font-medium">Source</th>
+                <th className="text-left px-3 py-1.5 font-medium">Observed</th>
+                <th className="px-3 py-1.5" />
+              </tr>
+            </thead>
+            <tbody>
+              {candidates.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="px-3 py-4 text-center text-text-muted italic"
+                  >
+                    No name candidates have been observed for this host yet.
+                  </td>
+                </tr>
+              ) : (
+                candidates.map((c, i) => (
+                  <CandidateRow
+                    key={`${c.source ?? "src"}-${c.name ?? ""}-${i}`}
+                    candidate={c}
+                    winning={
+                      c.usable === true &&
+                      c.source === source &&
+                      c.name === displayName
+                    }
+                    onUse={() => void onUseCandidate(c)}
+                    busy={update.isPending}
+                  />
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="flex items-center justify-between">
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => void onRefresh()}
+          loading={refresh.isPending}
+          icon={<RefreshCw className="h-3 w-3" />}
+        >
+          Refresh identity now
+        </Button>
+        <span className="text-[11px] text-text-muted flex items-center gap-1">
+          <Info className="h-3 w-3" />
+          Auto-runs via SmartScan when a host lacks a name.
+        </span>
+      </section>
+    </div>
+  );
+}
+
+function CandidateRow({
+  candidate,
+  winning,
+  onUse,
+  busy,
+}: {
+  candidate: NameCandidate;
+  winning: boolean;
+  onUse: () => void;
+  busy: boolean;
+}) {
+  const observedAt = candidate.observed_at;
+  return (
+    <tr
+      className={cn(
+        "border-t border-border",
+        candidate.usable === false && "text-text-muted",
+      )}
+    >
+      <td className="px-3 py-2 break-all">
+        {winning ? <span className="text-success mr-1">✓</span> : null}
+        <span className={winning ? "font-semibold" : ""}>
+          {candidate.name ?? "—"}
+        </span>
+      </td>
+      <td className="px-3 py-2">
+        <SourceBadge source={candidate.source ?? ""} />
+      </td>
+      <td className="px-3 py-2 text-text-muted whitespace-nowrap">
+        {observedAt ? formatRelative(observedAt) : "—"}
+      </td>
+      <td className="px-3 py-2 text-right">
+        {candidate.usable === false ? (
+          <span className="text-danger/70 text-[11px]">
+            {candidate.not_usable_reason ?? "unusable"}
+          </span>
+        ) : winning ? (
+          <span className="text-success text-[11px]">selected</span>
+        ) : (
+          <button
+            type="button"
+            onClick={onUse}
+            disabled={busy}
+            className="text-[11px] text-accent hover:underline disabled:text-text-muted"
+          >
+            use
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function SourceBadge({ source }: { source: string }) {
+  if (!source) return null;
+  return (
+    <span className="inline-block px-1.5 py-0.5 rounded bg-surface text-[10px] uppercase tracking-wide text-text-muted">
+      {source}
+    </span>
+  );
+}
+
+function formatRelative(iso: string): string {
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return "—";
+  const seconds = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}

--- a/frontend/src/routes/hosts.test.tsx
+++ b/frontend/src/routes/hosts.test.tsx
@@ -10,6 +10,14 @@ vi.mock("../api/hooks/use-hosts", () => ({
   useUpdateHost: vi.fn(),
   useDeleteHost: vi.fn(),
   useBulkDeleteHosts: vi.fn(),
+  useUpdateCustomName: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  })),
+  useRefreshIdentity: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  })),
 }));
 
 vi.mock("../api/hooks/use-host-networks", () => ({

--- a/frontend/src/routes/hosts.tsx
+++ b/frontend/src/routes/hosts.tsx
@@ -22,6 +22,7 @@ import {
 import { SortHeader } from "../components/sort-header";
 import type { SortOrder } from "../components/sort-header";
 import { Button } from "../components/button";
+import { HostIdentityPanel } from "../components/host-identity-panel";
 import {
   useHosts,
   useHost,
@@ -196,8 +197,13 @@ function HostDetailPanel({
   const { data: full, isLoading, isError, error } = useHost(host.id ?? "");
   const h = (full ?? host) as HostWithDetails;
 
-  // Active detail tab — "interfaces" only shown when SNMP interface data is present
-  const [detailTab, setDetailTab] = useState<"overview" | "interfaces">("overview");
+  // Active detail tab. "interfaces" is only shown when SNMP interface data is
+  // present; "identity" is always available.
+  const [detailTab, setDetailTab] = useState<
+    "overview" | "identity" | "interfaces"
+  >("overview");
+  // Controls the inline chevron panel on the Overview tab's Identity row.
+  const [identityExpanded, setIdentityExpanded] = useState(false);
 
   // Expanded port banners: Set of "port-protocol" keys with banner expanded
   const [expandedBanners, setExpandedBanners] = useState<Set<string>>(new Set());
@@ -388,26 +394,33 @@ function HostDetailPanel({
           </button>
         </div>
 
-        {/* Tab bar — shown only when SNMP interface data is present */}
-        {h.snmp_data?.interfaces && h.snmp_data.interfaces.length > 0 && (
-          <div className="flex border-b border-border shrink-0">
-            {(["overview", "interfaces"] as const).map((tab) => (
-              <button
-                key={tab}
-                type="button"
-                onClick={() => setDetailTab(tab)}
-                className={cn(
-                  "px-5 py-2.5 text-xs font-medium capitalize transition-colors border-b-2 -mb-px",
-                  detailTab === tab
-                    ? "border-accent text-text-primary"
-                    : "border-transparent text-text-muted hover:text-text-secondary",
-                )}
-              >
-                {tab}
-              </button>
-            ))}
-          </div>
-        )}
+        {/* Tab bar — identity is always available; interfaces only shows
+            when SNMP interface data is present. */}
+        <div className="flex border-b border-border shrink-0">
+          {(
+            [
+              "overview",
+              "identity",
+              ...(h.snmp_data?.interfaces && h.snmp_data.interfaces.length > 0
+                ? (["interfaces"] as const)
+                : []),
+            ] as const
+          ).map((tab) => (
+            <button
+              key={tab}
+              type="button"
+              onClick={() => setDetailTab(tab)}
+              className={cn(
+                "px-5 py-2.5 text-xs font-medium capitalize transition-colors border-b-2 -mb-px",
+                detailTab === tab
+                  ? "border-accent text-text-primary"
+                  : "border-transparent text-text-muted hover:text-text-secondary",
+              )}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
 
         {/* Body */}
         <div className="flex-1 overflow-y-auto px-5 py-4 space-y-6">
@@ -467,9 +480,43 @@ function HostDetailPanel({
 
           {/* Identity */}
           <section>
-            <h3 className="text-xs font-medium text-text-primary mb-3">
-              Identity
-            </h3>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-xs font-medium text-text-primary flex items-center gap-1.5">
+                Identity
+                {h.display_name_source && h.display_name_source !== "ip" ? (
+                  <span className="text-[10px] uppercase tracking-wide text-text-muted">
+                    ({h.display_name_source})
+                  </span>
+                ) : null}
+              </h3>
+              <button
+                type="button"
+                onClick={() => setIdentityExpanded((v) => !v)}
+                className="flex items-center gap-1 text-[11px] text-text-muted hover:text-text-primary"
+                aria-expanded={identityExpanded}
+                aria-label={
+                  identityExpanded ? "Collapse name sources" : "Expand name sources"
+                }
+              >
+                {identityExpanded ? (
+                  <ChevronDown className="h-3 w-3" />
+                ) : (
+                  <ChevronRight className="h-3 w-3" />
+                )}
+                {(h.name_candidates?.length ?? 0) > 0
+                  ? `${h.name_candidates?.length ?? 0} sources`
+                  : "sources"}
+              </button>
+            </div>
+            {identityExpanded && (
+              <div className="mb-4">
+                <HostIdentityPanel
+                  host={h}
+                  mode="compact"
+                  onManageClick={() => setDetailTab("identity")}
+                />
+              </div>
+            )}
             {isLoading ? (
               <div className="space-y-2">
                 {Array.from({ length: 5 }).map((_, i) => (
@@ -1248,6 +1295,16 @@ function HostDetailPanel({
           </section>
 
           </> /* end overview tab */}
+
+          {/* Identity tab — full candidate list + custom-name override */}
+          {detailTab === "identity" && (
+            <section>
+              <h3 className="text-xs font-medium text-text-primary mb-3">
+                Identity
+              </h3>
+              <HostIdentityPanel host={h} mode="full" />
+            </section>
+          )}
 
           {/* Interfaces tab */}
           {detailTab === "interfaces" && h.snmp_data?.interfaces && (
@@ -2083,7 +2140,9 @@ export function HostsPage() {
                         </td>
                         {colVis.hostname && (
                           <td className="py-3 pr-4 text-text-secondary">
-                            {host.hostname ?? "—"}
+                            {(host as HostWithDetails).display_name ??
+                              host.hostname ??
+                              "—"}
                           </td>
                         )}
                         <td className="py-3 pr-4">

--- a/internal/api/handlers/common_test.go
+++ b/internal/api/handlers/common_test.go
@@ -152,6 +152,9 @@ func (nilHostServicer) GetHost(_ context.Context, _ uuid.UUID) (*db.Host, error)
 func (nilHostServicer) UpdateHost(_ context.Context, _ uuid.UUID, _ db.UpdateHostInput) (*db.Host, error) {
 	panic("nilHostServicer: UpdateHost called unexpectedly")
 }
+func (nilHostServicer) UpdateCustomName(_ context.Context, _ uuid.UUID, _ *string) (*db.Host, error) {
+	panic("nilHostServicer: UpdateCustomName called unexpectedly")
+}
 func (nilHostServicer) DeleteHost(_ context.Context, _ uuid.UUID) error {
 	panic("nilHostServicer: DeleteHost called unexpectedly")
 }

--- a/internal/api/handlers/host.go
+++ b/internal/api/handlers/host.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -299,6 +300,73 @@ func (h *HostHandler) UpdateHost(w http.ResponseWriter, r *http.Request) {
 			return h.hostToResponse(host)
 		},
 		"api_hosts_updated_total")
+}
+
+// CustomNameRequest is the body of PATCH /hosts/{id}/custom-name.
+// Nil CustomName clears the override; non-nil (after trim) sets it.
+type CustomNameRequest struct {
+	CustomName *string `json:"custom_name"`
+}
+
+const maxCustomNameLength = 255
+
+// UpdateCustomName handles PATCH /api/v1/hosts/{id}/custom-name.
+// Sets or clears the user-defined display-name override for a host.
+// Pass null or an empty/whitespace-only string to clear.
+//
+//	@Summary		Set or clear a host's custom display name
+//	@Description	PATCH the user-defined display-name override. Pass {"custom_name": null} or empty string to clear.
+//	@Tags			hosts
+//	@Accept			json
+//	@Produce		json
+//	@Param			id		path		string				true	"Host UUID"
+//	@Param			body	body		CustomNameRequest	true	"Custom name payload"
+//	@Success		200		{object}	HostResponse
+//	@Failure		400		{object}	ErrorResponse
+//	@Failure		404		{object}	ErrorResponse
+//	@Failure		500		{object}	ErrorResponse
+//	@Router			/hosts/{id}/custom-name [patch]
+func (h *HostHandler) UpdateCustomName(w http.ResponseWriter, r *http.Request) {
+	hostID, err := extractUUIDFromPath(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	var req CustomNameRequest
+	if parseErr := parseJSON(r, &req); parseErr != nil {
+		writeError(w, r, http.StatusBadRequest, parseErr)
+		return
+	}
+
+	// Normalize: whitespace-only = clear. Over-length = 400.
+	var name *string
+	if req.CustomName != nil {
+		trimmed := strings.TrimSpace(*req.CustomName)
+		switch {
+		case trimmed == "":
+			name = nil
+		case len(trimmed) > maxCustomNameLength:
+			writeError(w, r, http.StatusBadRequest,
+				fmt.Errorf("custom_name too long (max %d characters)", maxCustomNameLength))
+			return
+		default:
+			name = &trimmed
+		}
+	}
+
+	host, err := h.service.UpdateCustomName(r.Context(), hostID, name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			writeError(w, r, http.StatusNotFound, err)
+			return
+		}
+		h.logger.Error("Failed to update custom_name", "host_id", hostID, "error", err)
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, h.hostToResponse(host))
 }
 
 // DeleteHost handles DELETE /api/v1/hosts/{id} - delete a host.

--- a/internal/api/handlers/host.go
+++ b/internal/api/handlers/host.go
@@ -15,6 +15,7 @@ import (
 	"github.com/anstrom/scanorama/internal/db"
 	"github.com/anstrom/scanorama/internal/errors"
 	"github.com/anstrom/scanorama/internal/metrics"
+	"github.com/anstrom/scanorama/internal/services"
 )
 
 // Validation constants for host fields.
@@ -125,6 +126,32 @@ type HostResponse struct {
 	Certificates      []*db.Certificate     `json:"certificates"`
 	SNMPData          *db.HostSNMPData      `json:"snmp_data"`
 	KnowledgeScore    int                   `json:"knowledge_score"`
+	// DisplayName is the winning name chosen by the identity resolver.
+	// Always set — falls back to IPAddress when no source produced a usable name.
+	DisplayName string `json:"display_name"`
+	// DisplayNameSource tags where DisplayName came from:
+	// custom|mdns|snmp|ptr|cert|ip.
+	DisplayNameSource string `json:"display_name_source"`
+	// CustomName is the user-defined override (nil when unset).
+	CustomName *string `json:"custom_name,omitempty"`
+	// HostnameSource is the provenance tag for Hostname: manual|ptr|mdns|snmp|cert.
+	HostnameSource *string `json:"hostname_source,omitempty"`
+	// NameCandidates is every automatic name candidate (usable or not) observed
+	// for this host. Always present — make([]..., 0) rather than nil so it
+	// serializes as [] not null. Empty on list responses (computed only on
+	// GET /hosts/{id} where the related tables are joined).
+	NameCandidates []NameCandidateResponse `json:"name_candidates"`
+}
+
+// NameCandidateResponse is one entry in HostResponse.NameCandidates — a
+// single name value from an auto-discovery source, tagged with whether it
+// was deemed usable and why not (when applicable).
+type NameCandidateResponse struct {
+	Name            string     `json:"name"`
+	Source          string     `json:"source"`
+	Usable          bool       `json:"usable"`
+	NotUsableReason string     `json:"not_usable_reason,omitempty"`
+	ObservedAt      *time.Time `json:"observed_at,omitempty"`
 }
 
 // HostScanResponse represents a scan associated with a host.
@@ -244,6 +271,10 @@ func (h *HostHandler) GetHost(w http.ResponseWriter, r *http.Request) {
 					resp.SNMPData = snmpData
 				}
 			}
+			// Refine display_name using the full candidate set now that the
+			// related-table data is loaded, and populate name_candidates for
+			// the Identity tab.
+			h.augmentWithFullIdentity(&resp, host, resp.DNSRecords, resp.Certificates, resp.SNMPData)
 			return resp
 		},
 		"api_hosts_retrieved_total")
@@ -650,13 +681,26 @@ func populateResponseTimeFields(r *HostResponse, host *db.Host) {
 
 func (h *HostHandler) hostToResponse(host *db.Host) HostResponse {
 	response := HostResponse{
-		ID:        host.ID.String(),
-		IPAddress: host.IPAddress.String(),
-		Status:    host.Status,
-		FirstSeen: host.FirstSeen,
-		CreatedAt: host.FirstSeen,
-		UpdatedAt: host.LastSeen,
+		ID:             host.ID.String(),
+		IPAddress:      host.IPAddress.String(),
+		Status:         host.Status,
+		FirstSeen:      host.FirstSeen,
+		CreatedAt:      host.FirstSeen,
+		UpdatedAt:      host.LastSeen,
+		CustomName:     host.CustomName,
+		HostnameSource: host.HostnameSource,
+		NameCandidates: []NameCandidateResponse{},
 	}
+
+	// Best-effort display name using only fields on the Host row. GetHost
+	// overrides this later with the full-fat resolution that includes DNS
+	// records, cert subjects and SNMP data.
+	resolution := services.ResolveDisplayName(
+		basicIdentityInputs(host),
+		services.DefaultIdentityRankOrder,
+	)
+	response.DisplayName = resolution.Name
+	response.DisplayNameSource = string(resolution.Source)
 
 	// Handle optional fields
 	if host.Hostname != nil {

--- a/internal/api/handlers/host_identity.go
+++ b/internal/api/handlers/host_identity.go
@@ -1,0 +1,152 @@
+package handlers
+
+import (
+	"github.com/anstrom/scanorama/internal/db"
+	"github.com/anstrom/scanorama/internal/services"
+)
+
+// basicIdentityInputs builds an IdentityInputs snapshot using only fields that
+// live on the Host row itself — no joins against host_dns_records,
+// certificates, or host_snmp_data. hosts.hostname is passed as a PTR
+// observation because that's the historical source (the DNS enricher was the
+// sole writer before migration 027 added hostname_source). The quality filter
+// (DNSNameIsUsable) still gates it, so garbage ISP PTR values are rejected
+// correctly even if hostname_source is NULL.
+//
+// Use fullIdentityInputs when the caller has already fetched DNS records,
+// cert subjects and SNMP data (e.g. GetHost).
+func basicIdentityInputs(host *db.Host) services.IdentityInputs {
+	in := services.IdentityInputs{
+		IPAddress:  host.IPAddress.String(),
+		CustomName: host.CustomName,
+		MDNSName:   host.MDNSName,
+		MDNSSeenAt: host.LastSeen,
+	}
+	if host.Hostname != nil && *host.Hostname != "" {
+		in.PTRRecords = []services.PTRObservation{
+			{Name: *host.Hostname, ObservedAt: host.LastSeen},
+		}
+	}
+	return in
+}
+
+// fullIdentityInputs layers the related-table data fetched by GetHost on top
+// of basicIdentityInputs so the Identity tab can render every observed name
+// candidate — including the unusable ones with explanations.
+//
+// Cert subjects are reported with ForwardMatchesIP=false by default: verifying
+// the forward A/AAAA lookup against the host IP requires live DNS and is not
+// performed synchronously on the hot GetHost path. Unverified certs therefore
+// appear in the candidate list as unusable with a reason, and never win the
+// display_name race.
+func fullIdentityInputs(
+	host *db.Host,
+	dnsRecords []db.DNSRecord,
+	certs []*db.Certificate,
+	snmp *db.HostSNMPData,
+) services.IdentityInputs {
+	in := basicIdentityInputs(host)
+
+	if ptrs := ptrObservationsFromDNS(dnsRecords); len(ptrs) > 0 {
+		// Replace the single hostname-as-PTR fallback from basicIdentityInputs
+		// with the authoritative list from host_dns_records.
+		in.PTRRecords = ptrs
+	}
+
+	if snmp != nil && snmp.SysName != nil && *snmp.SysName != "" {
+		in.SNMPSysName = snmp.SysName
+		if !snmp.CollectedAt.IsZero() {
+			in.SNMPSeenAt = snmp.CollectedAt
+		}
+	}
+
+	in.CertSubjects = certSubjectsFromCerts(certs)
+	return in
+}
+
+// ptrObservationsFromDNS extracts PTR records from the host's DNS record set.
+// Non-PTR rows and PTR rows with empty values are skipped.
+func ptrObservationsFromDNS(dnsRecords []db.DNSRecord) []services.PTRObservation {
+	out := make([]services.PTRObservation, 0, len(dnsRecords))
+	for i := range dnsRecords {
+		r := dnsRecords[i]
+		if r.RecordType != "PTR" || r.Value == "" {
+			continue
+		}
+		out = append(out, services.PTRObservation{
+			Name:       r.Value,
+			ObservedAt: r.ResolvedAt,
+		})
+	}
+	return out
+}
+
+// certSubjectsFromCerts flattens certs into subject entries (CN first, then
+// each SAN). ForwardMatchesIP is always false — verification is deferred.
+func certSubjectsFromCerts(certs []*db.Certificate) []services.CertSubject {
+	out := make([]services.CertSubject, 0, len(certs))
+	for _, c := range certs {
+		if c == nil {
+			continue
+		}
+		observed := c.ScannedAt
+		if c.SubjectCN != nil && *c.SubjectCN != "" {
+			out = append(out, services.CertSubject{
+				Name:             *c.SubjectCN,
+				Kind:             "cn",
+				ObservedAt:       observed,
+				ForwardMatchesIP: false,
+			})
+		}
+		for _, san := range c.SANs {
+			if san == "" {
+				continue
+			}
+			out = append(out, services.CertSubject{
+				Name:             san,
+				Kind:             "san",
+				ObservedAt:       observed,
+				ForwardMatchesIP: false,
+			})
+		}
+	}
+	return out
+}
+
+// toNameCandidateResponses converts resolver candidates to the API shape,
+// converting zero-valued ObservedAt timestamps to nil so they serialize as
+// omitted rather than "0001-01-01T00:00:00Z".
+func toNameCandidateResponses(cs []services.NameCandidate) []NameCandidateResponse {
+	out := make([]NameCandidateResponse, 0, len(cs))
+	for _, c := range cs {
+		r := NameCandidateResponse{
+			Name:            c.Name,
+			Source:          string(c.Source),
+			Usable:          c.Usable,
+			NotUsableReason: c.NotUsableReason,
+		}
+		if !c.ObservedAt.IsZero() {
+			t := c.ObservedAt
+			r.ObservedAt = &t
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// resolveAndListCandidates builds the display_name / candidate list pair for
+// a host given its related data, and writes them onto the response. Intended
+// for the GET /hosts/{id} path where all identity-related tables are joined.
+func (h *HostHandler) augmentWithFullIdentity(
+	resp *HostResponse,
+	host *db.Host,
+	dnsRecords []db.DNSRecord,
+	certs []*db.Certificate,
+	snmp *db.HostSNMPData,
+) {
+	inputs := fullIdentityInputs(host, dnsRecords, certs, snmp)
+	resolution := services.ResolveDisplayName(inputs, services.DefaultIdentityRankOrder)
+	resp.DisplayName = resolution.Name
+	resp.DisplayNameSource = string(resolution.Source)
+	resp.NameCandidates = toNameCandidateResponses(services.ListNameCandidates(inputs))
+}

--- a/internal/api/handlers/host_test.go
+++ b/internal/api/handlers/host_test.go
@@ -1436,3 +1436,127 @@ func TestHostHandler_CreateHost_Conflict(t *testing.T) {
 		assert.Contains(t, errResp["message"], "192.168.1.50")
 	})
 }
+
+// ── UpdateCustomName ─────────────────────────────────────────────────────────
+
+func TestHostHandler_UpdateCustomName_Success(t *testing.T) {
+	h, store, ctrl := newHostHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	hostID := uuid.New()
+	customName := "office-router"
+	returned := &db.Host{
+		ID:         hostID,
+		IPAddress:  db.IPAddr{IP: net.ParseIP("192.168.1.10")},
+		Status:     db.HostStatusUp,
+		CustomName: &customName,
+	}
+
+	store.EXPECT().
+		UpdateCustomName(gomock.Any(), hostID, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ uuid.UUID, name *string) (*db.Host, error) {
+			require.NotNil(t, name)
+			assert.Equal(t, "office-router", *name)
+			return returned, nil
+		})
+
+	body, err := json.Marshal(CustomNameRequest{CustomName: &customName})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPatch,
+		"/api/v1/hosts/"+hostID.String()+"/custom-name", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = mux.SetURLVars(req, map[string]string{"id": hostID.String()})
+	w := httptest.NewRecorder()
+
+	h.UpdateCustomName(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "office-router", resp["custom_name"])
+}
+
+func TestHostHandler_UpdateCustomName_ClearsOverride(t *testing.T) {
+	// {"custom_name": "  "} and {"custom_name": null} both clear — verify the
+	// handler normalizes whitespace to nil before calling the service.
+	h, store, ctrl := newHostHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	hostID := uuid.New()
+	store.EXPECT().
+		UpdateCustomName(gomock.Any(), hostID, gomock.Nil()).
+		Return(&db.Host{ID: hostID, IPAddress: db.IPAddr{IP: net.ParseIP("192.168.1.10")}}, nil)
+
+	body := []byte(`{"custom_name": "   "}`)
+	req := httptest.NewRequest(http.MethodPatch,
+		"/api/v1/hosts/"+hostID.String()+"/custom-name", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = mux.SetURLVars(req, map[string]string{"id": hostID.String()})
+	w := httptest.NewRecorder()
+
+	h.UpdateCustomName(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestHostHandler_UpdateCustomName_TooLong_Returns400(t *testing.T) {
+	h, _, ctrl := newHostHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	hostID := uuid.New()
+	long := strings.Repeat("a", 256)
+	body, err := json.Marshal(CustomNameRequest{CustomName: &long})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPatch,
+		"/api/v1/hosts/"+hostID.String()+"/custom-name", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = mux.SetURLVars(req, map[string]string{"id": hostID.String()})
+	w := httptest.NewRecorder()
+
+	h.UpdateCustomName(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHostHandler_UpdateCustomName_NotFound_Returns404(t *testing.T) {
+	h, store, ctrl := newHostHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	hostID := uuid.New()
+	store.EXPECT().
+		UpdateCustomName(gomock.Any(), hostID, gomock.Any()).
+		Return(nil, notFoundErr("host", hostID.String()))
+
+	name := "x"
+	body, err := json.Marshal(CustomNameRequest{CustomName: &name})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPatch,
+		"/api/v1/hosts/"+hostID.String()+"/custom-name", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = mux.SetURLVars(req, map[string]string{"id": hostID.String()})
+	w := httptest.NewRecorder()
+
+	h.UpdateCustomName(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHostHandler_UpdateCustomName_InvalidUUID_Returns400(t *testing.T) {
+	h, _, ctrl := newHostHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	body := []byte(`{"custom_name": "x"}`)
+	req := httptest.NewRequest(http.MethodPatch,
+		"/api/v1/hosts/not-a-uuid/custom-name", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", "not-a-uuid")
+	w := httptest.NewRecorder()
+
+	h.UpdateCustomName(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/internal/api/handlers/interfaces.go
+++ b/internal/api/handlers/interfaces.go
@@ -77,6 +77,7 @@ type HostServicer interface {
 	CreateHost(ctx context.Context, input db.CreateHostInput) (*db.Host, error)
 	GetHost(ctx context.Context, id uuid.UUID) (*db.Host, error)
 	UpdateHost(ctx context.Context, id uuid.UUID, input db.UpdateHostInput) (*db.Host, error)
+	UpdateCustomName(ctx context.Context, id uuid.UUID, name *string) (*db.Host, error)
 	DeleteHost(ctx context.Context, id uuid.UUID) error
 	BulkDeleteHosts(ctx context.Context, ids []uuid.UUID) (int64, error)
 	GetHostScans(ctx context.Context, hostID uuid.UUID, offset, limit int) ([]*db.Scan, int64, error)

--- a/internal/api/handlers/mocks/mock_host_servicer.go
+++ b/internal/api/handlers/mocks/mock_host_servicer.go
@@ -508,6 +508,45 @@ func (c *MockHostServicerRemoveHostTagsCall) DoAndReturn(f func(context.Context,
 	return c
 }
 
+// UpdateCustomName mocks base method.
+func (m *MockHostServicer) UpdateCustomName(ctx context.Context, id uuid.UUID, name *string) (*db.Host, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateCustomName", ctx, id, name)
+	ret0, _ := ret[0].(*db.Host)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateCustomName indicates an expected call of UpdateCustomName.
+func (mr *MockHostServicerMockRecorder) UpdateCustomName(ctx, id, name any) *MockHostServicerUpdateCustomNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCustomName", reflect.TypeOf((*MockHostServicer)(nil).UpdateCustomName), ctx, id, name)
+	return &MockHostServicerUpdateCustomNameCall{Call: call}
+}
+
+// MockHostServicerUpdateCustomNameCall wrap *gomock.Call
+type MockHostServicerUpdateCustomNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockHostServicerUpdateCustomNameCall) Return(arg0 *db.Host, arg1 error) *MockHostServicerUpdateCustomNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockHostServicerUpdateCustomNameCall) Do(f func(context.Context, uuid.UUID, *string) (*db.Host, error)) *MockHostServicerUpdateCustomNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockHostServicerUpdateCustomNameCall) DoAndReturn(f func(context.Context, uuid.UUID, *string) (*db.Host, error)) *MockHostServicerUpdateCustomNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // UpdateHost mocks base method.
 func (m *MockHostServicer) UpdateHost(ctx context.Context, id uuid.UUID, input db.UpdateHostInput) (*db.Host, error) {
 	m.ctrl.T.Helper()

--- a/internal/api/handlers/smartscan.go
+++ b/internal/api/handlers/smartscan.go
@@ -23,6 +23,7 @@ type smartScanServicer interface {
 	GetProfileRecommendations(ctx context.Context) ([]services.ProfileRecommendation, error)
 	EvaluateHostByID(ctx context.Context, hostID uuid.UUID) (*services.ScanStage, error)
 	QueueSmartScan(ctx context.Context, hostID uuid.UUID) (uuid.UUID, error)
+	QueueIdentityEnrichment(ctx context.Context, hostID uuid.UUID) (uuid.UUID, error)
 	QueueBatch(ctx context.Context, filter services.BatchFilter) (*services.BatchResult, error)
 }
 
@@ -144,6 +145,52 @@ type triggerHostResponse struct {
 	Queued  bool   `json:"queued"`
 	ScanID  string `json:"scan_id,omitempty"`
 	Message string `json:"message,omitempty"`
+}
+
+// RefreshIdentity handles POST /api/v1/smart-scan/hosts/{id}/refresh-identity.
+// It unconditionally queues an identity_enrichment scan for the host —
+// bypassing the usual "does the host need this?" evaluation because the
+// user asked explicitly via the Identity tab's "Refresh identity now" button.
+//
+//	@Summary		Refresh host identity
+//	@Description	Queues an identity_enrichment scan for the host, probing mDNS/SNMP/DNS/TLS surfaces so post-scan
+//	@Description	enrichment can fill in name signals. Runs even when the host already has a usable name.
+//	@Tags			smart-scan
+//	@Produce		json
+//	@Param			id	path		string	true	"Host UUID"
+//	@Success		202	{object}	triggerHostResponse
+//	@Failure		400	{object}	ErrorResponse
+//	@Failure		404	{object}	ErrorResponse
+//	@Failure		429	{object}	ErrorResponse
+//	@Failure		500	{object}	ErrorResponse
+//	@Router			/smart-scan/hosts/{id}/refresh-identity [post]
+func (h *SmartScanHandler) RefreshIdentity(w http.ResponseWriter, r *http.Request) {
+	hostID, err := parseHostID(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	scanID, err := h.service.QueueIdentityEnrichment(r.Context(), hostID)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			writeError(w, r, http.StatusNotFound, err)
+			return
+		}
+		if stderrors.Is(err, scanning.ErrQueueFull) {
+			writeError(w, r, http.StatusTooManyRequests, err)
+			return
+		}
+		h.logger.Error("Failed to refresh host identity", "host_id", hostID, "error", err)
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	writeJSON(w, r, http.StatusAccepted, triggerHostResponse{
+		HostID: hostID.String(),
+		Queued: true,
+		ScanID: scanID.String(),
+	})
 }
 
 // TriggerBatch handles POST /api/v1/smart-scan/trigger-batch.

--- a/internal/api/handlers/smartscan_test.go
+++ b/internal/api/handlers/smartscan_test.go
@@ -27,6 +27,7 @@ type mockSmartScanServicer struct {
 	getProfileRecommendationsFn func(ctx context.Context) ([]services.ProfileRecommendation, error)
 	evaluateHostByIDFn          func(ctx context.Context, id uuid.UUID) (*services.ScanStage, error)
 	queueSmartScanFn            func(ctx context.Context, id uuid.UUID) (uuid.UUID, error)
+	queueIdentityEnrichmentFn   func(ctx context.Context, id uuid.UUID) (uuid.UUID, error)
 	queueBatchFn                func(ctx context.Context, f services.BatchFilter) (*services.BatchResult, error)
 }
 
@@ -49,6 +50,15 @@ func (m *mockSmartScanServicer) EvaluateHostByID(ctx context.Context, id uuid.UU
 
 func (m *mockSmartScanServicer) QueueSmartScan(ctx context.Context, id uuid.UUID) (uuid.UUID, error) {
 	return m.queueSmartScanFn(ctx, id)
+}
+
+func (m *mockSmartScanServicer) QueueIdentityEnrichment(
+	ctx context.Context, id uuid.UUID,
+) (uuid.UUID, error) {
+	if m.queueIdentityEnrichmentFn == nil {
+		return uuid.Nil, nil
+	}
+	return m.queueIdentityEnrichmentFn(ctx, id)
 }
 
 func (m *mockSmartScanServicer) QueueBatch(

--- a/internal/api/handlers/smartscan_test.go
+++ b/internal/api/handlers/smartscan_test.go
@@ -81,6 +81,7 @@ func routeSmartScan(h *SmartScanHandler, method, path string, body []byte) *http
 	r.HandleFunc("/api/v1/smart-scan/profile-recommendations", h.GetProfileRecommendations).Methods("GET")
 	r.HandleFunc("/api/v1/smart-scan/hosts/{id}/stage", h.EvaluateHost).Methods("GET")
 	r.HandleFunc("/api/v1/smart-scan/hosts/{id}/trigger", h.TriggerHost).Methods("POST")
+	r.HandleFunc("/api/v1/smart-scan/hosts/{id}/refresh-identity", h.RefreshIdentity).Methods("POST")
 	r.HandleFunc("/api/v1/smart-scan/trigger-batch", h.TriggerBatch).Methods("POST")
 
 	var req *http.Request
@@ -240,6 +241,49 @@ func TestSmartScan_TriggerHost_QueueFull_Returns429(t *testing.T) {
 
 	w := routeSmartScan(newSmartScanHandler(svc), "POST",
 		"/api/v1/smart-scan/hosts/"+hostID.String()+"/trigger", nil)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+}
+
+// ── RefreshIdentity ───────────────────────────────────────────────────────────
+
+func TestSmartScan_RefreshIdentity_Returns202WithScanID(t *testing.T) {
+	hostID := uuid.New()
+	scanID := uuid.New()
+	svc := &mockSmartScanServicer{
+		queueIdentityEnrichmentFn: func(_ context.Context, id uuid.UUID) (uuid.UUID, error) {
+			assert.Equal(t, hostID, id)
+			return scanID, nil
+		},
+	}
+
+	w := routeSmartScan(newSmartScanHandler(svc), "POST",
+		"/api/v1/smart-scan/hosts/"+hostID.String()+"/refresh-identity", nil)
+	require.Equal(t, http.StatusAccepted, w.Code)
+
+	var resp triggerHostResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Queued)
+	assert.Equal(t, scanID.String(), resp.ScanID)
+	assert.Equal(t, hostID.String(), resp.HostID)
+}
+
+func TestSmartScan_RefreshIdentity_BadUUID_Returns400(t *testing.T) {
+	svc := &mockSmartScanServicer{}
+	w := routeSmartScan(newSmartScanHandler(svc), "POST",
+		"/api/v1/smart-scan/hosts/not-a-uuid/refresh-identity", nil)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSmartScan_RefreshIdentity_QueueFull_Returns429(t *testing.T) {
+	hostID := uuid.New()
+	svc := &mockSmartScanServicer{
+		queueIdentityEnrichmentFn: func(_ context.Context, _ uuid.UUID) (uuid.UUID, error) {
+			return uuid.Nil, scanning.ErrQueueFull
+		},
+	}
+
+	w := routeSmartScan(newSmartScanHandler(svc), "POST",
+		"/api/v1/smart-scan/hosts/"+hostID.String()+"/refresh-identity", nil)
 	assert.Equal(t, http.StatusTooManyRequests, w.Code)
 }
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -116,6 +116,7 @@ func (s *Server) setupSmartScanRoutes(api *mux.Router, h *apihandlers.SmartScanH
 	api.HandleFunc("/smart-scan/profile-recommendations", h.GetProfileRecommendations).Methods("GET")
 	api.HandleFunc("/smart-scan/hosts/{id}/stage", h.EvaluateHost).Methods("GET")
 	api.HandleFunc("/smart-scan/hosts/{id}/trigger", h.TriggerHost).Methods("POST")
+	api.HandleFunc("/smart-scan/hosts/{id}/refresh-identity", h.RefreshIdentity).Methods("POST")
 	api.HandleFunc("/smart-scan/trigger-batch", h.TriggerBatch).Methods("POST")
 }
 
@@ -139,6 +140,7 @@ func (s *Server) setupHostRoutes(api *mux.Router, h *apihandlers.HostHandler) {
 	api.HandleFunc("/hosts/{id}", h.GetHost).Methods("GET")
 	api.HandleFunc("/hosts/{id}", h.UpdateHost).Methods("PUT")
 	api.HandleFunc("/hosts/{id}", h.DeleteHost).Methods("DELETE")
+	api.HandleFunc("/hosts/{id}/custom-name", h.UpdateCustomName).Methods("PATCH")
 	api.HandleFunc("/hosts/{id}/scans", h.GetHostScans).Methods("GET")
 	api.HandleFunc("/hosts/{id}/networks", h.GetHostNetworks).Methods("GET")
 }

--- a/internal/db/027_host_identity.sql
+++ b/internal/db/027_host_identity.sql
@@ -1,0 +1,46 @@
+-- Migration 027: Host identity resolution
+--
+-- Adds the plumbing for picking a single "display name" per host from several
+-- candidate sources, plus an explicit user-defined override.
+--
+-- Two nullable columns on hosts:
+--   custom_name      — user-defined override. Written only by the UI's
+--                      Identity tab. Always wins when non-null; auto-enrichers
+--                      never touch it.
+--   hostname_source  — provenance tag for the existing hosts.hostname value.
+--                      One of manual|ptr|mdns|snmp|cert. Existing non-null
+--                      hostnames are backfilled as 'ptr' — historically the
+--                      DNS enricher was the only writer.
+--
+-- Configurable ranking lives on the existing settings table under key
+-- identity.rank_order as a JSONB array.
+
+ALTER TABLE hosts
+    ADD COLUMN IF NOT EXISTS custom_name     VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS hostname_source VARCHAR(32)
+        CHECK (hostname_source IS NULL OR hostname_source IN (
+            'manual', 'ptr', 'mdns', 'snmp', 'cert'
+        ));
+
+-- Backfill provenance for every existing non-null hostname.
+UPDATE hosts
+   SET hostname_source = 'ptr'
+ WHERE hostname IS NOT NULL
+   AND hostname <> ''
+   AND hostname_source IS NULL;
+
+-- Seed default identity rank order. Operators can edit via the settings API.
+INSERT INTO settings (key, value, type, description) VALUES
+    ('identity.rank_order',
+     '["mdns","snmp","ptr","cert"]',
+     'string[]',
+     'Ordered list of automatic name sources for display_name resolution')
+ON CONFLICT (key) DO NOTHING;
+
+COMMENT ON COLUMN hosts.custom_name IS
+    'User-defined display-name override. Wins over any auto-discovered name '
+    'when non-null. Never written by enrichers.';
+
+COMMENT ON COLUMN hosts.hostname_source IS
+    'Provenance for hosts.hostname: one of manual|ptr|mdns|snmp|cert. '
+    'NULL means unknown/legacy.';

--- a/internal/db/hosts_additional_unit_test.go
+++ b/internal/db/hosts_additional_unit_test.go
@@ -487,6 +487,7 @@ var getHostColumns = []string{
 	"tags",
 	"knowledge_score",
 	"device_id", "mdns_name", "device_name",
+	"custom_name", "hostname_source",
 }
 
 func TestGetHost_Success(t *testing.T) {
@@ -526,6 +527,8 @@ func TestGetHost_Success(t *testing.T) {
 			nil, // device_id
 			nil, // mdns_name
 			nil, // device_name
+			nil, // custom_name
+			nil, // hostname_source
 		))
 
 	// fetchHostPorts — return empty result set (no ports for this host).

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -382,6 +382,13 @@ type Host struct {
 	MDNSName *string `db:"mdns_name" json:"mdns_name,omitempty"`
 	// DeviceName is the name of the attached device, populated by JOIN in GetHost/ListHosts.
 	DeviceName *string `db:"-" json:"device_name,omitempty"`
+	// CustomName is a user-defined display-name override. When non-null it wins
+	// over any auto-discovered candidate in display_name resolution. Enrichers
+	// never write this column; only the Identity tab's custom-name input does.
+	CustomName *string `db:"custom_name" json:"custom_name,omitempty"`
+	// HostnameSource tags the provenance of Hostname: one of
+	// manual|ptr|mdns|snmp|cert. NULL means unknown/legacy.
+	HostnameSource *string `db:"hostname_source" json:"hostname_source,omitempty"`
 }
 
 // GetOSFingerprint returns the OS fingerprint information.

--- a/internal/db/repository_host.go
+++ b/internal/db/repository_host.go
@@ -737,6 +737,35 @@ func (r *HostRepository) UpdateHost(ctx context.Context, id uuid.UUID, input Upd
 	return r.GetHost(ctx, id)
 }
 
+// UpdateCustomName sets or clears the user-defined display-name override
+// for a host. Pass nil to clear. Returns ErrNotFound when the host does
+// not exist. Unlike UpdateHost this is a single-column, single-purpose
+// update: it never touches last_seen (this is a user edit, not an
+// observation) and bypasses the dynamic SET-clause builder entirely.
+func (r *HostRepository) UpdateCustomName(ctx context.Context, id uuid.UUID, name *string) (*Host, error) {
+	var sv sql.NullString
+	if name != nil {
+		sv = sql.NullString{String: *name, Valid: true}
+	}
+
+	result, err := r.db.ExecContext(ctx,
+		`UPDATE hosts SET custom_name = $1 WHERE id = $2`,
+		sv, id)
+	if err != nil {
+		return nil, sanitizeDBError("update host custom_name", err)
+	}
+
+	rows, rErr := result.RowsAffected()
+	if rErr != nil {
+		return nil, fmt.Errorf("custom_name update: rows affected: %w", rErr)
+	}
+	if rows == 0 {
+		return nil, errors.ErrNotFoundWithID("host", id.String())
+	}
+
+	return r.GetHost(ctx, id)
+}
+
 // DeleteHost deletes a host by ID.
 func (r *HostRepository) DeleteHost(ctx context.Context, id uuid.UUID) error {
 	// Start a transaction.

--- a/internal/db/repository_host.go
+++ b/internal/db/repository_host.go
@@ -322,7 +322,9 @@ func (r *HostRepository) ListHosts(
 			END AS scan_count,
 			h.device_id,
 			h.mdns_name,
-			dv.name AS device_name
+			dv.name AS device_name,
+			h.custom_name,
+			h.hostname_source
 		FROM hosts h
 		LEFT JOIN port_scans ps ON h.id = ps.host_id
 		LEFT JOIN port_scans ps2 ON h.id = ps2.host_id
@@ -347,7 +349,7 @@ func (r *HostRepository) ListHosts(
 			h.response_time_ms, h.response_time_min_ms, h.response_time_max_ms, h.response_time_avg_ms,
 			h.ignore_scanning, h.first_seen, h.last_seen, h.status,
 			h.status_changed_at, h.previous_status, h.timeout_count, h.tags, h.knowledge_score,
-			h.device_id, h.mdns_name, dv.name
+			h.device_id, h.mdns_name, dv.name, h.custom_name, h.hostname_source
 	`
 
 	// Resolve ORDER BY clause from validated sort parameters.
@@ -527,6 +529,8 @@ type hostScanVars struct {
 	ignoreScanning                        *bool
 	previousStatus                        *string
 	timeoutCount                          int
+	customName                            *string
+	hostnameSource                        *string
 }
 
 // applyHostScanVars copies the scanned nullable fields from vars into host,
@@ -551,6 +555,8 @@ func applyHostScanVars(host *Host, vars hostScanVars) {
 	host.StatusChangedAt = vars.statusChangedAt
 	assignStringPtr(&host.PreviousStatus, vars.previousStatus)
 	host.TimeoutCount = vars.timeoutCount
+	assignStringPtr(&host.CustomName, vars.customName)
+	assignStringPtr(&host.HostnameSource, vars.hostnameSource)
 }
 
 func (r *HostRepository) GetHost(ctx context.Context, id uuid.UUID) (*Host, error) {
@@ -584,7 +590,9 @@ func (r *HostRepository) GetHost(ctx context.Context, id uuid.UUID) (*Host, erro
 			h.knowledge_score,
 			h.device_id,
 			h.mdns_name,
-			dv.name AS device_name
+			dv.name AS device_name,
+			h.custom_name,
+			h.hostname_source
 		FROM hosts h
 		LEFT JOIN devices dv ON dv.id = h.device_id
 		WHERE h.id = $1
@@ -623,6 +631,8 @@ func (r *HostRepository) GetHost(ctx context.Context, id uuid.UUID) (*Host, erro
 		&host.DeviceID,
 		&host.MDNSName,
 		&host.DeviceName,
+		&vars.customName,
+		&vars.hostnameSource,
 	)
 	if err != nil {
 		if stderrors.Is(err, sql.ErrNoRows) {
@@ -1106,102 +1116,78 @@ func (r *HostRepository) getHostCount(ctx context.Context, whereClause string, a
 	return total, nil
 }
 
+// scanSingleHostRow reads one row from the list-hosts query into a Host.
+// Extracted from scanHostRows so the loop stays under the funlen limit.
+func scanSingleHostRow(rows *sql.Rows) (*Host, error) {
+	host := &Host{}
+	var ipAddress string
+	var vars hostScanVars
+	var openPorts sql.NullInt64
+	var totalPortsScanned int64
+	var scanCount sql.NullInt64
+
+	err := rows.Scan(
+		&host.ID,
+		&ipAddress,
+		&vars.hostname,
+		&vars.macAddressStr,
+		&vars.vendor,
+		&vars.osFamily,
+		&vars.osName,
+		&vars.osVersion,
+		&vars.osConfidence,
+		&vars.osDetectedAt,
+		&vars.osMethod,
+		&vars.osDetails,
+		&vars.discoveryMethod,
+		&vars.responseTimeMS,
+		&vars.responseTimeMinMS,
+		&vars.responseTimeMaxMS,
+		&vars.responseTimeAvgMS,
+		&vars.ignoreScanning,
+		&host.FirstSeen,
+		&host.LastSeen,
+		&host.Status,
+		&vars.statusChangedAt,
+		&vars.previousStatus,
+		&vars.timeoutCount,
+		&host.Tags,
+		&host.KnowledgeScore,
+		&openPorts,
+		&totalPortsScanned,
+		&scanCount,
+		&host.DeviceID,
+		&host.MDNSName,
+		&host.DeviceName,
+		&vars.customName,
+		&vars.hostnameSource,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan host row: %w", err)
+	}
+
+	host.IPAddress = IPAddr{IP: net.ParseIP(ipAddress)}
+	applyHostScanVars(host, vars)
+
+	// Aggregated port counts are list-specific; when NULL (host has never
+	// been scanned) leave the zero value so the frontend renders "—".
+	if openPorts.Valid {
+		host.TotalPorts = int(openPorts.Int64)
+	}
+	if scanCount.Valid {
+		host.ScanCount = int(scanCount.Int64)
+	}
+	return host, nil
+}
+
 // scanHostRows processes query result rows into Host structs.
 func (r *HostRepository) scanHostRows(rows *sql.Rows) ([]*Host, error) {
 	var hosts []*Host
 	for rows.Next() {
-		host := &Host{}
-		var ipAddress string
-		var hostname, macAddressStr, vendor, osFamily, osName, osVersion *string
-		var osConfidence, responseTimeMS *int
-		var responseTimeMinMS, responseTimeMaxMS, responseTimeAvgMS *int
-		var osDetectedAt *time.Time
-		var osMethod *string
-		var osDetails JSONB
-		var discoveryMethod *string
-		var ignoreScanning *bool
-		var statusChangedAt *time.Time
-		var previousStatus *string
-		var timeoutCount int
-
-		var openPorts sql.NullInt64
-		var totalPortsScanned int64
-		var scanCount sql.NullInt64
-
-		err := rows.Scan(
-			&host.ID,
-			&ipAddress,
-			&hostname,
-			&macAddressStr,
-			&vendor,
-			&osFamily,
-			&osName,
-			&osVersion,
-			&osConfidence,
-			&osDetectedAt,
-			&osMethod,
-			&osDetails,
-			&discoveryMethod,
-			&responseTimeMS,
-			&responseTimeMinMS,
-			&responseTimeMaxMS,
-			&responseTimeAvgMS,
-			&ignoreScanning,
-			&host.FirstSeen,
-			&host.LastSeen,
-			&host.Status,
-			&statusChangedAt,
-			&previousStatus,
-			&timeoutCount,
-			&host.Tags,
-			&host.KnowledgeScore,
-			&openPorts,
-			&totalPortsScanned,
-			&scanCount,
-			&host.DeviceID,
-			&host.MDNSName,
-			&host.DeviceName,
-		)
+		host, err := scanSingleHostRow(rows)
 		if err != nil {
-			return nil, fmt.Errorf("failed to scan host row: %w", err)
+			return nil, err
 		}
-
-		// Convert IP address.
-		host.IPAddress = IPAddr{IP: net.ParseIP(ipAddress)}
-
-		// Handle nullable fields using helper functions.
-		assignStringPtr(&host.Hostname, hostname)
-		assignMACAddress(&host.MACAddress, macAddressStr)
-		assignStringPtr(&host.Vendor, vendor)
-		assignStringPtr(&host.OSFamily, osFamily)
-		assignStringPtr(&host.OSName, osName)
-		assignStringPtr(&host.OSVersion, osVersion)
-		assignIntPtr(&host.OSConfidence, osConfidence)
-		host.OSDetectedAt = osDetectedAt
-		assignStringPtr(&host.OSMethod, osMethod)
-		host.OSDetails = osDetails
-		assignStringPtr(&host.DiscoveryMethod, discoveryMethod)
-		assignIntPtr(&host.ResponseTimeMS, responseTimeMS)
-		assignIntPtr(&host.ResponseTimeMinMS, responseTimeMinMS)
-		assignIntPtr(&host.ResponseTimeMaxMS, responseTimeMaxMS)
-		assignIntPtr(&host.ResponseTimeAvgMS, responseTimeAvgMS)
-		assignBoolFromPtr(&host.IgnoreScanning, ignoreScanning)
-		host.StatusChangedAt = statusChangedAt
-		assignStringPtr(&host.PreviousStatus, previousStatus)
-		host.TimeoutCount = timeoutCount
-
-		// Wire the aggregated port counts from the list query.
-		// These are counts across all scan jobs — not latest-state — so they
-		// are only used for the list view summary numbers, not the detail panel.
-		// NULL means the host has never been scanned (no port_scan rows exist);
-		// the zero value (0) is left in place, which the frontend renders as "—".
-		if openPorts.Valid {
-			host.TotalPorts = int(openPorts.Int64)
-		}
-		if scanCount.Valid {
-			host.ScanCount = int(scanCount.Int64)
-		}
-
 		hosts = append(hosts, host)
 	}
 

--- a/internal/db/repository_host_tags_unit_test.go
+++ b/internal/db/repository_host_tags_unit_test.go
@@ -371,6 +371,7 @@ func TestHostRepository_GetHost_PopulatesTags(t *testing.T) {
 				pq.StringArray{"prod", "web"}, // tags
 				0,                             // knowledge_score
 				nil, nil, nil,                 // device_id, mdns_name, device_name
+				nil, nil, // custom_name, hostname_source
 			))
 
 	// fetchHostPorts — no ports.
@@ -415,6 +416,7 @@ func TestHostRepository_GetHost_EmptyTags(t *testing.T) {
 				pq.StringArray{},
 				0,             // knowledge_score
 				nil, nil, nil, // device_id, mdns_name, device_name
+				nil, nil, // custom_name, hostname_source
 			))
 
 	mock.ExpectQuery("SELECT DISTINCT").
@@ -474,6 +476,7 @@ func TestHostRepository_ScanHostRows_PopulatesTags(t *testing.T) {
 				int64(3),                             // total_ports_scanned
 				sql.NullInt64{Int64: 1, Valid: true}, // scan_count
 				nil, nil, nil,                        // device_id, mdns_name, device_name
+				nil, nil, // custom_name, hostname_source
 			))
 
 	filters := &HostFilters{}

--- a/internal/enrichment/dns_test.go
+++ b/internal/enrichment/dns_test.go
@@ -590,6 +590,7 @@ var getHostCols = []string{
 	"tags",
 	"knowledge_score",
 	"device_id", "mdns_name", "device_name",
+	"custom_name", "hostname_source",
 }
 
 // TestMaybeSetHostname_UpdateHostSucceeds verifies that maybeSetHostname logs
@@ -624,6 +625,7 @@ func TestMaybeSetHostname_UpdateHostSucceeds(t *testing.T) {
 			pq.StringArray{},
 			0,
 			nil, nil, nil, // device_id, mdns_name, device_name
+			nil, nil, // custom_name, hostname_source
 		))
 	hostMock.ExpectQuery("SELECT DISTINCT").
 		WillReturnRows(sqlmock.NewRows([]string{"port", "protocol", "state", "service_name", "scanned_at"}))

--- a/internal/services/host.go
+++ b/internal/services/host.go
@@ -21,6 +21,7 @@ type hostRepository interface {
 	CreateHost(ctx context.Context, input db.CreateHostInput) (*db.Host, error)
 	GetHost(ctx context.Context, id uuid.UUID) (*db.Host, error)
 	UpdateHost(ctx context.Context, id uuid.UUID, input db.UpdateHostInput) (*db.Host, error)
+	UpdateCustomName(ctx context.Context, id uuid.UUID, name *string) (*db.Host, error)
 	DeleteHost(ctx context.Context, id uuid.UUID) error
 	BulkDeleteHosts(ctx context.Context, ids []uuid.UUID) (int64, error)
 	GetHostScans(ctx context.Context, hostID uuid.UUID, offset, limit int) ([]*db.Scan, int64, error)
@@ -72,6 +73,14 @@ func (s *HostService) GetHost(ctx context.Context, id uuid.UUID) (*db.Host, erro
 // UpdateHost applies the provided changes to an existing host record.
 func (s *HostService) UpdateHost(ctx context.Context, id uuid.UUID, input db.UpdateHostInput) (*db.Host, error) {
 	return s.repo.UpdateHost(ctx, id, input)
+}
+
+// UpdateCustomName sets or clears the user-defined display-name override for
+// a host. Pass nil to clear.
+func (s *HostService) UpdateCustomName(
+	ctx context.Context, id uuid.UUID, name *string,
+) (*db.Host, error) {
+	return s.repo.UpdateCustomName(ctx, id, name)
 }
 
 // DeleteHost removes a host record by its UUID.

--- a/internal/services/host_test.go
+++ b/internal/services/host_test.go
@@ -20,20 +20,21 @@ import (
 // ---------------------------------------------------------------------------
 
 type mockHostRepo struct {
-	listHostsFn       func(ctx context.Context, filters *db.HostFilters, offset, limit int) ([]*db.Host, int64, error)
-	createHostFn      func(ctx context.Context, input db.CreateHostInput) (*db.Host, error)
-	getHostFn         func(ctx context.Context, id uuid.UUID) (*db.Host, error)
-	updateHostFn      func(ctx context.Context, id uuid.UUID, input db.UpdateHostInput) (*db.Host, error)
-	deleteHostFn      func(ctx context.Context, id uuid.UUID) error
-	bulkDeleteHostsFn func(ctx context.Context, ids []uuid.UUID) (int64, error)
-	getHostScansFn    func(ctx context.Context, hostID uuid.UUID, offset, limit int) ([]*db.Scan, int64, error)
-	getAllTagsFn      func(ctx context.Context) ([]string, error)
-	updateHostTagsFn  func(ctx context.Context, id uuid.UUID, tags []string) error
-	addHostTagsFn     func(ctx context.Context, id uuid.UUID, tags []string) error
-	removeHostTagsFn  func(ctx context.Context, id uuid.UUID, tags []string) error
-	bulkUpdateTagsFn  func(ctx context.Context, ids []uuid.UUID, tags []string, action string) error
-	getHostGroupsFn   func(ctx context.Context, hostID uuid.UUID) ([]db.HostGroupSummary, error)
-	getHostNetworksFn func(ctx context.Context, hostID uuid.UUID) ([]*db.Network, error)
+	listHostsFn        func(ctx context.Context, filters *db.HostFilters, offset, limit int) ([]*db.Host, int64, error)
+	createHostFn       func(ctx context.Context, input db.CreateHostInput) (*db.Host, error)
+	getHostFn          func(ctx context.Context, id uuid.UUID) (*db.Host, error)
+	updateHostFn       func(ctx context.Context, id uuid.UUID, input db.UpdateHostInput) (*db.Host, error)
+	updateCustomNameFn func(ctx context.Context, id uuid.UUID, name *string) (*db.Host, error)
+	deleteHostFn       func(ctx context.Context, id uuid.UUID) error
+	bulkDeleteHostsFn  func(ctx context.Context, ids []uuid.UUID) (int64, error)
+	getHostScansFn     func(ctx context.Context, hostID uuid.UUID, offset, limit int) ([]*db.Scan, int64, error)
+	getAllTagsFn       func(ctx context.Context) ([]string, error)
+	updateHostTagsFn   func(ctx context.Context, id uuid.UUID, tags []string) error
+	addHostTagsFn      func(ctx context.Context, id uuid.UUID, tags []string) error
+	removeHostTagsFn   func(ctx context.Context, id uuid.UUID, tags []string) error
+	bulkUpdateTagsFn   func(ctx context.Context, ids []uuid.UUID, tags []string, action string) error
+	getHostGroupsFn    func(ctx context.Context, hostID uuid.UUID) ([]db.HostGroupSummary, error)
+	getHostNetworksFn  func(ctx context.Context, hostID uuid.UUID) ([]*db.Network, error)
 }
 
 func (m *mockHostRepo) GetHostNetworks(ctx context.Context, hostID uuid.UUID) ([]*db.Network, error) {
@@ -59,6 +60,13 @@ func (m *mockHostRepo) GetHost(ctx context.Context, id uuid.UUID) (*db.Host, err
 
 func (m *mockHostRepo) UpdateHost(ctx context.Context, id uuid.UUID, input db.UpdateHostInput) (*db.Host, error) {
 	return m.updateHostFn(ctx, id, input)
+}
+
+func (m *mockHostRepo) UpdateCustomName(ctx context.Context, id uuid.UUID, name *string) (*db.Host, error) {
+	if m.updateCustomNameFn == nil {
+		return nil, nil
+	}
+	return m.updateCustomNameFn(ctx, id, name)
 }
 
 func (m *mockHostRepo) DeleteHost(ctx context.Context, id uuid.UUID) error {

--- a/internal/services/identity.go
+++ b/internal/services/identity.go
@@ -1,0 +1,259 @@
+// Package services contains the scanorama application-layer orchestration.
+// This file holds the host-identity resolver: given a snapshot of every
+// name-like signal observed for a host, it picks one canonical display
+// name and enumerates all the alternatives for the Identity tab.
+package services
+
+import (
+	"strings"
+	"time"
+
+	"github.com/anstrom/scanorama/internal/enrichment"
+)
+
+// Source identifies where a host name candidate came from.
+type Source string
+
+// Known identity sources. SourceIP is the final fallback when nothing else
+// produced a usable name.
+const (
+	SourceCustom Source = "custom"
+	SourceMDNS   Source = "mdns"
+	SourceSNMP   Source = "snmp"
+	SourcePTR    Source = "ptr"
+	SourceCert   Source = "cert"
+	SourceIP     Source = "ip"
+)
+
+const (
+	maxSNMPSysNameLen = 253
+	minPrintableASCII = 0x20
+	maxPrintableASCII = 0x7E
+
+	confidenceCustom = 1.0
+	confidenceMDNS   = 0.9
+	confidenceSNMP   = 0.8
+	confidencePTR    = 0.6
+	confidenceCert   = 0.5
+	confidenceIP     = 0.0
+)
+
+// IdentityResolution is the single winning display name for a host.
+type IdentityResolution struct {
+	Name       string
+	Source     Source
+	Confidence float64
+}
+
+// NameCandidate is one row of the Identity tab table. Unusable candidates
+// are still included so the UI can show users why a given value was not
+// promoted.
+type NameCandidate struct {
+	Name            string
+	Source          Source
+	Usable          bool
+	NotUsableReason string
+	ObservedAt      time.Time
+}
+
+// PTRObservation is a single PTR record with its observation timestamp.
+type PTRObservation struct {
+	Name       string
+	ObservedAt time.Time
+}
+
+// CertSubject is a TLS cert CN or SAN entry with pre-computed reverse-match
+// information. ForwardMatchesIP is true when a forward A/AAAA lookup of
+// Name resolves back to the host's IP — the only case where the cert
+// identity can be trusted as the host's identity.
+type CertSubject struct {
+	Name             string
+	Kind             string // "cn" or "san"
+	ObservedAt       time.Time
+	ForwardMatchesIP bool
+}
+
+// IdentityInputs is the complete input to the resolver. Callers assemble
+// it by querying the DB (and for cert subjects, forward-resolving CN/SAN
+// values to compare against the host IP) before invoking ResolveDisplayName
+// or ListNameCandidates.
+type IdentityInputs struct {
+	IPAddress string
+
+	CustomName *string
+
+	MDNSName   *string
+	MDNSSeenAt time.Time
+
+	SNMPSysName *string
+	SNMPSeenAt  time.Time
+
+	PTRRecords   []PTRObservation
+	CertSubjects []CertSubject
+}
+
+// ResolveDisplayName picks the winning display name by walking rankOrder
+// (for example ["mdns","snmp","ptr","cert"]) and returning the first usable
+// candidate from each source. A non-empty CustomName always wins, and the
+// host IP is the last-resort fallback. Unknown source names in rankOrder
+// are silently skipped so operator-edited config can't crash the resolver.
+func ResolveDisplayName(in IdentityInputs, rankOrder []string) IdentityResolution {
+	if name, ok := trimmedCustomName(in.CustomName); ok {
+		return IdentityResolution{Name: name, Source: SourceCustom, Confidence: confidenceCustom}
+	}
+
+	for _, sourceName := range rankOrder {
+		c := pickFirstUsable(candidatesFrom(in, Source(sourceName)))
+		if c == nil {
+			continue
+		}
+		return IdentityResolution{Name: c.Name, Source: c.Source, Confidence: confidenceFor(c.Source)}
+	}
+
+	return IdentityResolution{Name: in.IPAddress, Source: SourceIP, Confidence: confidenceIP}
+}
+
+// ListNameCandidates enumerates every automatic name candidate for a host,
+// usable or not, in a stable order (mdns, snmp, ptr, cert). CustomName is
+// intentionally excluded — the API surfaces it as its own field because the
+// UI renders it in a separate input, not in the candidate table.
+func ListNameCandidates(in IdentityInputs) []NameCandidate {
+	// Upper-bound: at most one row each from mdns and snmp, plus one per
+	// PTR record and cert subject.
+	upperBound := 2 + len(in.PTRRecords) + len(in.CertSubjects)
+	out := make([]NameCandidate, 0, upperBound)
+	for _, source := range []Source{SourceMDNS, SourceSNMP, SourcePTR, SourceCert} {
+		out = append(out, candidatesFrom(in, source)...)
+	}
+	return out
+}
+
+func confidenceFor(s Source) float64 {
+	switch s {
+	case SourceCustom:
+		return confidenceCustom
+	case SourceMDNS:
+		return confidenceMDNS
+	case SourceSNMP:
+		return confidenceSNMP
+	case SourcePTR:
+		return confidencePTR
+	case SourceCert:
+		return confidenceCert
+	case SourceIP:
+		return confidenceIP
+	}
+	return confidenceIP
+}
+
+func pickFirstUsable(cs []NameCandidate) *NameCandidate {
+	for i := range cs {
+		if cs[i].Usable {
+			return &cs[i]
+		}
+	}
+	return nil
+}
+
+func candidatesFrom(in IdentityInputs, source Source) []NameCandidate {
+	switch source {
+	case SourceMDNS:
+		return mdnsCandidates(in)
+	case SourceSNMP:
+		return snmpCandidates(in)
+	case SourcePTR:
+		return ptrCandidates(in)
+	case SourceCert:
+		return certCandidates(in)
+	case SourceCustom, SourceIP:
+		// Not enumerable through the auto-candidate path.
+		return nil
+	}
+	return nil
+}
+
+func trimmedCustomName(p *string) (string, bool) {
+	if p == nil {
+		return "", false
+	}
+	name := strings.TrimSpace(*p)
+	if name == "" {
+		return "", false
+	}
+	return name, true
+}
+
+func mdnsCandidates(in IdentityInputs) []NameCandidate {
+	if in.MDNSName == nil {
+		return nil
+	}
+	name := strings.TrimSpace(*in.MDNSName)
+	if name == "" {
+		return nil
+	}
+	usable := strings.HasSuffix(strings.ToLower(name), ".local")
+	c := NameCandidate{Name: name, Source: SourceMDNS, Usable: usable, ObservedAt: in.MDNSSeenAt}
+	if !usable {
+		c.NotUsableReason = "mDNS name does not end in .local"
+	}
+	return []NameCandidate{c}
+}
+
+func snmpCandidates(in IdentityInputs) []NameCandidate {
+	if in.SNMPSysName == nil {
+		return nil
+	}
+	name := strings.TrimSpace(*in.SNMPSysName)
+	if name == "" {
+		return nil
+	}
+	usable, reason := validateSNMPSysName(name)
+	c := NameCandidate{Name: name, Source: SourceSNMP, Usable: usable, ObservedAt: in.SNMPSeenAt}
+	if !usable {
+		c.NotUsableReason = reason
+	}
+	return []NameCandidate{c}
+}
+
+func validateSNMPSysName(name string) (usable bool, reason string) {
+	if len(name) > maxSNMPSysNameLen {
+		return false, "sys_name too long"
+	}
+	for _, r := range name {
+		if r < minPrintableASCII || r > maxPrintableASCII {
+			return false, "sys_name contains non-printable characters"
+		}
+	}
+	return true, ""
+}
+
+func ptrCandidates(in IdentityInputs) []NameCandidate {
+	if len(in.PTRRecords) == 0 {
+		return nil
+	}
+	out := make([]NameCandidate, 0, len(in.PTRRecords))
+	for _, r := range in.PTRRecords {
+		usable := enrichment.DNSNameIsUsable(r.Name)
+		c := NameCandidate{Name: r.Name, Source: SourcePTR, Usable: usable, ObservedAt: r.ObservedAt}
+		if !usable {
+			c.NotUsableReason = "filtered: unusable PTR pattern"
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+func certCandidates(in IdentityInputs) []NameCandidate {
+	if len(in.CertSubjects) == 0 {
+		return nil
+	}
+	out := make([]NameCandidate, 0, len(in.CertSubjects))
+	for _, s := range in.CertSubjects {
+		c := NameCandidate{Name: s.Name, Source: SourceCert, Usable: s.ForwardMatchesIP, ObservedAt: s.ObservedAt}
+		if !s.ForwardMatchesIP {
+			c.NotUsableReason = "cert subject does not forward-resolve to host IP"
+		}
+		out = append(out, c)
+	}
+	return out
+}

--- a/internal/services/identity.go
+++ b/internal/services/identity.go
@@ -25,6 +25,14 @@ const (
 	SourceIP     Source = "ip"
 )
 
+// DefaultIdentityRankOrder matches the seeded identity.rank_order setting
+// (migration 027). Callers that can't reach the settings row should use this
+// slice so behavior stays consistent with a fresh install.
+//
+// Don't take &DefaultIdentityRankOrder — it's meant to be copied or ranged
+// over, not mutated.
+var DefaultIdentityRankOrder = []string{"mdns", "snmp", "ptr", "cert"}
+
 const (
 	maxSNMPSysNameLen = 253
 	minPrintableASCII = 0x20

--- a/internal/services/identity_test.go
+++ b/internal/services/identity_test.go
@@ -1,0 +1,300 @@
+package services
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func defaultRankOrder() []string { return []string{"mdns", "snmp", "ptr", "cert"} }
+
+func TestResolveDisplayName_CustomWinsOverEverything(t *testing.T) {
+	in := IdentityInputs{
+		IPAddress:    "192.168.1.10",
+		CustomName:   strPtr("my-laptop"),
+		MDNSName:     strPtr("sams-macbook.local"),
+		SNMPSysName:  strPtr("laptop-snmp"),
+		PTRRecords:   []PTRObservation{{Name: "laptop.example.com", ObservedAt: time.Now()}},
+		CertSubjects: []CertSubject{{Name: "laptop.example.com", ForwardMatchesIP: true}},
+	}
+
+	r := ResolveDisplayName(in, defaultRankOrder())
+
+	assert.Equal(t, "my-laptop", r.Name)
+	assert.Equal(t, SourceCustom, r.Source)
+	assert.InDelta(t, confidenceCustom, r.Confidence, 0.0001)
+}
+
+func TestResolveDisplayName_CustomWhitespaceOnlyIsIgnored(t *testing.T) {
+	in := IdentityInputs{
+		IPAddress:  "192.168.1.10",
+		CustomName: strPtr("   "),
+		MDNSName:   strPtr("laptop.local"),
+	}
+
+	r := ResolveDisplayName(in, defaultRankOrder())
+
+	assert.Equal(t, "laptop.local", r.Name)
+	assert.Equal(t, SourceMDNS, r.Source)
+}
+
+func TestResolveDisplayName_CustomTrimmed(t *testing.T) {
+	in := IdentityInputs{
+		IPAddress:  "192.168.1.10",
+		CustomName: strPtr("  hub  "),
+	}
+
+	r := ResolveDisplayName(in, defaultRankOrder())
+
+	assert.Equal(t, "hub", r.Name)
+	assert.Equal(t, SourceCustom, r.Source)
+}
+
+func TestResolveDisplayName_RankOrderRespected(t *testing.T) {
+	in := IdentityInputs{
+		IPAddress:   "192.168.1.10",
+		MDNSName:    strPtr("laptop.local"),
+		SNMPSysName: strPtr("laptop-snmp"),
+	}
+
+	mdnsFirst := ResolveDisplayName(in, []string{"mdns", "snmp"})
+	assert.Equal(t, "laptop.local", mdnsFirst.Name)
+	assert.Equal(t, SourceMDNS, mdnsFirst.Source)
+
+	snmpFirst := ResolveDisplayName(in, []string{"snmp", "mdns"})
+	assert.Equal(t, "laptop-snmp", snmpFirst.Name)
+	assert.Equal(t, SourceSNMP, snmpFirst.Source)
+}
+
+func TestResolveDisplayName_SkipsUnusableMDNS(t *testing.T) {
+	in := IdentityInputs{
+		IPAddress:   "192.168.1.10",
+		MDNSName:    strPtr("laptop"), // missing .local suffix
+		SNMPSysName: strPtr("fallback"),
+	}
+
+	r := ResolveDisplayName(in, defaultRankOrder())
+
+	assert.Equal(t, "fallback", r.Name)
+	assert.Equal(t, SourceSNMP, r.Source)
+}
+
+func TestResolveDisplayName_PTRQualityFilterRejects(t *testing.T) {
+	in := IdentityInputs{
+		IPAddress: "10.1.2.3",
+		PTRRecords: []PTRObservation{
+			{Name: "dhcp-1-2-3.dynamic.comcast.net", ObservedAt: time.Now()},
+		},
+	}
+
+	r := ResolveDisplayName(in, []string{"ptr"})
+
+	assert.Equal(t, "10.1.2.3", r.Name, "quality-filtered PTR should fall through to IP")
+	assert.Equal(t, SourceIP, r.Source)
+}
+
+func TestResolveDisplayName_PTRFirstUsableWins(t *testing.T) {
+	now := time.Now()
+	in := IdentityInputs{
+		IPAddress: "10.1.2.3",
+		PTRRecords: []PTRObservation{
+			{Name: "dhcp-1-2-3.dynamic.comcast.net", ObservedAt: now},
+			{Name: "laptop.example.com", ObservedAt: now},
+		},
+	}
+
+	r := ResolveDisplayName(in, []string{"ptr"})
+
+	assert.Equal(t, "laptop.example.com", r.Name)
+	assert.Equal(t, SourcePTR, r.Source)
+}
+
+func TestResolveDisplayName_CertRequiresReverseMatch(t *testing.T) {
+	in := IdentityInputs{
+		IPAddress: "10.1.2.3",
+		CertSubjects: []CertSubject{
+			{Name: "unrelated.example.com", Kind: "cn", ForwardMatchesIP: false},
+		},
+	}
+
+	skipped := ResolveDisplayName(in, []string{"cert"})
+	assert.Equal(t, SourceIP, skipped.Source)
+
+	in.CertSubjects[0].ForwardMatchesIP = true
+	matched := ResolveDisplayName(in, []string{"cert"})
+	assert.Equal(t, "unrelated.example.com", matched.Name)
+	assert.Equal(t, SourceCert, matched.Source)
+}
+
+func TestResolveDisplayName_UnknownSourceSilentlySkipped(t *testing.T) {
+	in := IdentityInputs{
+		IPAddress: "192.168.1.10",
+		MDNSName:  strPtr("laptop.local"),
+	}
+
+	r := ResolveDisplayName(in, []string{"made-up-source", "", "mdns"})
+
+	assert.Equal(t, "laptop.local", r.Name)
+	assert.Equal(t, SourceMDNS, r.Source)
+}
+
+func TestResolveDisplayName_FallbackToIP(t *testing.T) {
+	in := IdentityInputs{IPAddress: "10.1.2.3"}
+
+	r := ResolveDisplayName(in, defaultRankOrder())
+
+	assert.Equal(t, "10.1.2.3", r.Name)
+	assert.Equal(t, SourceIP, r.Source)
+	assert.InDelta(t, confidenceIP, r.Confidence, 0.0001)
+}
+
+func TestResolveDisplayName_EmptyRankOrderFallsThroughToIP(t *testing.T) {
+	in := IdentityInputs{
+		IPAddress: "10.1.2.3",
+		MDNSName:  strPtr("laptop.local"),
+	}
+
+	r := ResolveDisplayName(in, nil)
+
+	assert.Equal(t, "10.1.2.3", r.Name)
+	assert.Equal(t, SourceIP, r.Source)
+}
+
+func TestValidateSNMPSysName(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantUsable bool
+		wantReason string
+	}{
+		{"normal", "switch-01", true, ""},
+		{"with spaces", "Office Printer 3", true, ""},
+		{
+			"too long",
+			strings.Repeat("a", maxSNMPSysNameLen+1),
+			false,
+			"sys_name too long",
+		},
+		{"contains tab", "switch\t01", false, "sys_name contains non-printable characters"},
+		{"contains null byte", "switch\x00", false, "sys_name contains non-printable characters"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			usable, reason := validateSNMPSysName(tc.input)
+			assert.Equal(t, tc.wantUsable, usable)
+			assert.Equal(t, tc.wantReason, reason)
+		})
+	}
+}
+
+func TestListNameCandidates_ExcludesCustomName(t *testing.T) {
+	in := IdentityInputs{
+		IPAddress:  "10.1.2.3",
+		CustomName: strPtr("alias"),
+		MDNSName:   strPtr("laptop.local"),
+	}
+
+	cs := ListNameCandidates(in)
+
+	for _, c := range cs {
+		assert.NotEqual(t, SourceCustom, c.Source, "custom_name must not appear in candidate list")
+	}
+	require.Len(t, cs, 1)
+	assert.Equal(t, "laptop.local", cs[0].Name)
+}
+
+func TestListNameCandidates_StableOrderMDNSSNMPPTRCert(t *testing.T) {
+	now := time.Now()
+	in := IdentityInputs{
+		IPAddress:   "10.1.2.3",
+		MDNSName:    strPtr("laptop.local"),
+		SNMPSysName: strPtr("laptop-snmp"),
+		PTRRecords: []PTRObservation{
+			{Name: "laptop.example.com", ObservedAt: now},
+		},
+		CertSubjects: []CertSubject{
+			{Name: "laptop.example.com", Kind: "cn", ForwardMatchesIP: true, ObservedAt: now},
+		},
+	}
+
+	cs := ListNameCandidates(in)
+
+	require.Len(t, cs, 4)
+	assert.Equal(t, SourceMDNS, cs[0].Source)
+	assert.Equal(t, SourceSNMP, cs[1].Source)
+	assert.Equal(t, SourcePTR, cs[2].Source)
+	assert.Equal(t, SourceCert, cs[3].Source)
+}
+
+func TestListNameCandidates_ReturnsEmptySliceNotNil(t *testing.T) {
+	in := IdentityInputs{IPAddress: "10.1.2.3"}
+
+	cs := ListNameCandidates(in)
+
+	require.NotNil(t, cs, "must be empty slice not nil so JSON encodes as [] not null")
+	assert.Len(t, cs, 0)
+}
+
+func TestListNameCandidates_IncludesUnusableWithReason(t *testing.T) {
+	now := time.Now()
+	in := IdentityInputs{
+		IPAddress: "10.1.2.3",
+		MDNSName:  strPtr("bare-mdns"), // missing .local
+		PTRRecords: []PTRObservation{
+			{Name: "dhcp-1-2-3.dynamic.comcast.net", ObservedAt: now},
+		},
+		CertSubjects: []CertSubject{
+			{Name: "unrelated.example.com", Kind: "cn", ForwardMatchesIP: false, ObservedAt: now},
+		},
+	}
+
+	cs := ListNameCandidates(in)
+
+	require.Len(t, cs, 3)
+
+	mdns := cs[0]
+	assert.Equal(t, SourceMDNS, mdns.Source)
+	assert.False(t, mdns.Usable)
+	assert.Contains(t, mdns.NotUsableReason, ".local")
+
+	ptr := cs[1]
+	assert.Equal(t, SourcePTR, ptr.Source)
+	assert.False(t, ptr.Usable)
+	assert.Contains(t, ptr.NotUsableReason, "PTR pattern")
+
+	cert := cs[2]
+	assert.Equal(t, SourceCert, cert.Source)
+	assert.False(t, cert.Usable)
+	assert.Contains(t, cert.NotUsableReason, "forward-resolve")
+}
+
+func TestListNameCandidates_SNMPEmptyOrNilProducesNothing(t *testing.T) {
+	in := IdentityInputs{IPAddress: "10.1.2.3", SNMPSysName: strPtr("")}
+
+	cs := ListNameCandidates(in)
+
+	assert.Empty(t, cs)
+}
+
+func TestConfidenceFor(t *testing.T) {
+	tests := []struct {
+		source Source
+		want   float64
+	}{
+		{SourceCustom, confidenceCustom},
+		{SourceMDNS, confidenceMDNS},
+		{SourceSNMP, confidenceSNMP},
+		{SourcePTR, confidencePTR},
+		{SourceCert, confidenceCert},
+		{SourceIP, confidenceIP},
+		{Source("unknown"), confidenceIP},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.source), func(t *testing.T) {
+			assert.InDelta(t, tc.want, confidenceFor(tc.source), 0.0001)
+		})
+	}
+}

--- a/internal/services/smartscan.go
+++ b/internal/services/smartscan.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/anstrom/scanorama/internal/db"
+	"github.com/anstrom/scanorama/internal/enrichment"
 	"github.com/anstrom/scanorama/internal/profiles"
 	"github.com/anstrom/scanorama/internal/scanning"
 )
@@ -105,6 +106,21 @@ type smartHostRepository interface {
 
 // stageSkip is the Stage value returned when no scan action is recommended.
 const stageSkip = "skip"
+
+// stageIdentityEnrichment is returned when a host is up but has no usable
+// name from any cheap-to-check source — SmartScan queues a light probe of
+// common identity surfaces (SSH/HTTP/SNMP/TLS) so post-scan enrichment can
+// harvest mDNS/SNMP sysName/PTR/cert signals on the next pass.
+const stageIdentityEnrichment = "identity_enrichment"
+
+// identityEnrichmentPorts are the ports SmartScan probes when running an
+// identity_enrichment stage. Each is an identity surface:
+//
+//	22  — SSH banner / host keys
+//	80  — HTTP Server / title / redirect
+//	161 — SNMP sysName (if reachable with configured community)
+//	443 — TLS cert CN / SANs
+const identityEnrichmentPorts = "22,80,161,443"
 
 // Auto-progression defaults. Exported so the API server can pass them
 // explicitly to WithAutoProgression rather than using magic numbers.
@@ -343,6 +359,8 @@ func (s *SmartScanService) EvaluateHost(ctx context.Context, host *db.Host) (*Sc
 	switch {
 	case !hasOS && host.Status == "up":
 		return s.stageOSDetection(), nil
+	case host.Status == "up" && !hasUsableHostName(host):
+		return s.stageIdentityEnrichment(), nil
 	case hasOS && !hasOpenPorts:
 		return s.stageWithProfile(ctx, host, "port_expansion"), nil
 	case hasOpenPorts && !hasServices:
@@ -357,6 +375,54 @@ func (s *SmartScanService) EvaluateHost(ctx context.Context, host *db.Host) (*Sc
 	default:
 		return &ScanStage{Stage: stageSkip, Reason: "host knowledge is sufficient"}, nil
 	}
+}
+
+// stageIdentityEnrichment returns a ScanStage that probes the ports most
+// likely to yield a host name. Post-scan enrichment (DNS, banner/TLS, SNMP)
+// picks up the signals and fills hosts.hostname / hosts.mdns_name /
+// host_snmp_data / certificates on the next pass.
+func (s *SmartScanService) stageIdentityEnrichment() *ScanStage {
+	return &ScanStage{
+		Stage:    stageIdentityEnrichment,
+		ScanType: "connect",
+		Ports:    identityEnrichmentPorts,
+		Reason:   "host has no usable name — probing identity surfaces (mDNS, SNMP, DNS, TLS)",
+	}
+}
+
+// hasUsableHostName reports whether the host already has a name worth keeping
+// as its display name, using only fields on the Host struct (no DB I/O).
+// Truthy sources:
+//   - custom_name non-empty (user override)
+//   - mdns_name ending in .local
+//   - hostname non-empty AND passing enrichment.DNSNameIsUsable
+//
+// Cert subjects and PTR records are intentionally NOT consulted: certs need
+// forward-resolution to validate, and PTR records live in host_dns_records
+// with no guarantee that the latest value was promoted to hosts.hostname.
+// SmartScan may therefore over-trigger identity_enrichment in the rare case
+// where a usable cert exists but nothing else does — an acceptable cost.
+func hasUsableHostName(host *db.Host) bool {
+	if hasNonBlank(host.CustomName) {
+		return true
+	}
+	if host.MDNSName != nil {
+		name := strings.TrimSpace(*host.MDNSName)
+		if strings.HasSuffix(strings.ToLower(name), ".local") {
+			return true
+		}
+	}
+	if host.Hostname != nil {
+		name := strings.TrimSpace(*host.Hostname)
+		if name != "" && enrichment.DNSNameIsUsable(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasNonBlank(p *string) bool {
+	return p != nil && strings.TrimSpace(*p) != ""
 }
 
 // stageOSDetection returns a ScanStage configured for OS fingerprinting.

--- a/internal/services/smartscan.go
+++ b/internal/services/smartscan.go
@@ -107,6 +107,11 @@ type smartHostRepository interface {
 // stageSkip is the Stage value returned when no scan action is recommended.
 const stageSkip = "skip"
 
+// hostStatusGone is the hosts.status value for hosts the scanner has
+// stopped trying. Duplicated as a literal would trip goconst; reused here
+// and in QueueIdentityEnrichment to guard against probing gone hosts.
+const hostStatusGone = "gone"
+
 // stageIdentityEnrichment is returned when a host is up but has no usable
 // name from any cheap-to-check source — SmartScan queues a light probe of
 // common identity surfaces (SSH/HTTP/SNMP/TLS) so post-scan enrichment can
@@ -336,7 +341,7 @@ func (s *SmartScanService) EvaluateHostByID(ctx context.Context, hostID uuid.UUI
 // Returns a ScanStage with Stage == "skip" when no action is recommended.
 func (s *SmartScanService) EvaluateHost(ctx context.Context, host *db.Host) (*ScanStage, error) {
 	// Hosts that are gone or explicitly excluded from scanning are always skipped.
-	if host.Status == "gone" || host.IgnoreScanning {
+	if host.Status == hostStatusGone || host.IgnoreScanning {
 		return &ScanStage{Stage: stageSkip, Reason: "host is gone or excluded from scanning"}, nil
 	}
 
@@ -494,6 +499,23 @@ func (s *SmartScanService) QueueSmartScan(ctx context.Context, hostID uuid.UUID)
 		return uuid.Nil, nil
 	}
 
+	return s.createAndQueueScan(ctx, host, stage, db.ScanSourceAPI)
+}
+
+// QueueIdentityEnrichment queues an identity_enrichment scan for a host
+// unconditionally — bypassing EvaluateHost's usability check. Used by the
+// "Refresh identity now" button in the Identity tab; the user has asked
+// explicitly, so the fact that the host may already have a usable name is
+// irrelevant. Returns the created scan UUID.
+func (s *SmartScanService) QueueIdentityEnrichment(ctx context.Context, hostID uuid.UUID) (uuid.UUID, error) {
+	host, err := s.hostRepo.GetHost(ctx, hostID)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("failed to load host: %w", err)
+	}
+	if host.Status == hostStatusGone || host.IgnoreScanning {
+		return uuid.Nil, fmt.Errorf("host is gone or excluded from scanning")
+	}
+	stage := s.stageIdentityEnrichment()
 	return s.createAndQueueScan(ctx, host, stage, db.ScanSourceAPI)
 }
 

--- a/internal/services/smartscan_test.go
+++ b/internal/services/smartscan_test.go
@@ -129,13 +129,17 @@ func mustParseIP(s string) db.IPAddr {
 	return db.IPAddr{IP: ip}
 }
 
-// hostUp returns a minimal up host seen recently (not stale).
+// hostUp returns a minimal up host seen recently (not stale). Hostname is
+// set to a name that passes enrichment.DNSNameIsUsable so the identity
+// enrichment stage does not fire in tests that care about other stages.
+// Tests that want the no-name path should clear Hostname explicitly.
 func hostUp(ip string) *db.Host {
 	return &db.Host{
 		ID:        uuid.New(),
 		IPAddress: mustParseIP(ip),
 		Status:    "up",
 		LastSeen:  time.Now(),
+		Hostname:  strPtr("srv.example.com"),
 	}
 }
 
@@ -276,6 +280,160 @@ func TestEvaluateHost_FallsBackOnOpenPortsError(t *testing.T) {
 	stage, err := svc.EvaluateHost(context.Background(), host)
 	require.NoError(t, err)
 	assert.Equal(t, "port_expansion", stage.Stage)
+}
+
+// ── EvaluateHost: identity enrichment ────────────────────────────────────────
+
+func TestEvaluateHost_IdentityEnrichmentWhenNoName(t *testing.T) {
+	// OS known, open ports found, services resolved — the host is otherwise
+	// "complete" except it has no usable name. Identity enrichment must win.
+	svc := newTestService(true /*hasOpenPorts*/, true /*hasServices*/)
+	host := hostUp("10.0.0.20")
+	host.OSFamily = strPtr("linux")
+	host.Hostname = nil // no name at all
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, stageIdentityEnrichment, stage.Stage)
+	assert.Equal(t, identityEnrichmentPorts, stage.Ports)
+	assert.Equal(t, "connect", stage.ScanType)
+}
+
+func TestEvaluateHost_IdentityEnrichmentPreferredOverPortExpansion(t *testing.T) {
+	// hasOS, !hasOpenPorts, no name — both identity and port_expansion would
+	// match, but identity fires first.
+	svc := newTestService(false /*hasOpenPorts*/, false)
+	host := hostUp("10.0.0.21")
+	host.OSFamily = strPtr("linux")
+	host.Hostname = nil
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, stageIdentityEnrichment, stage.Stage)
+}
+
+func TestEvaluateHost_OSDetectionWinsOverIdentity(t *testing.T) {
+	// !hasOS AND no name — os_detection runs first. Identity comes on the
+	// next pass once OS is resolved.
+	svc := newTestService(false, false)
+	host := hostUp("10.0.0.22")
+	host.Hostname = nil
+	// OSFamily left nil
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, "os_detection", stage.Stage)
+}
+
+func TestEvaluateHost_IdentitySkippedWhenMDNSLocalPresent(t *testing.T) {
+	svc := newTestService(false, false)
+	host := hostUp("10.0.0.23")
+	host.OSFamily = strPtr("linux")
+	host.Hostname = nil
+	host.MDNSName = strPtr("printer.local")
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, "port_expansion", stage.Stage, "mDNS .local name makes identity enrichment unnecessary")
+}
+
+func TestEvaluateHost_IdentitySkippedWhenCustomNameSet(t *testing.T) {
+	svc := newTestService(false, false)
+	host := hostUp("10.0.0.24")
+	host.OSFamily = strPtr("linux")
+	host.Hostname = nil
+	host.CustomName = strPtr("sams-laptop")
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, "port_expansion", stage.Stage, "custom_name is the user's override and counts as a usable name")
+}
+
+func TestEvaluateHost_IdentityFiresWhenHostnameIsJunkPTR(t *testing.T) {
+	// Host has a hostname but it's a DHCP-generated ISP PTR pattern that
+	// DNSNameIsUsable rejects. Identity must fire so we can probe for
+	// something better.
+	svc := newTestService(false, false)
+	host := hostUp("10.0.0.25")
+	host.OSFamily = strPtr("linux")
+	host.Hostname = strPtr("dhcp-10-0-0-25.dynamic.comcast.net")
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, stageIdentityEnrichment, stage.Stage)
+}
+
+func TestEvaluateHost_IdentitySkippedWhenHostIsDown(t *testing.T) {
+	// A down host with no name should not trigger identity enrichment —
+	// we can't probe it.
+	svc := newTestService(false, false)
+	host := hostUp("10.0.0.26")
+	host.Status = "down"
+	host.OSFamily = strPtr("linux")
+	host.Hostname = nil
+
+	stage, err := svc.EvaluateHost(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, "port_expansion", stage.Stage,
+		"identity_enrichment requires status=up; port_expansion still considers OS+no-ports")
+}
+
+func TestHasUsableHostName(t *testing.T) {
+	tests := []struct {
+		name string
+		host *db.Host
+		want bool
+	}{
+		{
+			"custom_name set",
+			&db.Host{CustomName: strPtr("alias")},
+			true,
+		},
+		{
+			"custom_name whitespace only does not count",
+			&db.Host{CustomName: strPtr("   ")},
+			false,
+		},
+		{
+			"mdns .local counts",
+			&db.Host{MDNSName: strPtr("printer.local")},
+			true,
+		},
+		{
+			"mdns without .local does not count",
+			&db.Host{MDNSName: strPtr("printer")},
+			false,
+		},
+		{
+			"usable hostname counts",
+			&db.Host{Hostname: strPtr("srv.example.com")},
+			true,
+		},
+		{
+			"DHCP-pattern hostname does not count",
+			&db.Host{Hostname: strPtr("dhcp-10-0-0-1.dynamic.comcast.net")},
+			false,
+		},
+		{
+			"all nil",
+			&db.Host{},
+			false,
+		},
+		{
+			"custom wins even when everything else is junk",
+			&db.Host{
+				CustomName: strPtr("alias"),
+				Hostname:   strPtr("dhcp-10-0-0-1.dynamic.comcast.net"),
+				MDNSName:   strPtr("not-a-local-name"),
+			},
+			true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hasUsableHostName(tc.host))
+		})
+	}
 }
 
 // ── QueueBatch ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Introduces a canonical **display name** per host, a user-defined **custom_name** override, a SmartScan **identity_enrichment** stage that fires when a host lacks a name, and the dashboard surfaces to make it all visible.

Brainstormed and spec'd live; design is committed at [docs/superpowers/specs/2026-04-16-host-identity-design.md](../blob/feat/host-identity-resolution/docs/superpowers/specs/2026-04-16-host-identity-design.md).

## What's in it

**Backend (Go):**
- Migration 027 — `hosts.custom_name`, `hosts.hostname_source` (CHECK-constrained), seeded `identity.rank_order` setting
- `internal/services/identity.go` — pure resolver with 20 table-driven tests covering every per-source rule (mDNS `.local`, SNMP printable/length, PTR quality filter, cert reverse-match)
- `internal/services/smartscan.go` — new `identity_enrichment` stage slotted between `os_detection` and `port_expansion`; probes ports 22/80/161/443 so post-scan enrichment can harvest name signals
- `internal/db/repository_host.go` — `UpdateCustomName` (null clears) + `custom_name`/`hostname_source` wired through `GetHost` / `ListHosts` / `scanHostRows`
- `HostResponse` gains `display_name`, `display_name_source`, `custom_name`, `hostname_source`, `name_candidates[]`
- `PATCH /hosts/{id}/custom-name` — body `{"custom_name": "..."|null}`; whitespace-only clears; >255 chars → 400
- `POST /smart-scan/hosts/{id}/refresh-identity` — unconditional identity_enrichment queue; 202 with scan id

**Frontend:**
- `useUpdateCustomName` / `useRefreshIdentity` hooks (+ 9 tests)
- `<HostIdentityPanel mode="compact" | "full">` — one component, two layouts
- Overview tab: chevron expand next to the Identity section shows the top-N candidates read-only
- New **Identity** tab: full ranked table with inline "use" links, custom-name input (Save/Clear), "Refresh identity now" button
- Host list: primary label prefers `display_name` → `hostname` → IP

**Tests:** backend +28, frontend +9, all green. Lint clean. Swagger regenerated; no drift.

## Closes

Addresses the user's report: "I'm currently missing names on several hosts and SmartScan doesn't add them." SmartScan now treats absent names as a knowledge gap.

## Follow-up (not in this PR)

- Async cert CN forward-match verifier — currently all cert candidates are reported as unusable with reason, so they're visible in the Identity tab but never win `display_name`
- Component test for `<HostIdentityPanel>` — hook and handler layers are covered; the component itself renders via the existing hosts.test.tsx (with the new mocks added)
- Dynamic / query-driven port lists for SmartScan stages — tracked in #742

## Test plan

- [ ] Open a host detail page and click the Identity chevron — top candidates render read-only
- [ ] Switch to the Identity tab — full ranked table with "use" links, Save/Clear for custom name, Refresh identity now button
- [ ] Set a custom name → host list + Overview tab primary label updates to the custom value
- [ ] Clear the custom name (null or whitespace) → display reverts to the auto-picked source
- [ ] Run a discovery + scan cycle on a mixed-OS subnet and confirm SmartScan queues identity_enrichment for nameless hosts
- [ ] Inspect a host with a junk-PTR hostname (matches DNSNameIsUsable rejection patterns) — `display_name_source` should fall back past PTR

🤖 Generated with [Claude Code](https://claude.com/claude-code)