### PR TITLE
test(enrichment): add coverage for banner helper functions

### DIFF
--- a/internal/enrichment/banner.go
+++ b/internal/enrichment/banner.go
@@ -37,7 +37,8 @@ const (
 	zgrabMaxSizeKB    = 256
 	zgrabMaxRedirects = 3
 
-	serviceSSH = "ssh"
+	serviceSSH   = "ssh"
+	serviceHTTPS = "https"
 )
 
 // tlsPorts is the set of port numbers that should receive a TLS/HTTPS probe.
@@ -344,7 +345,7 @@ func (g *BannerGrabber) grabTLS(ctx context.Context, t BannerTarget, port int, a
 	}
 
 	// Also store a banner entry for this port.
-	svc := "https"
+	svc := serviceHTTPS
 	banner := &db.PortBanner{
 		HostID:    t.HostID,
 		Port:      port,
@@ -642,7 +643,7 @@ func (g *BannerGrabber) storeZGrabHTTPBanner(
 	// Service identification and raw banner summary.
 	svc := "http"
 	if resp.TLS != nil {
-		svc = "https"
+		svc = serviceHTTPS
 	}
 	banner.Service = &svc
 

--- a/internal/enrichment/banner_network_test.go
+++ b/internal/enrichment/banner_network_test.go
@@ -17,6 +17,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"log/slog"
 	"math/big"
 	"net"
@@ -376,6 +377,52 @@ func TestKeyTypeFromPublicKey(t *testing.T) {
 	assert.Equal(t, "ECDSA", keyTypeFromPublicKey(ecKey.Public()))
 	assert.Equal(t, "", keyTypeFromPublicKey(nil))
 	assert.Equal(t, "", keyTypeFromPublicKey("unknown"))
+}
+
+// ── markProbeDone ─────────────────────────────────────────────────────────────
+
+// TestMarkProbeDone_DBError verifies that markProbeDone does not panic and
+// only logs a warning when MarkExtendedProbeDone returns an error.
+func TestMarkProbeDone_DBError(t *testing.T) {
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	// MarkExtendedProbeDone tries to upsert — return a DB error.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnError(fmt.Errorf("db unavailable"))
+
+	// Must not panic.
+	g.markProbeDone(context.Background(), uuid.New(), 8080)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── grabTLS — fallback ────────────────────────────────────────────────────────
+
+// TestGrabTLS_FallsBackToPlain verifies that when the TLS handshake fails
+// (the target speaks plain TCP, not TLS), grabTLS falls back to grabPlain and
+// stores the raw banner.
+func TestGrabTLS_FallsBackToPlain(t *testing.T) {
+	addr := startTCPServer(t, "NOT-TLS-BANNER\r\n")
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+
+	var port int
+	parsePort(portStr, &port)
+
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	// grabPlain (called by grabTLS on handshake failure) stores the banner.
+	mock.ExpectExec("INSERT INTO port_banners").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	target := BannerTarget{HostID: uuid.New(), IP: host}
+	g.grabTLS(context.Background(), target, port, addr)
+
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 // parsePort parses a decimal port string into *out.

--- a/internal/enrichment/banner_test.go
+++ b/internal/enrichment/banner_test.go
@@ -10,12 +10,17 @@ import (
 	"crypto/x509"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	zcrypto_x509 "github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zgrab2"
 	zgrabhttp_lib "github.com/zmap/zgrab2/lib/http"
 	zgrabhttp "github.com/zmap/zgrab2/modules/http"
+
+	"github.com/anstrom/scanorama/internal/db"
 )
 
 // ── parseBannerText ─────────────────────────────────────────────────────────
@@ -158,4 +163,83 @@ func TestTLSVersionString(t *testing.T) {
 			assert.Equal(t, tc.want, tlsVersionString(tc.version))
 		})
 	}
+}
+
+// ── buildTLSSummary ──────────────────────────────────────────────────────────
+
+func TestBuildTLSSummary(t *testing.T) {
+	ver := "TLS 1.2"
+	cn := "example.com"
+
+	cases := []struct {
+		name string
+		cert *db.Certificate
+		want string
+	}{
+		{"both fields set", &db.Certificate{TLSVersion: &ver, SubjectCN: &cn}, "TLS TLS 1.2 CN=example.com"},
+		{"nil TLSVersion", &db.Certificate{SubjectCN: &cn}, "TLS  CN=example.com"},
+		{"nil SubjectCN", &db.Certificate{TLSVersion: &ver}, "TLS TLS 1.2 CN="},
+		{"both nil", &db.Certificate{}, "TLS  CN="},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, buildTLSSummary(tc.cert))
+		})
+	}
+}
+
+// ── populateCertFromParsed ───────────────────────────────────────────────────
+
+func TestPopulateCertFromParsed_Nil(t *testing.T) {
+	cert := &db.Certificate{HostID: uuid.New()}
+	populateCertFromParsed(cert, nil)
+	assert.Nil(t, cert.SubjectCN)
+	assert.Nil(t, cert.SANs)
+	assert.Nil(t, cert.Issuer)
+	assert.Nil(t, cert.NotBefore)
+	assert.Nil(t, cert.NotAfter)
+	assert.Nil(t, cert.KeyType)
+}
+
+func TestPopulateCertFromParsed_AllFields(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	notBefore := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	notAfter := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
+
+	// Construct zcrypto_x509.Certificate directly — no need for a real DER cert
+	// since populateCertFromParsed only reads exported fields.
+	parsed := &zcrypto_x509.Certificate{}
+	parsed.Subject.CommonName = "leaf.example.com"
+	parsed.Issuer.CommonName = "root.example.com"
+	parsed.DNSNames = []string{"leaf.example.com", "alt.example.com"}
+	parsed.NotBefore = notBefore
+	parsed.NotAfter = notAfter
+	parsed.PublicKey = &key.PublicKey
+
+	cert := &db.Certificate{HostID: uuid.New()}
+	populateCertFromParsed(cert, parsed)
+
+	require.NotNil(t, cert.SubjectCN)
+	assert.Equal(t, "leaf.example.com", *cert.SubjectCN)
+	assert.Equal(t, []string{"leaf.example.com", "alt.example.com"}, cert.SANs)
+	require.NotNil(t, cert.Issuer)
+	assert.Equal(t, "root.example.com", *cert.Issuer)
+	require.NotNil(t, cert.NotBefore)
+	assert.WithinDuration(t, notBefore, *cert.NotBefore, time.Second)
+	require.NotNil(t, cert.NotAfter)
+	assert.WithinDuration(t, notAfter, *cert.NotAfter, time.Second)
+	require.NotNil(t, cert.KeyType)
+	assert.Equal(t, "RSA", *cert.KeyType)
+}
+
+func TestPopulateCertFromParsed_EmptyCN_NoSubjectSet(t *testing.T) {
+	parsed := &zcrypto_x509.Certificate{}
+	// Subject.CommonName is zero-value ("") — SubjectCN must not be set.
+	cert := &db.Certificate{HostID: uuid.New()}
+	populateCertFromParsed(cert, parsed)
+	assert.Nil(t, cert.SubjectCN)
+	assert.Nil(t, cert.Issuer)
 }

--- a/internal/enrichment/banner_zgrab2_test.go
+++ b/internal/enrichment/banner_zgrab2_test.go
@@ -27,6 +27,8 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	zcrypto_tls "github.com/zmap/zcrypto/tls"
+	zgrabhttp_lib "github.com/zmap/zgrab2/lib/http"
 	zgrabhttp "github.com/zmap/zgrab2/modules/http"
 	gossh "golang.org/x/crypto/ssh"
 
@@ -709,6 +711,122 @@ func TestGrabOne_UnknownService_CapExceeded(t *testing.T) {
 
 	pi := PortInfo{Number: port, Service: "", AllowExtendedProbe: false}
 	g.grabOne(context.Background(), BannerTarget{HostID: uuid.New(), IP: host}, pi)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── storeZGrabHTTPBanner — response variants ──────────────────────────────────
+
+// UpsertHTTPPortData args: id, host_id, port, protocol, raw_banner, service,
+// version, http_status_code, http_redirect, http_response_headers, scanned_at.
+// ($1 through $11 — see repository_banners.go:UpsertHTTPPortData)
+
+// TestStoreZGrabHTTPBanner_HTTP200 verifies that a plain-HTTP 200 response
+// stores service="http" and http_status_code=200.
+func TestStoreZGrabHTTPBanner_HTTP200(t *testing.T) {
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	svc := "http"
+	sc := int16(200)
+	mock.ExpectExec("INSERT INTO port_banners").
+		WithArgs(
+			sqlmock.AnyArg(), // id
+			sqlmock.AnyArg(), // host_id
+			80,               // port
+			"tcp",            // protocol
+			sqlmock.AnyArg(), // raw_banner
+			&svc,             // service: "http"
+			(*string)(nil),   // version: nil (no Server header)
+			&sc,              // http_status_code: 200
+			(*string)(nil),   // http_redirect
+			sqlmock.AnyArg(), // http_response_headers
+			sqlmock.AnyArg(), // scanned_at
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	resp := &zgrabhttp_lib.Response{
+		StatusCode: 200,
+		Header:     zgrabhttp_lib.Header{},
+	}
+	results := &zgrabhttp.Results{Response: resp}
+	g.storeZGrabHTTPBanner(context.Background(), BannerTarget{HostID: uuid.New(), IP: "127.0.0.1"}, 80, results)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestStoreZGrabHTTPBanner_HTTPS verifies that service="https" is stored when
+// resp.TLS is non-nil (HTTPS connection detected).
+func TestStoreZGrabHTTPBanner_HTTPS(t *testing.T) {
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	svc := "https"
+	sc := int16(200)
+	mock.ExpectExec("INSERT INTO port_banners").
+		WithArgs(
+			sqlmock.AnyArg(), // id
+			sqlmock.AnyArg(), // host_id
+			443,              // port
+			"tcp",            // protocol
+			sqlmock.AnyArg(), // raw_banner
+			&svc,             // service: "https" (TLS detected)
+			(*string)(nil),   // version
+			&sc,              // http_status_code: 200
+			(*string)(nil),   // http_redirect
+			sqlmock.AnyArg(), // http_response_headers
+			sqlmock.AnyArg(), // scanned_at
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	resp := &zgrabhttp_lib.Response{
+		StatusCode: 200,
+		Header:     zgrabhttp_lib.Header{},
+		TLS:        &zcrypto_tls.ConnectionState{},
+	}
+	results := &zgrabhttp.Results{Response: resp}
+
+	target := BannerTarget{HostID: uuid.New(), IP: "127.0.0.1"}
+	g.storeZGrabHTTPBanner(context.Background(), target, 443, results)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestStoreZGrabHTTPBanner_ServerHeader verifies that the Server response
+// header is stored as the banner Version field.
+func TestStoreZGrabHTTPBanner_ServerHeader(t *testing.T) {
+	database, mock := newBannerMockDB(t)
+	repo := db.NewBannerRepository(database)
+	g := NewBannerGrabber(repo, newTestLogger(), "")
+
+	svc := "http"
+	sc := int16(200)
+	ver := "nginx/1.24.0"
+	mock.ExpectExec("INSERT INTO port_banners").
+		WithArgs(
+			sqlmock.AnyArg(), // id
+			sqlmock.AnyArg(), // host_id
+			80,               // port
+			"tcp",            // protocol
+			sqlmock.AnyArg(), // raw_banner
+			&svc,             // service: "http"
+			&ver,             // version: "nginx/1.24.0" (from Server header)
+			&sc,              // http_status_code: 200
+			(*string)(nil),   // http_redirect
+			sqlmock.AnyArg(), // http_response_headers (includes Server)
+			sqlmock.AnyArg(), // scanned_at
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	hdr := zgrabhttp_lib.Header{}
+	hdr.Set("Server", "nginx/1.24.0")
+	resp := &zgrabhttp_lib.Response{
+		StatusCode: 200,
+		Header:     hdr,
+	}
+	results := &zgrabhttp.Results{Response: resp}
+
+	target := BannerTarget{HostID: uuid.New(), IP: "127.0.0.1"}
+	g.storeZGrabHTTPBanner(context.Background(), target, 80, results)
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }


### PR DESCRIPTION
## Summary

- `TestBuildTLSSummary` — 4 table cases (both fields, nil version, nil CN, both nil)
- `TestPopulateCertFromParsed_*` — nil no-op, all fields (subject CN, SANs, issuer, dates, RSA key type), empty CN guard
- `TestMarkProbeDone_DBError` — confirms no panic when `MarkExtendedProbeDone` returns an error
- `TestGrabTLS_FallsBackToPlain` — plain TCP server causes TLS handshake failure; verifies fallback to `grabPlain` stores banner
- `TestStoreZGrabHTTPBanner_HTTP200/HTTPS/ServerHeader` — exercises status code storage, `resp.TLS != nil` → `"https"` service detection, and Server header → Version field

## Test plan

- CI runs `go test -short ./...` (unit) and `go test ./...` (integration); all new tests are covered by the `-short` run since they use mock DB or in-process TCP servers only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)