### PR TITLE
feat(dashboard): device hooks, detail page, and roadmap update to v0.27-dev

### DIFF
--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -1,7 +1,7 @@
 # Scanorama Product Roadmap
 
 > Milestone-based roadmap focused on feature completeness.
-> Last updated: 2026-04-13 · Current version: v0.24.0
+> Last updated: 2026-04-19 · Current version: v0.27.0-dev
 
 ---
 
@@ -399,15 +399,15 @@ Scanorama is ready for other people to depend on. Auth works, the test suite is 
 
 ## Milestone Summary
 
-| Milestone | Theme | Key Deliverables | Target |
+| Milestone | Theme | Key Deliverables | Status |
 |-----------|-------|------------------|--------|
-| **v0.23** | Tables & Discovery Changelog | Sorting, bulk actions, discovery diff (new/updated/gone), MAC vendor lookup (OUI), response timing, slow host detection | Next |
-| **v0.24** | Tags, Groups, Dashboard & Admin | Tag UI, host groups, profile cloning, enhanced dashboard stats, live activity feed, quick actions, settings page, system status | Next |
-| **v0.25** | Smart Profiles & Smart Scan | Smart profiles, progressive scanning, ZGrab2 banners, GoSNMP enrichment, DNSX, curated port DB, knowledge scores | Next |
-| **v0.26** | Analytics, Reporting & Queries | Port/OS/service charts, web tech fingerprinting (httpx), vuln scanning (nuclei), saved queries, scheduled reports, PDF export, business & system health metrics (#222) | Later |
-| **v0.27** | UX Polish | Scan diff, export, global search, dark mode, webhooks, per-host alert rules (#695), onboarding | Later |
+| **v0.23** | Tables & Discovery Changelog | Sorting, bulk actions, discovery diff (new/updated/gone), MAC vendor lookup (OUI), response timing, slow host detection | Done ✓ |
+| **v0.24** | Tags, Groups, Dashboard & Admin | Tag UI, host groups, profile cloning, enhanced dashboard stats, live activity feed, quick actions, settings page, system status | Done ✓ |
+| **v0.25** | Smart Profiles & Smart Scan | Smart profiles, progressive scanning, ZGrab2 banners, GoSNMP enrichment, DNSX, curated port DB, knowledge scores | Done ✓ |
+| **v0.26** | Analytics, Reporting & Queries | Port/OS/service charts, web tech fingerprinting (httpx), vuln scanning (nuclei), saved queries, scheduled reports, PDF export, business & system health metrics | Done ✓ |
+| **v0.27** | UX Polish | Scan diff, export, global search, dark mode, webhooks, per-host alert rules (#695), device identity (#713), onboarding | Current |
 | **v0.28** | Network Topology | Visual graph of network topology using LLDP/CDP neighbor data from v0.25; nodes = hosts/switches, edges = confirmed connections, filterable by network/group/tag (#698) | Later |
-| **v1.0** | Production Release | Multi-user auth, RBAC, audit log, Linux privilege management (#554), `scanorama doctor`, capability detection, alerting infrastructure, OpenTelemetry tracing, Grafana dashboards (#222), test coverage, security audit | Later |
+| **v1.0** | Production Release | Multi-user auth, RBAC, audit log, Linux privilege management (#554), `scanorama doctor`, capability detection, alerting infrastructure, test coverage, security audit | Later |
 
 ---
 

--- a/frontend/src/api/hooks/use-devices.test.ts
+++ b/frontend/src/api/hooks/use-devices.test.ts
@@ -1,0 +1,296 @@
+import { waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHookWithQuery } from "../../test/utils";
+import {
+  useDevices,
+  useDevice,
+  useCreateDevice,
+  useUpdateDevice,
+  useDeleteDevice,
+  useAttachHost,
+  useDetachHost,
+  useAcceptSuggestion,
+  useDismissSuggestion,
+} from "./use-devices";
+
+vi.mock("../client", () => ({
+  api: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PUT: vi.fn(),
+    DELETE: vi.fn(),
+  },
+}));
+
+import { api } from "../client";
+const mockGet = vi.mocked(api.GET);
+const mockPost = vi.mocked(api.POST);
+const mockPut = vi.mocked(api.PUT);
+const mockDelete = vi.mocked(api.DELETE);
+
+const ok = (data: unknown) =>
+  Promise.resolve({ data, error: undefined, response: new Response() }) as ReturnType<typeof mockGet>;
+
+const fail = (msg = "boom") =>
+  Promise.resolve({
+    data: undefined,
+    error: { message: msg },
+    response: new Response(null, { status: 500 }),
+  }) as ReturnType<typeof mockGet>;
+
+const okMut = (data: unknown) =>
+  Promise.resolve({ data, error: undefined, response: new Response() }) as ReturnType<typeof mockPost>;
+
+const failMut = (msg = "boom") =>
+  Promise.resolve({
+    data: undefined,
+    error: { message: msg },
+    response: new Response(null, { status: 500 }),
+  }) as ReturnType<typeof mockPost>;
+
+// ── useDevices ────────────────────────────────────────────────────────────────
+
+describe("useDevices", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns the device list on success", async () => {
+    mockGet.mockImplementation(((path: string) => {
+      expect(path).toBe("/devices");
+      return ok({ devices: [{ id: "d1", name: "Lab Pi", mac_count: 2, host_count: 1 }] });
+    }) as typeof mockGet);
+
+    const { result } = renderHookWithQuery(() => useDevices());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect((result.current.data as { name: string }[])[0].name).toBe("Lab Pi");
+  });
+
+  it("surfaces errors", async () => {
+    mockGet.mockImplementation((() => fail()) as typeof mockGet);
+    const { result } = renderHookWithQuery(() => useDevices());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+// ── useDevice ─────────────────────────────────────────────────────────────────
+
+describe("useDevice", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns device detail on success", async () => {
+    mockGet.mockImplementation(((path: string) => {
+      expect(path).toBe("/devices/{id}");
+      return ok({ id: "d1", name: "Lab Pi", known_macs: [], known_names: [], hosts: [] });
+    }) as typeof mockGet);
+
+    const { result } = renderHookWithQuery(() => useDevice("d1"));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect((result.current.data as { name: string }).name).toBe("Lab Pi");
+  });
+
+  it("surfaces errors", async () => {
+    mockGet.mockImplementation((() => fail()) as typeof mockGet);
+    const { result } = renderHookWithQuery(() => useDevice("d1"));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("is disabled when id is empty", () => {
+    const { result } = renderHookWithQuery(() => useDevice(""));
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+});
+
+// ── useCreateDevice ───────────────────────────────────────────────────────────
+
+describe("useCreateDevice", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("calls POST /devices with the provided body", async () => {
+    mockPost.mockResolvedValue(okMut({ id: "d2", name: "Core Switch" }));
+
+    const { result, actHook } = renderHookWithQuery(() => useCreateDevice());
+    await actHook(async () => {
+      await result.current.mutateAsync({ name: "Core Switch" });
+    });
+
+    expect(mockPost).toHaveBeenCalledWith("/devices", expect.objectContaining({
+      body: { name: "Core Switch" },
+    }));
+  });
+
+  it("throws on error", async () => {
+    mockPost.mockResolvedValue(failMut("name required") as ReturnType<typeof mockPost>);
+
+    const { result, actHook } = renderHookWithQuery(() => useCreateDevice());
+    await expect(
+      actHook(async () => { await result.current.mutateAsync({ name: "" }); }),
+    ).rejects.toThrow();
+  });
+});
+
+// ── useUpdateDevice ───────────────────────────────────────────────────────────
+
+describe("useUpdateDevice", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("calls PUT /devices/{id} with the provided body", async () => {
+    mockPut.mockResolvedValue(okMut({ id: "d1", name: "Updated" }) as ReturnType<typeof mockPut>);
+
+    const { result, actHook } = renderHookWithQuery(() => useUpdateDevice());
+    await actHook(async () => {
+      await result.current.mutateAsync({ id: "d1", body: { name: "Updated" } });
+    });
+
+    expect(mockPut).toHaveBeenCalledWith("/devices/{id}", expect.objectContaining({
+      params: { path: { id: "d1" } },
+      body: { name: "Updated" },
+    }));
+  });
+
+  it("throws on error", async () => {
+    mockPut.mockResolvedValue(failMut("not found") as ReturnType<typeof mockPut>);
+
+    const { result, actHook } = renderHookWithQuery(() => useUpdateDevice());
+    await expect(
+      actHook(async () => { await result.current.mutateAsync({ id: "d1", body: { name: "x" } }); }),
+    ).rejects.toThrow();
+  });
+});
+
+// ── useDeleteDevice ───────────────────────────────────────────────────────────
+
+describe("useDeleteDevice", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("calls DELETE /devices/{id}", async () => {
+    mockDelete.mockResolvedValue(okMut(undefined) as ReturnType<typeof mockDelete>);
+
+    const { result, actHook } = renderHookWithQuery(() => useDeleteDevice());
+    await actHook(async () => { await result.current.mutateAsync("d1"); });
+
+    expect(mockDelete).toHaveBeenCalledWith("/devices/{id}", expect.objectContaining({
+      params: { path: { id: "d1" } },
+    }));
+  });
+
+  it("throws on error", async () => {
+    mockDelete.mockResolvedValue(failMut("not found") as ReturnType<typeof mockDelete>);
+
+    const { result, actHook } = renderHookWithQuery(() => useDeleteDevice());
+    await expect(
+      actHook(async () => { await result.current.mutateAsync("d1"); }),
+    ).rejects.toThrow();
+  });
+});
+
+// ── useAttachHost ─────────────────────────────────────────────────────────────
+
+describe("useAttachHost", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("calls POST /devices/{id}/hosts/{host_id}", async () => {
+    mockPost.mockResolvedValue(okMut(undefined));
+
+    const { result, actHook } = renderHookWithQuery(() => useAttachHost());
+    await actHook(async () => {
+      await result.current.mutateAsync({ deviceId: "d1", hostId: "h1" });
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/devices/{id}/hosts/{host_id}",
+      expect.objectContaining({ params: { path: { id: "d1", host_id: "h1" } } }),
+    );
+  });
+
+  it("throws on error", async () => {
+    mockPost.mockResolvedValue(failMut("conflict"));
+
+    const { result, actHook } = renderHookWithQuery(() => useAttachHost());
+    await expect(
+      actHook(async () => { await result.current.mutateAsync({ deviceId: "d1", hostId: "h1" }); }),
+    ).rejects.toThrow();
+  });
+});
+
+// ── useDetachHost ─────────────────────────────────────────────────────────────
+
+describe("useDetachHost", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("calls DELETE /devices/{id}/hosts/{host_id}", async () => {
+    mockDelete.mockResolvedValue(okMut(undefined) as ReturnType<typeof mockDelete>);
+
+    const { result, actHook } = renderHookWithQuery(() => useDetachHost());
+    await actHook(async () => {
+      await result.current.mutateAsync({ deviceId: "d1", hostId: "h1" });
+    });
+
+    expect(mockDelete).toHaveBeenCalledWith(
+      "/devices/{id}/hosts/{host_id}",
+      expect.objectContaining({ params: { path: { id: "d1", host_id: "h1" } } }),
+    );
+  });
+
+  it("throws on error", async () => {
+    mockDelete.mockResolvedValue(failMut("not found") as ReturnType<typeof mockDelete>);
+
+    const { result, actHook } = renderHookWithQuery(() => useDetachHost());
+    await expect(
+      actHook(async () => { await result.current.mutateAsync({ deviceId: "d1", hostId: "h1" }); }),
+    ).rejects.toThrow();
+  });
+});
+
+// ── useAcceptSuggestion ───────────────────────────────────────────────────────
+
+describe("useAcceptSuggestion", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("calls POST /devices/suggestions/{id}/accept", async () => {
+    mockPost.mockResolvedValue(okMut(undefined));
+
+    const { result, actHook } = renderHookWithQuery(() => useAcceptSuggestion());
+    await actHook(async () => { await result.current.mutateAsync("s1"); });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/devices/suggestions/{id}/accept",
+      expect.objectContaining({ params: { path: { id: "s1" } } }),
+    );
+  });
+
+  it("throws on error", async () => {
+    mockPost.mockResolvedValue(failMut("not found"));
+
+    const { result, actHook } = renderHookWithQuery(() => useAcceptSuggestion());
+    await expect(
+      actHook(async () => { await result.current.mutateAsync("s1"); }),
+    ).rejects.toThrow();
+  });
+});
+
+// ── useDismissSuggestion ──────────────────────────────────────────────────────
+
+describe("useDismissSuggestion", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("calls POST /devices/suggestions/{id}/dismiss", async () => {
+    mockPost.mockResolvedValue(okMut(undefined));
+
+    const { result, actHook } = renderHookWithQuery(() => useDismissSuggestion());
+    await actHook(async () => { await result.current.mutateAsync("s1"); });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/devices/suggestions/{id}/dismiss",
+      expect.objectContaining({ params: { path: { id: "s1" } } }),
+    );
+  });
+
+  it("throws on error", async () => {
+    mockPost.mockResolvedValue(failMut("not found"));
+
+    const { result, actHook } = renderHookWithQuery(() => useDismissSuggestion());
+    await expect(
+      actHook(async () => { await result.current.mutateAsync("s1"); }),
+    ).rejects.toThrow();
+  });
+});

--- a/frontend/src/api/hooks/use-devices.ts
+++ b/frontend/src/api/hooks/use-devices.ts
@@ -1,0 +1,138 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../client";
+import { ApiError } from "../errors";
+
+export function useDevices() {
+  return useQuery({
+    queryKey: ["devices"],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET("/devices");
+      if (error) throw new ApiError(response.status, error);
+      return data?.devices ?? [];
+    },
+  });
+}
+
+export function useDevice(id: string) {
+  return useQuery({
+    queryKey: ["devices", id],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET("/devices/{id}", {
+        params: { path: { id } },
+      });
+      if (error) throw new ApiError(response.status, error);
+      return data;
+    },
+    enabled: !!id,
+  });
+}
+
+export function useCreateDevice() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: { name: string; notes?: string }) => {
+      const { data, error, response } = await api.POST("/devices", { body });
+      if (error) throw new ApiError(response.status, error);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["devices"] });
+    },
+  });
+}
+
+export function useUpdateDevice() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, body }: { id: string; body: { name?: string; notes?: string } }) => {
+      const { data, error, response } = await api.PUT("/devices/{id}", {
+        params: { path: { id } },
+        body,
+      });
+      if (error) throw new ApiError(response.status, error);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["devices"] });
+    },
+  });
+}
+
+export function useDeleteDevice() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { error, response } = await api.DELETE("/devices/{id}", {
+        params: { path: { id } },
+      });
+      if (error) throw new ApiError(response.status, error);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["devices"] });
+    },
+  });
+}
+
+export function useAttachHost() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ deviceId, hostId }: { deviceId: string; hostId: string }) => {
+      const { error, response } = await api.POST("/devices/{id}/hosts/{host_id}", {
+        params: { path: { id: deviceId, host_id: hostId } },
+      });
+      if (error) throw new ApiError(response.status, error);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["devices"] });
+      queryClient.invalidateQueries({ queryKey: ["hosts"] });
+    },
+  });
+}
+
+export function useDetachHost() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ deviceId, hostId }: { deviceId: string; hostId: string }) => {
+      const { error, response } = await api.DELETE("/devices/{id}/hosts/{host_id}", {
+        params: { path: { id: deviceId, host_id: hostId } },
+      });
+      if (error) throw new ApiError(response.status, error);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["devices"] });
+      queryClient.invalidateQueries({ queryKey: ["hosts"] });
+    },
+  });
+}
+
+export function useAcceptSuggestion() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { error, response } = await api.POST("/devices/suggestions/{id}/accept", {
+        params: { path: { id } },
+      });
+      if (error) throw new ApiError(response.status, error);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["devices"] });
+      queryClient.invalidateQueries({ queryKey: ["hosts"] });
+      queryClient.invalidateQueries({ queryKey: ["discovery"] });
+    },
+  });
+}
+
+export function useDismissSuggestion() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { error, response } = await api.POST("/devices/suggestions/{id}/dismiss", {
+        params: { path: { id } },
+      });
+      if (error) throw new ApiError(response.status, error);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["discovery"] });
+    },
+  });
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -17,6 +17,7 @@ import { SchedulesPage } from "./routes/schedules";
 import { AdminPage } from "./routes/admin";
 import { GroupsPage } from "./routes/groups";
 import { PortsPage } from "./routes/ports";
+import { DeviceDetailPage } from "./routes/devices";
 
 const rootRoute = createRootRoute({
   component: RootLayout,
@@ -98,6 +99,15 @@ const portsRoute = createRoute({
   component: PortsPage,
 });
 
+const deviceDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/devices/$id",
+  component: function DeviceDetailRoute() {
+    const { id } = deviceDetailRoute.useParams();
+    return <DeviceDetailPage id={id} />;
+  },
+});
+
 const routeTree = rootRoute.addChildren([
   dashboardRoute,
   scansRoute,
@@ -109,6 +119,7 @@ const routeTree = rootRoute.addChildren([
   schedulesRoute,
   groupsRoute,
   portsRoute,
+  deviceDetailRoute,
   adminRoute,
 ]);
 

--- a/frontend/src/routes/devices.test.tsx
+++ b/frontend/src/routes/devices.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DeviceDetailPage } from "./devices";
+
+// ── Mock hooks ────────────────────────────────────────────────────────────────
+
+vi.mock("../api/hooks/use-devices", () => ({
+  useDevice: vi.fn(),
+  useDeleteDevice: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  useDetachHost: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  useUpdateDevice: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+}));
+
+vi.mock("../components/toast-provider", () => ({
+  useToast: () => ({ toast: { success: vi.fn(), error: vi.fn() } }),
+}));
+
+import { useDevice } from "../api/hooks/use-devices";
+const mockUseDevice = vi.mocked(useDevice);
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const mockDevice = {
+  id: "d1",
+  name: "Lab Pi",
+  notes: "Raspberry Pi 4 in the lab",
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-06-01T00:00:00Z",
+  known_macs: [
+    { id: "m1", mac_address: "AA:BB:CC:DD:EE:FF", first_seen: "2024-01-01T00:00:00Z", last_seen: "2024-06-01T00:00:00Z" },
+  ],
+  known_names: [
+    { id: "n1", name: "lab-pi.local", source: "mdns", first_seen: "2024-01-01T00:00:00Z", last_seen: "2024-06-01T00:00:00Z" },
+  ],
+  hosts: [
+    { id: "h1", ip_address: "192.168.1.50", hostname: "lab-pi", status: "up", mac_address: undefined, os_family: "Linux", vendor: "Raspberry Pi Foundation", first_seen: "2024-01-01T00:00:00Z", last_seen: "2024-06-01T00:00:00Z" },
+  ],
+};
+
+function setupDefaultMocks() {
+  mockUseDevice.mockReturnValue({
+    data: mockDevice,
+    isLoading: false,
+    isError: false,
+  } as ReturnType<typeof useDevice>);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("DeviceDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  it("shows loading skeleton while data is fetching", () => {
+    mockUseDevice.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    } as ReturnType<typeof useDevice>);
+
+    render(<DeviceDetailPage id="d1" />);
+    expect(document.querySelector(".animate-pulse")).not.toBeNull();
+  });
+
+  it("shows error state when the device fails to load", () => {
+    mockUseDevice.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as ReturnType<typeof useDevice>);
+
+    render(<DeviceDetailPage id="d1" />);
+    expect(screen.getByText("Failed to load device.")).toBeInTheDocument();
+  });
+
+  it("renders device name, notes, and meta in the happy path", () => {
+    render(<DeviceDetailPage id="d1" />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Lab Pi");
+    expect(screen.getByText("Raspberry Pi 4 in the lab")).toBeInTheDocument();
+  });
+
+  it("renders known MAC addresses", () => {
+    render(<DeviceDetailPage id="d1" />);
+    expect(screen.getByText("AA:BB:CC:DD:EE:FF")).toBeInTheDocument();
+  });
+
+  it("renders known names with source badge", () => {
+    render(<DeviceDetailPage id="d1" />);
+    expect(screen.getByText("lab-pi.local")).toBeInTheDocument();
+    expect(screen.getByText("mDNS")).toBeInTheDocument();
+  });
+
+  it("renders attached host IP and hostname", () => {
+    render(<DeviceDetailPage id="d1" />);
+    expect(screen.getByText("192.168.1.50")).toBeInTheDocument();
+    expect(screen.getByText("lab-pi")).toBeInTheDocument();
+  });
+
+  it("shows empty states when lists are empty", () => {
+    mockUseDevice.mockReturnValue({
+      data: { ...mockDevice, known_macs: [], known_names: [], hosts: [] },
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useDevice>);
+
+    render(<DeviceDetailPage id="d1" />);
+    expect(screen.getByText("No MACs recorded.")).toBeInTheDocument();
+    expect(screen.getByText("No names recorded.")).toBeInTheDocument();
+    expect(screen.getByText("No hosts attached.")).toBeInTheDocument();
+  });
+
+  it("shows delete confirm when Delete device is clicked", async () => {
+    const user = userEvent.setup();
+    render(<DeviceDetailPage id="d1" />);
+
+    await user.click(screen.getByText("Delete device"));
+    expect(screen.getByText("Delete this device?")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /confirm/i })).toBeInTheDocument();
+  });
+
+  it("hides delete confirm when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    render(<DeviceDetailPage id="d1" />);
+
+    await user.click(screen.getByText("Delete device"));
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(screen.queryByText("Delete this device?")).not.toBeInTheDocument();
+  });
+
+  it("opens rename modal when Rename device button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<DeviceDetailPage id="d1" />);
+
+    await user.click(screen.getByRole("button", { name: "Rename device" }));
+    expect(screen.getByRole("dialog", { name: "Rename device" })).toBeInTheDocument();
+  });
+
+  it("calls onClose when the close button is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<DeviceDetailPage id="d1" onClose={onClose} />);
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/routes/devices.tsx
+++ b/frontend/src/routes/devices.tsx
@@ -1,0 +1,315 @@
+import { X, Cpu, Wifi, Tag, Pencil, Trash2, Link2Off } from "lucide-react";
+import { useState } from "react";
+import { Button } from "../components/button";
+import { StatusBadge, Skeleton } from "../components";
+import { formatRelativeTime, cn } from "../lib/utils";
+import { useToast } from "../components/toast-provider";
+import { getErrorMessage } from "../api/errors";
+import {
+  useDevice,
+  useUpdateDevice,
+  useDeleteDevice,
+  useDetachHost,
+} from "../api/hooks/use-devices";
+
+// ── Source badge ──────────────────────────────────────────────────────────────
+
+const SOURCE_LABEL: Record<string, string> = {
+  mdns: "mDNS",
+  dns: "DNS",
+  snmp: "SNMP",
+  netbios: "NetBIOS",
+  user: "User",
+};
+
+function SourceBadge({ source }: { source: string }) {
+  return (
+    <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-surface-raised text-text-muted border border-border/60">
+      {SOURCE_LABEL[source] ?? source}
+    </span>
+  );
+}
+
+// ── Edit name modal ───────────────────────────────────────────────────────────
+
+interface EditNameModalProps {
+  id: string;
+  currentName: string;
+  onClose: () => void;
+}
+
+function EditNameModal({ id, currentName, onClose }: EditNameModalProps) {
+  const { toast } = useToast();
+  const [name, setName] = useState(currentName);
+  const [error, setError] = useState<string | null>(null);
+  const { mutateAsync: updateDevice, isPending } = useUpdateDevice();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) { setError("Name is required."); return; }
+    try {
+      await updateDevice({ id, body: { name: trimmed } });
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to rename device."));
+      return;
+    }
+    toast.success("Device renamed.");
+    onClose();
+  }
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 z-50" onClick={onClose} aria-hidden="true" />
+      <div
+        role="dialog"
+        aria-label="Rename device"
+        className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-sm bg-surface border border-border rounded-lg shadow-xl p-6 space-y-4"
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-text-primary">Rename Device</h2>
+          <button type="button" onClick={onClose} aria-label="Close" className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoFocus
+            className={cn(
+              "w-full px-3 py-1.5 text-xs rounded border border-border",
+              "bg-surface text-text-primary placeholder:text-text-muted",
+              "focus:outline-none focus:ring-1 focus:ring-border",
+            )}
+          />
+          {error && <p className="text-xs text-danger">{error}</p>}
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" onClick={onClose} type="button">Cancel</Button>
+            <Button type="submit" loading={isPending} disabled={!name.trim()}>Save</Button>
+          </div>
+        </form>
+      </div>
+    </>
+  );
+}
+
+// ── Device detail page ────────────────────────────────────────────────────────
+
+interface DeviceDetailPageProps {
+  id: string;
+  onClose?: () => void;
+}
+
+export function DeviceDetailPage({ id, onClose }: DeviceDetailPageProps) {
+  const { toast } = useToast();
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const { data: device, isLoading, isError } = useDevice(id);
+  const { mutateAsync: deleteDevice, isPending: isDeleting } = useDeleteDevice();
+  const { mutateAsync: detachHost, isPending: isDetaching } = useDetachHost();
+
+  async function handleDelete() {
+    try {
+      await deleteDevice(id);
+    } catch (err) {
+      toast.error(getErrorMessage(err, "Failed to delete device."));
+      setShowDeleteConfirm(false);
+      return;
+    }
+    toast.success("Device deleted.");
+    onClose?.();
+  }
+
+  async function handleDetach(hostId: string) {
+    try {
+      await detachHost({ deviceId: id, hostId });
+      toast.success("Host detached.");
+    } catch (err) {
+      toast.error(getErrorMessage(err, "Failed to detach host."));
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6 p-6">
+        <Skeleton className="h-5 w-48" />
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-4 w-full" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !device) {
+    return (
+      <div className="p-6 text-sm text-text-muted">
+        Failed to load device.
+      </div>
+    );
+  }
+
+  const knownMacs = device.known_macs ?? [];
+  const knownNames = device.known_names ?? [];
+  const hosts = device.hosts ?? [];
+
+  return (
+    <>
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-2 min-w-0">
+            <Cpu className="h-4 w-4 text-text-muted shrink-0" />
+            <h1 className="text-sm font-semibold text-text-primary truncate">{device.name}</h1>
+          </div>
+          <div className="flex items-center gap-1.5 shrink-0">
+            <button
+              type="button"
+              aria-label="Rename device"
+              onClick={() => setShowEditModal(true)}
+              className="p-1.5 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+            {onClose && (
+              <button
+                type="button"
+                aria-label="Close"
+                onClick={onClose}
+                className="p-1.5 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Meta */}
+        <div className="space-y-1.5 text-xs">
+          <div className="flex gap-2">
+            <span className="text-text-muted w-24 shrink-0">Created</span>
+            <span className="text-text-secondary">{formatRelativeTime(device.created_at ?? "")}</span>
+          </div>
+          <div className="flex gap-2">
+            <span className="text-text-muted w-24 shrink-0">Updated</span>
+            <span className="text-text-secondary">{formatRelativeTime(device.updated_at ?? "")}</span>
+          </div>
+          {device.notes && (
+            <p className="text-text-secondary pt-1">{device.notes}</p>
+          )}
+        </div>
+
+        {/* Known MACs */}
+        <section>
+          <h2 className="text-xs font-medium text-text-primary flex items-center gap-1.5 mb-2">
+            <Wifi className="h-3.5 w-3.5 text-text-muted" />
+            Known MACs
+          </h2>
+          {knownMacs.length === 0 ? (
+            <p className="text-xs text-text-muted">No MACs recorded.</p>
+          ) : (
+            <div className="space-y-1">
+              {knownMacs.map((m) => (
+                <div key={m.id} className="flex items-center justify-between gap-2 py-1 border-b border-border/40 last:border-0">
+                  <span className="font-mono text-xs text-text-primary">{m.mac_address}</span>
+                  <span className="text-[10px] text-text-muted whitespace-nowrap">
+                    last seen {formatRelativeTime(m.last_seen ?? "")}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Known Names */}
+        <section>
+          <h2 className="text-xs font-medium text-text-primary flex items-center gap-1.5 mb-2">
+            <Tag className="h-3.5 w-3.5 text-text-muted" />
+            Known Names
+          </h2>
+          {knownNames.length === 0 ? (
+            <p className="text-xs text-text-muted">No names recorded.</p>
+          ) : (
+            <div className="space-y-1">
+              {knownNames.map((n) => (
+                <div key={n.id} className="flex items-center justify-between gap-2 py-1 border-b border-border/40 last:border-0">
+                  <span className="text-xs text-text-primary truncate">{n.name}</span>
+                  <SourceBadge source={n.source ?? ""} />
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Attached hosts */}
+        <section>
+          <h2 className="text-xs font-medium text-text-primary mb-2">Attached Hosts</h2>
+          {hosts.length === 0 ? (
+            <p className="text-xs text-text-muted">No hosts attached.</p>
+          ) : (
+            <div className="space-y-0.5">
+              {hosts.map((h) => (
+                <div key={h.id} className="flex items-center justify-between gap-2 py-1.5 border-b border-border/40 last:border-0">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="font-mono text-xs text-text-primary shrink-0">{h.ip_address}</span>
+                    {h.hostname && (
+                      <span className="text-xs text-text-muted truncate">{h.hostname}</span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <StatusBadge status={h.status ?? "unknown"} />
+                    <button
+                      type="button"
+                      aria-label={`Detach ${h.ip_address}`}
+                      onClick={() => { if (h.id) void handleDetach(h.id); }}
+                      disabled={isDetaching}
+                      className="p-0.5 rounded text-text-muted hover:text-danger hover:bg-danger/10 transition-colors"
+                    >
+                      <Link2Off className="h-3 w-3" />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Delete */}
+        <div className="pt-2 border-t border-border">
+          {!showDeleteConfirm ? (
+            <button
+              type="button"
+              onClick={() => setShowDeleteConfirm(true)}
+              className="flex items-center gap-1.5 text-xs text-text-muted hover:text-danger transition-colors"
+            >
+              <Trash2 className="h-3 w-3" />
+              Delete device
+            </button>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-text-muted">Delete this device?</span>
+              <Button variant="danger" onClick={() => void handleDelete()} loading={isDeleting} className="text-xs h-6 px-2">
+                Confirm
+              </Button>
+              <Button variant="secondary" onClick={() => setShowDeleteConfirm(false)} className="text-xs h-6 px-2">
+                Cancel
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showEditModal && (
+        <EditNameModal
+          id={id}
+          currentName={device.name ?? ""}
+          onClose={() => setShowEditModal(false)}
+        />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds all React Query hooks for the device identity API (`use-devices.ts`) — `useDevices`, `useDevice`, `useCreateDevice`, `useUpdateDevice`, `useDeleteDevice`, `useAttachHost`, `useDetachHost`, `useAcceptSuggestion`, `useDismissSuggestion`
- Adds `DeviceDetailPage` at `/devices/:id` showing known MACs, known names with source badges, attached hosts table with detach buttons, rename modal, and delete confirm
- Registers `/devices/$id` in the TanStack Router route tree
- Updates `docs/planning/ROADMAP.md` to reflect current version `v0.27.0-dev` and marks v0.23–v0.26 as Done

## Test plan

- [ ] Navigate to `/#/devices/<uuid>` for a device with known MACs and names — all sections render
- [ ] Detach a host from the device — host disappears from the list and the host's `device_id` clears
- [ ] Rename a device — new name appears in the header
- [ ] Delete a device — page closes/redirects, device no longer in list
- [ ] Acceptance/dismiss of suggestions is exercised via the discovery diff page (covered by #735)

Closes #734
Mentions #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)