### PR TITLE
fix(frontend): repair build after dep bumps

### DIFF
--- a/frontend/src/api/hooks/use-devices.test.ts
+++ b/frontend/src/api/hooks/use-devices.test.ts
@@ -29,24 +29,24 @@ const mockPut = vi.mocked(api.PUT);
 const mockDelete = vi.mocked(api.DELETE);
 
 const ok = (data: unknown) =>
-  Promise.resolve({ data, error: undefined, response: new Response() }) as ReturnType<typeof mockGet>;
+  ({ data, error: undefined, response: new Response() }) as Awaited<ReturnType<typeof mockGet>>;
 
 const fail = (msg = "boom") =>
-  Promise.resolve({
+  ({
     data: undefined,
     error: { message: msg },
     response: new Response(null, { status: 500 }),
-  }) as ReturnType<typeof mockGet>;
+  }) as Awaited<ReturnType<typeof mockGet>>;
 
 const okMut = (data: unknown) =>
-  Promise.resolve({ data, error: undefined, response: new Response() }) as ReturnType<typeof mockPost>;
+  ({ data, error: undefined, response: new Response() }) as Awaited<ReturnType<typeof mockPost>>;
 
 const failMut = (msg = "boom") =>
-  Promise.resolve({
+  ({
     data: undefined,
     error: { message: msg },
     response: new Response(null, { status: 500 }),
-  }) as ReturnType<typeof mockPost>;
+  }) as Awaited<ReturnType<typeof mockPost>>;
 
 // ── useDevices ────────────────────────────────────────────────────────────────
 
@@ -119,7 +119,7 @@ describe("useCreateDevice", () => {
   });
 
   it("throws on error", async () => {
-    mockPost.mockResolvedValue(failMut("name required") as ReturnType<typeof mockPost>);
+    mockPost.mockResolvedValue(failMut("name required") as Awaited<ReturnType<typeof mockPost>>);
 
     const { result, actHook } = renderHookWithQuery(() => useCreateDevice());
     await expect(
@@ -134,7 +134,7 @@ describe("useUpdateDevice", () => {
   beforeEach(() => vi.resetAllMocks());
 
   it("calls PUT /devices/{id} with the provided body", async () => {
-    mockPut.mockResolvedValue(okMut({ id: "d1", name: "Updated" }) as ReturnType<typeof mockPut>);
+    mockPut.mockResolvedValue(okMut({ id: "d1", name: "Updated" }) as Awaited<ReturnType<typeof mockPut>>);
 
     const { result, actHook } = renderHookWithQuery(() => useUpdateDevice());
     await actHook(async () => {
@@ -148,7 +148,7 @@ describe("useUpdateDevice", () => {
   });
 
   it("throws on error", async () => {
-    mockPut.mockResolvedValue(failMut("not found") as ReturnType<typeof mockPut>);
+    mockPut.mockResolvedValue(failMut("not found") as Awaited<ReturnType<typeof mockPut>>);
 
     const { result, actHook } = renderHookWithQuery(() => useUpdateDevice());
     await expect(
@@ -163,7 +163,7 @@ describe("useDeleteDevice", () => {
   beforeEach(() => vi.resetAllMocks());
 
   it("calls DELETE /devices/{id}", async () => {
-    mockDelete.mockResolvedValue(okMut(undefined) as ReturnType<typeof mockDelete>);
+    mockDelete.mockResolvedValue(okMut(undefined) as Awaited<ReturnType<typeof mockDelete>>);
 
     const { result, actHook } = renderHookWithQuery(() => useDeleteDevice());
     await actHook(async () => { await result.current.mutateAsync("d1"); });
@@ -174,7 +174,7 @@ describe("useDeleteDevice", () => {
   });
 
   it("throws on error", async () => {
-    mockDelete.mockResolvedValue(failMut("not found") as ReturnType<typeof mockDelete>);
+    mockDelete.mockResolvedValue(failMut("not found") as Awaited<ReturnType<typeof mockDelete>>);
 
     const { result, actHook } = renderHookWithQuery(() => useDeleteDevice());
     await expect(
@@ -218,7 +218,7 @@ describe("useDetachHost", () => {
   beforeEach(() => vi.resetAllMocks());
 
   it("calls DELETE /devices/{id}/hosts/{host_id}", async () => {
-    mockDelete.mockResolvedValue(okMut(undefined) as ReturnType<typeof mockDelete>);
+    mockDelete.mockResolvedValue(okMut(undefined) as Awaited<ReturnType<typeof mockDelete>>);
 
     const { result, actHook } = renderHookWithQuery(() => useDetachHost());
     await actHook(async () => {
@@ -232,7 +232,7 @@ describe("useDetachHost", () => {
   });
 
   it("throws on error", async () => {
-    mockDelete.mockResolvedValue(failMut("not found") as ReturnType<typeof mockDelete>);
+    mockDelete.mockResolvedValue(failMut("not found") as Awaited<ReturnType<typeof mockDelete>>);
 
     const { result, actHook } = renderHookWithQuery(() => useDetachHost());
     await expect(

--- a/frontend/src/api/hooks/use-discovery.ts
+++ b/frontend/src/api/hooks/use-discovery.ts
@@ -11,7 +11,7 @@ type CreateDiscoveryJobRequest =
 interface DiscoveryListParams {
   page?: number;
   page_size?: number;
-  status?: string;
+  status?: "pending" | "running" | "completed" | "failed";
 }
 
 // ── Diff types ────────────────────────────────────────────────────────────────

--- a/frontend/src/api/hooks/use-hosts.test.ts
+++ b/frontend/src/api/hooks/use-hosts.test.ts
@@ -32,47 +32,47 @@ const mockDelete = vi.mocked(api.DELETE);
 const mockPatch = vi.mocked((api as any).PATCH);
 const mockPost = vi.mocked(api.POST);
 
-const ok = (data: unknown): ReturnType<typeof mockGet> =>
-  Promise.resolve({
+const ok = (data: unknown): Awaited<ReturnType<typeof mockGet>> =>
+  ({
     data,
     error: undefined,
     response: new Response(),
-  }) as ReturnType<typeof mockGet>;
+  }) as Awaited<ReturnType<typeof mockGet>>;
 
-const fail = (message = "something went wrong"): ReturnType<typeof mockGet> =>
-  Promise.resolve({
+const fail = (message = "something went wrong"): Awaited<ReturnType<typeof mockGet>> =>
+  ({
     data: undefined,
     error: { message },
     response: new Response(),
-  }) as ReturnType<typeof mockGet>;
+  }) as Awaited<ReturnType<typeof mockGet>>;
 
-const okPut = (data: unknown): ReturnType<typeof mockPut> =>
-  Promise.resolve({
+const okPut = (data: unknown): Awaited<ReturnType<typeof mockPut>> =>
+  ({
     data,
     error: undefined,
     response: new Response(),
-  }) as ReturnType<typeof mockPut>;
+  }) as Awaited<ReturnType<typeof mockPut>>;
 
-const failPut = (message = "update failed"): ReturnType<typeof mockPut> =>
-  Promise.resolve({
+const failPut = (message = "update failed"): Awaited<ReturnType<typeof mockPut>> =>
+  ({
     data: undefined,
     error: { message },
     response: new Response(null, { status: 400 }),
-  }) as ReturnType<typeof mockPut>;
+  }) as Awaited<ReturnType<typeof mockPut>>;
 
-const failDelete = (message = "delete failed"): ReturnType<typeof mockDelete> =>
-  Promise.resolve({
+const failDelete = (message = "delete failed"): Awaited<ReturnType<typeof mockDelete>> =>
+  ({
     data: undefined,
     error: { message },
     response: new Response(null, { status: 400 }),
-  }) as ReturnType<typeof mockDelete>;
+  }) as Awaited<ReturnType<typeof mockDelete>>;
 
-const okDelete = (): ReturnType<typeof mockDelete> =>
-  Promise.resolve({
+const okDelete = (): Awaited<ReturnType<typeof mockDelete>> =>
+  ({
     data: undefined,
     error: undefined,
     response: new Response(),
-  }) as ReturnType<typeof mockDelete>;
+  }) as Awaited<ReturnType<typeof mockDelete>>;
 
 const mockHost = {
   id: "host-1",
@@ -647,7 +647,7 @@ describe("useRefreshIdentity", () => {
       data: { host_id: "host-1", queued: true, scan_id: "scan-42" },
       error: undefined,
       response: new Response(),
-    } as unknown as ReturnType<typeof mockPost>);
+    } as unknown as Awaited<ReturnType<typeof mockPost>>);
 
     const { result, actHook } = renderHookWithQuery(() => useRefreshIdentity());
 
@@ -656,9 +656,9 @@ describe("useRefreshIdentity", () => {
     });
 
     expect(mockPost).toHaveBeenCalledWith(
-      "/smart-scan/hosts/{hostId}/refresh-identity",
+      "/smart-scan/hosts/{id}/refresh-identity",
       expect.objectContaining({
-        params: { path: { hostId: "host-1" } },
+        params: { path: { id: "host-1" } },
       }),
     );
   });
@@ -668,7 +668,7 @@ describe("useRefreshIdentity", () => {
       data: { host_id: "host-1", queued: true, scan_id: "scan-42" },
       error: undefined,
       response: new Response(),
-    } as unknown as ReturnType<typeof mockPost>);
+    } as unknown as Awaited<ReturnType<typeof mockPost>>);
 
     const { result, actHook, queryClient } = renderHookWithQuery(() =>
       useRefreshIdentity(),
@@ -689,7 +689,7 @@ describe("useRefreshIdentity", () => {
       data: undefined,
       error: { message: "host not found" },
       response: new Response(null, { status: 404 }),
-    } as unknown as ReturnType<typeof mockPost>);
+    } as unknown as Awaited<ReturnType<typeof mockPost>>);
 
     const { result, actHook } = renderHookWithQuery(() => useRefreshIdentity());
 

--- a/frontend/src/api/hooks/use-hosts.ts
+++ b/frontend/src/api/hooks/use-hosts.ts
@@ -161,8 +161,8 @@ export function useRefreshIdentity() {
   return useMutation({
     mutationFn: async (hostId: string) => {
       const { data, error, response } = await api.POST(
-        "/smart-scan/hosts/{hostId}/refresh-identity",
-        { params: { path: { hostId } } },
+        "/smart-scan/hosts/{id}/refresh-identity",
+        { params: { path: { id: hostId } } },
       );
       if (error) throw new ApiError(response.status, error);
       return data;

--- a/frontend/src/api/hooks/use-networks.test.ts
+++ b/frontend/src/api/hooks/use-networks.test.ts
@@ -32,19 +32,19 @@ const mockPost = vi.mocked(api.POST);
 const mockPut = vi.mocked(api.PUT);
 const mockDelete = vi.mocked(api.DELETE);
 
-const ok = (data: unknown): ReturnType<typeof mockGet> =>
-  Promise.resolve({
+const ok = (data: unknown): Awaited<ReturnType<typeof mockGet>> =>
+  ({
     data,
     error: undefined,
     response: new Response(),
-  }) as ReturnType<typeof mockGet>;
+  }) as Awaited<ReturnType<typeof mockGet>>;
 
-const fail = (message = "something went wrong"): ReturnType<typeof mockGet> =>
-  Promise.resolve({
+const fail = (message = "something went wrong"): Awaited<ReturnType<typeof mockGet>> =>
+  ({
     data: undefined,
     error: { message },
     response: new Response(),
-  }) as ReturnType<typeof mockGet>;
+  }) as Awaited<ReturnType<typeof mockGet>>;
 
 const mockNetworks = [
   {
@@ -110,53 +110,53 @@ const mockExclusions = [
   },
 ];
 
-const okPost = (data: unknown): ReturnType<typeof mockPost> =>
-  Promise.resolve({
+const okPost = (data: unknown): Awaited<ReturnType<typeof mockPost>> =>
+  ({
     data,
     error: undefined,
     response: new Response(),
-  }) as ReturnType<typeof mockPost>;
+  }) as Awaited<ReturnType<typeof mockPost>>;
 
 const failPost = (
   message = "something went wrong",
-): ReturnType<typeof mockPost> =>
-  Promise.resolve({
+): Awaited<ReturnType<typeof mockPost>> =>
+  ({
     data: undefined,
     error: { message },
     response: new Response(),
-  }) as ReturnType<typeof mockPost>;
+  }) as Awaited<ReturnType<typeof mockPost>>;
 
-const okPut = (data: unknown): ReturnType<typeof mockPut> =>
-  Promise.resolve({
+const okPut = (data: unknown): Awaited<ReturnType<typeof mockPut>> =>
+  ({
     data,
     error: undefined,
     response: new Response(),
-  }) as ReturnType<typeof mockPut>;
+  }) as Awaited<ReturnType<typeof mockPut>>;
 
 const failPut = (
   message = "something went wrong",
-): ReturnType<typeof mockPut> =>
-  Promise.resolve({
+): Awaited<ReturnType<typeof mockPut>> =>
+  ({
     data: undefined,
     error: { message },
     response: new Response(),
-  }) as ReturnType<typeof mockPut>;
+  }) as Awaited<ReturnType<typeof mockPut>>;
 
-const okDelete = (): ReturnType<typeof mockDelete> =>
-  Promise.resolve({
+const okDelete = (): Awaited<ReturnType<typeof mockDelete>> =>
+  ({
     data: undefined,
     error: undefined,
     response: new Response(),
-  }) as ReturnType<typeof mockDelete>;
+  }) as Awaited<ReturnType<typeof mockDelete>>;
 
 const failDelete = (
   message = "something went wrong",
-): ReturnType<typeof mockDelete> =>
-  Promise.resolve({
+): Awaited<ReturnType<typeof mockDelete>> =>
+  ({
     data: undefined,
     error: { message },
     response: new Response(),
-  }) as ReturnType<typeof mockDelete>;
+  }) as Awaited<ReturnType<typeof mockDelete>>;
 
 // ── useNetworks ───────────────────────────────────────────────────────────────
 

--- a/frontend/src/api/hooks/use-scans.test.ts
+++ b/frontend/src/api/hooks/use-scans.test.ts
@@ -25,26 +25,26 @@ const mockGet = vi.mocked(api.GET);
 const mockPost = vi.mocked(api.POST);
 const mockDelete = vi.mocked(api.DELETE);
 
-const ok = (data: unknown): ReturnType<typeof mockGet> =>
-  Promise.resolve({
+const ok = (data: unknown): Awaited<ReturnType<typeof mockGet>> =>
+  ({
     data,
     error: undefined,
     response: new Response(),
-  }) as ReturnType<typeof mockGet>;
+  }) as Awaited<ReturnType<typeof mockGet>>;
 
-const fail = (message = "something went wrong"): ReturnType<typeof mockGet> =>
-  Promise.resolve({
+const fail = (message = "something went wrong"): Awaited<ReturnType<typeof mockGet>> =>
+  ({
     data: undefined,
     error: { message },
     response: new Response(),
-  }) as ReturnType<typeof mockGet>;
+  }) as Awaited<ReturnType<typeof mockGet>>;
 
-const okDelete = (): ReturnType<typeof mockDelete> =>
-  Promise.resolve({
+const okDelete = (): Awaited<ReturnType<typeof mockDelete>> =>
+  ({
     data: undefined,
     error: undefined,
     response: new Response(),
-  }) as ReturnType<typeof mockDelete>;
+  }) as Awaited<ReturnType<typeof mockDelete>>;
 
 const mockPagination = {
   page: 1,

--- a/frontend/src/api/hooks/use-schedules.test.ts
+++ b/frontend/src/api/hooks/use-schedules.test.ts
@@ -26,67 +26,67 @@ const mockPost = vi.mocked(api.POST);
 const mockPut = vi.mocked(api.PUT);
 const mockDelete = vi.mocked(api.DELETE);
 
-const ok = (data: unknown): ReturnType<typeof mockGet> =>
-  Promise.resolve({
+const ok = (data: unknown): Awaited<ReturnType<typeof mockGet>> =>
+  ({
     data,
     error: undefined,
     response: new Response(),
-  }) as ReturnType<typeof mockGet>;
+  }) as Awaited<ReturnType<typeof mockGet>>;
 
-const fail = (message = "something went wrong"): ReturnType<typeof mockGet> =>
-  Promise.resolve({
+const fail = (message = "something went wrong"): Awaited<ReturnType<typeof mockGet>> =>
+  ({
     data: undefined,
     error: { message },
     response: new Response(),
-  }) as ReturnType<typeof mockGet>;
+  }) as Awaited<ReturnType<typeof mockGet>>;
 
-const okPost = (data: unknown): ReturnType<typeof mockPost> =>
-  Promise.resolve({
+const okPost = (data: unknown): Awaited<ReturnType<typeof mockPost>> =>
+  ({
     data,
     error: undefined,
     response: new Response(),
-  }) as ReturnType<typeof mockPost>;
+  }) as Awaited<ReturnType<typeof mockPost>>;
 
 const failPost = (
   message = "something went wrong",
-): ReturnType<typeof mockPost> =>
-  Promise.resolve({
+): Awaited<ReturnType<typeof mockPost>> =>
+  ({
     data: undefined,
     error: { message },
     response: new Response(),
-  }) as ReturnType<typeof mockPost>;
+  }) as Awaited<ReturnType<typeof mockPost>>;
 
-const okPut = (data: unknown): ReturnType<typeof mockPut> =>
-  Promise.resolve({
+const okPut = (data: unknown): Awaited<ReturnType<typeof mockPut>> =>
+  ({
     data,
     error: undefined,
     response: new Response(),
-  }) as ReturnType<typeof mockPut>;
+  }) as Awaited<ReturnType<typeof mockPut>>;
 
 const failPut = (
   message = "something went wrong",
-): ReturnType<typeof mockPut> =>
-  Promise.resolve({
+): Awaited<ReturnType<typeof mockPut>> =>
+  ({
     data: undefined,
     error: { message },
     response: new Response(),
-  }) as ReturnType<typeof mockPut>;
+  }) as Awaited<ReturnType<typeof mockPut>>;
 
-const okDelete = (): ReturnType<typeof mockDelete> =>
-  Promise.resolve({
+const okDelete = (): Awaited<ReturnType<typeof mockDelete>> =>
+  ({
     data: undefined,
     error: undefined,
     response: new Response(),
-  }) as ReturnType<typeof mockDelete>;
+  }) as Awaited<ReturnType<typeof mockDelete>>;
 
 const failDelete = (
   message = "something went wrong",
-): ReturnType<typeof mockDelete> =>
-  Promise.resolve({
+): Awaited<ReturnType<typeof mockDelete>> =>
+  ({
     data: undefined,
     error: { message },
     response: new Response(),
-  }) as ReturnType<typeof mockDelete>;
+  }) as Awaited<ReturnType<typeof mockDelete>>;
 
 const mockSchedules = [
   {

--- a/frontend/src/components/filter-builder.test.tsx
+++ b/frontend/src/components/filter-builder.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { FilterBuilder } from "./filter-builder";
 import type { FilterGroup } from "../lib/filter-expr";
 

--- a/frontend/src/components/scan-network-modal.test.tsx
+++ b/frontend/src/components/scan-network-modal.test.tsx
@@ -356,7 +356,6 @@ describe("ScanNetworkModal", () => {
   });
 
   it("shows an error and does not call startScan when active host count is 0 at submit time", async () => {
-    const user = userEvent.setup();
     // Start with 3 hosts so button is enabled, then switch to 0
     const startScan = vi.fn();
     mockUseStartScan.mockReturnValue({

--- a/frontend/src/components/tag-input.test.tsx
+++ b/frontend/src/components/tag-input.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { TagInput } from "./tag-input";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/frontend/src/routes/devices.test.tsx
+++ b/frontend/src/routes/devices.test.tsx
@@ -104,7 +104,7 @@ describe("DeviceDetailPage", () => {
       data: { ...mockDevice, known_macs: [], known_names: [], hosts: [] },
       isLoading: false,
       isError: false,
-    } as ReturnType<typeof useDevice>);
+    } as unknown as ReturnType<typeof useDevice>);
 
     render(<DeviceDetailPage id="d1" />);
     expect(screen.getByText("No MACs recorded.")).toBeInTheDocument();

--- a/frontend/src/routes/discovery.tsx
+++ b/frontend/src/routes/discovery.tsx
@@ -414,6 +414,18 @@ function ComparePanel({
 }: ComparePanelProps) {
   const completedJobs = jobs.filter((j) => j.status === "completed");
 
+  const renderOption = (j: DiscoveryJobResponse) => {
+    const label: string = j.name ?? j.networks?.join(", ") ?? j.id ?? "";
+    const date = j.started_at
+      ? new Date(j.started_at).toLocaleDateString()
+      : "—";
+    return (
+      <option key={j.id} value={j.id ?? ""}>
+        {label} · {date}
+      </option>
+    );
+  };
+
   return (
     <div className="bg-surface border border-border rounded-lg p-4 space-y-4">
       {/* Header */}
@@ -442,14 +454,7 @@ function ComparePanel({
             className="bg-surface-raised border border-border rounded px-2 py-1.5 text-xs text-text-secondary focus:outline-none focus:border-accent"
           >
             <option value="">Select a run…</option>
-            {completedJobs.map((j) => (
-              <option key={j.id} value={j.id ?? ""}>
-                {j.name ?? j.networks?.join(", ") ?? j.id} ·{" "}
-                {j.started_at
-                  ? new Date(j.started_at).toLocaleDateString()
-                  : "—"}
-              </option>
-            ))}
+            {completedJobs.map(renderOption)}
           </select>
         </div>
 
@@ -464,14 +469,7 @@ function ComparePanel({
             className="bg-surface-raised border border-border rounded px-2 py-1.5 text-xs text-text-secondary focus:outline-none focus:border-accent"
           >
             <option value="">Select a run…</option>
-            {completedJobs.map((j) => (
-              <option key={j.id} value={j.id ?? ""}>
-                {j.name ?? j.networks?.join(", ") ?? j.id} ·{" "}
-                {j.started_at
-                  ? new Date(j.started_at).toLocaleDateString()
-                  : "—"}
-              </option>
-            ))}
+            {completedJobs.map(renderOption)}
           </select>
         </div>
       </div>
@@ -480,7 +478,7 @@ function ComparePanel({
       {isLoading && (
         <p className="text-xs text-text-muted">Loading comparison…</p>
       )}
-      {error && !isLoading && (
+      {!!error && !isLoading && (
         <p className="text-xs text-danger">
           {error instanceof Error ? error.message : "Failed to compare runs."}
         </p>

--- a/frontend/src/routes/groups.tsx
+++ b/frontend/src/routes/groups.tsx
@@ -377,7 +377,8 @@ function GroupDetailPanel({ group, onClose, onEdit }: GroupDetailPanelProps) {
               <PaginationBar
                 page={memberPage}
                 totalPages={totalMemberPages}
-                onPageChange={setMemberPage}
+                onPrev={() => setMemberPage((p) => Math.max(1, p - 1))}
+                onNext={() => setMemberPage((p) => Math.min(totalMemberPages, p + 1))}
                 className="mt-3"
               />
             )}

--- a/frontend/src/routes/hosts.test.tsx
+++ b/frontend/src/routes/hosts.test.tsx
@@ -373,6 +373,14 @@ function makeDeleteMutationResult(overrides = {}) {
   } as unknown as ReturnType<typeof useDeleteHost>;
 }
 
+function makeBulkDeleteMutationResult(overrides = {}) {
+  return {
+    mutateAsync: vi.fn().mockResolvedValue({ deleted: 0 }),
+    isPending: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useBulkDeleteHosts>;
+}
+
 beforeEach(async () => {
   vi.clearAllMocks();
   mockUseHosts.mockReturnValue(makeUseHostsResult());
@@ -380,7 +388,7 @@ beforeEach(async () => {
   mockUseHostScans.mockReturnValue(makeUseHostScansResult());
   mockUseUpdateHost.mockReturnValue(makeMutationResult());
   mockUseDeleteHost.mockReturnValue(makeDeleteMutationResult());
-  mockUseBulkDeleteHosts.mockReturnValue(makeDeleteMutationResult());
+  mockUseBulkDeleteHosts.mockReturnValue(makeBulkDeleteMutationResult());
 
   const { useHostNetworks } = await import("../api/hooks/use-host-networks");
   vi.mocked(useHostNetworks).mockReturnValue({


### PR DESCRIPTION
## Summary

Recent Dependabot/Renovate bumps (openapi-fetch, react-query, React 19 type tightening, swagger regen) left 36 TypeScript errors blocking \`npm run build\`. This PR repairs the build with no behavioural changes.

Three commits, one per category:

- **Mock helper return types** — \`openapi-fetch\` now types \`mockResolvedValue\` against the unwrapped value, so the hook test helpers \`ok\`/\`fail\`/\`okMut\`/\`failMut\` need to return bare objects (not \`Promise<...>\`). Fixed in 5 hook test files.
- **Unused imports** — stricter \`tsc\` flagged unused \`beforeEach\` and a stale \`user\` var.
- **API drift** — narrowed \`DiscoveryListParams.status\` to the literal union, renamed refresh-identity path param \`{hostId}\` → \`{id}\`, fixed React 19 \`unknown\`-rejecting JSX in \`discovery.tsx\`, switched \`PaginationBar\` to \`onPrev\`/\`onNext\`, and updated two test mocks for changed mutation/query signatures.

\`npm run build\` succeeds. \`npm run test\` passes 981/981.

## Test plan

- [ ] CI passes (Code Quality, Unit Tests, Frontend Tests, build)