### PR TITLE
refactor(db): add typed accessors to SettingsRepository

### DIFF
--- a/docs/superpowers/specs/2026-04-27-settings-typed-accessors-design.md
+++ b/docs/superpowers/specs/2026-04-27-settings-typed-accessors-design.md
@@ -1,0 +1,453 @@
+# Settings Typed Accessors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add four typed accessor methods to `SettingsRepository` that handle JSONB unquoting transparently, then migrate `PortListResolver` to use them instead of raw SQL with manual JSON parsing.
+
+**Architecture:** New methods call the existing `GetSetting` and type-convert `Setting.Value` (raw JSONB text). All four follow the same pattern: unmarshal the JSON value, return `(T, error)`. `db.ErrNotFound` propagates unchanged so callers decide the fallback. No silent defaults at the repository layer. `PortListResolver` gets an internal `settingsRepo *SettingsRepository` field; its fail-open fallback logic stays in the service layer.
+
+**Tech Stack:** Go, `encoding/json`, `go-sqlmock` (unit tests), existing `SettingsRepository` / `GetSetting` pattern.
+
+---
+
+## Context
+
+### Settings table
+
+```sql
+CREATE TABLE settings (
+    key         VARCHAR(100) PRIMARY KEY,
+    value       JSONB        NOT NULL,
+    description TEXT,
+    type        VARCHAR(20)  NOT NULL DEFAULT 'string',
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+```
+
+`GetSetting` queries `value::text`, so `Setting.Value` is the raw JSONB representation:
+- String `"hello"` → `"hello"` (JSON-quoted)
+- Integer `256` → `256` (bare)
+- Boolean `true` → `true` (bare)
+- Array `["a","b"]` → `["a","b"]`
+
+### Existing `GetSetting` query
+
+```go
+SELECT key, value::text, COALESCE(description, ''), type, updated_at
+FROM settings WHERE key = $1
+```
+
+Unit tests mock this query with `mock.ExpectQuery(`SELECT key, value`).WithArgs(key)`.
+
+### Current footgun in `PortListResolver`
+
+`readBasePorts` and `readLimit` run their own raw queries and do manual JSON unquoting:
+
+```go
+// readBasePorts: manual json.Unmarshal + fallback to raw string
+// readLimit: strings.Trim(raw, `"`) + strconv.Atoi
+```
+
+After this refactor both methods use typed accessors and contain no JSON handling.
+
+---
+
+## Files
+
+| File | Change |
+|------|--------|
+| `internal/db/repository_settings.go` | Add 4 typed accessor methods |
+| `internal/db/repository_settings_unit_test.go` | Add tests for 4 accessors |
+| `internal/services/portresolver.go` | Add `settingsRepo` field; simplify `readBasePorts`/`readLimit` |
+| `internal/services/portresolver_test.go` | Update mock expectations to match `GetSetting` query |
+
+---
+
+## Task 1: Typed accessors on `SettingsRepository`
+
+**Files:**
+- Modify: `internal/db/repository_settings.go`
+
+### Method signatures
+
+```go
+// GetStringSetting returns the unquoted string value for a string-typed setting.
+// Returns ErrNotFound if the key does not exist.
+func (r *SettingsRepository) GetStringSetting(ctx context.Context, key string) (string, error)
+
+// GetIntSetting returns the integer value for an int-typed setting.
+// Returns ErrNotFound if the key does not exist.
+func (r *SettingsRepository) GetIntSetting(ctx context.Context, key string) (int, error)
+
+// GetBoolSetting returns the boolean value for a bool-typed setting.
+// Returns ErrNotFound if the key does not exist.
+func (r *SettingsRepository) GetBoolSetting(ctx context.Context, key string) (bool, error)
+
+// GetStringSliceSetting returns the []string value for a string[]-typed setting.
+// Returns ErrNotFound if the key does not exist.
+func (r *SettingsRepository) GetStringSliceSetting(ctx context.Context, key string) ([]string, error)
+```
+
+### Implementation pattern (same for all four)
+
+```go
+func (r *SettingsRepository) GetStringSetting(ctx context.Context, key string) (string, error) {
+    s, err := r.GetSetting(ctx, key)
+    if err != nil {
+        return "", err
+    }
+    var val string
+    if err := json.Unmarshal([]byte(s.Value), &val); err != nil {
+        return "", fmt.Errorf("setting %q value is not a JSON string: %w", key, err)
+    }
+    return val, nil
+}
+
+func (r *SettingsRepository) GetIntSetting(ctx context.Context, key string) (int, error) {
+    s, err := r.GetSetting(ctx, key)
+    if err != nil {
+        return 0, err
+    }
+    var val int
+    if err := json.Unmarshal([]byte(s.Value), &val); err != nil {
+        return 0, fmt.Errorf("setting %q value is not a JSON integer: %w", key, err)
+    }
+    return val, nil
+}
+
+func (r *SettingsRepository) GetBoolSetting(ctx context.Context, key string) (bool, error) {
+    s, err := r.GetSetting(ctx, key)
+    if err != nil {
+        return false, err
+    }
+    var val bool
+    if err := json.Unmarshal([]byte(s.Value), &val); err != nil {
+        return false, fmt.Errorf("setting %q value is not a JSON boolean: %w", key, err)
+    }
+    return val, nil
+}
+
+func (r *SettingsRepository) GetStringSliceSetting(ctx context.Context, key string) ([]string, error) {
+    s, err := r.GetSetting(ctx, key)
+    if err != nil {
+        return nil, err
+    }
+    var val []string
+    if err := json.Unmarshal([]byte(s.Value), &val); err != nil {
+        return nil, fmt.Errorf("setting %q value is not a JSON string array: %w", key, err)
+    }
+    return val, nil
+}
+```
+
+`encoding/json` must be added to imports.
+
+- [ ] **Step 1: Add the four methods to `repository_settings.go`**
+
+Add after `GetSetting`, before `SetSetting`. Add `"encoding/json"` to imports.
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+go build ./internal/db/...
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/db/repository_settings.go
+git commit -m "feat(db): add typed accessors to SettingsRepository"
+```
+
+---
+
+## Task 2: Unit tests for typed accessors
+
+**Files:**
+- Modify: `internal/db/repository_settings_unit_test.go`
+
+### Test cases per accessor
+
+Each accessor needs four tests (same structure for all four):
+1. Happy path — key exists with correct JSON type
+2. Not found — key missing → `ErrNotFound`
+3. Wrong type — value is valid JSON but wrong type (e.g. `"123"` for GetIntSetting) → type error
+4. DB error — query fails → error propagated
+
+### Mock pattern (matches existing `makeSettingRow` helper and `GetSetting` query)
+
+The query being mocked is `GetSetting`'s query:
+```
+SELECT key, value::text, COALESCE(description, ''), type, updated_at
+FROM settings WHERE key = $1
+```
+
+Mock with:
+```go
+mock.ExpectQuery(`SELECT key, value`).
+    WithArgs("my.key").
+    WillReturnRows(makeSettingRow("my.key", `"hello"`, "", "string"))
+```
+
+### Full test examples
+
+```go
+func TestSettingsRepository_GetStringSetting_ReturnsUnquotedValue(t *testing.T) {
+    db, mock := newMockDB(t)
+    repo := NewSettingsRepository(db)
+
+    mock.ExpectQuery(`SELECT key, value`).
+        WithArgs("scan.label").
+        WillReturnRows(makeSettingRow("scan.label", `"fast"`, "", "string"))
+
+    val, err := repo.GetStringSetting(context.Background(), "scan.label")
+    require.NoError(t, err)
+    assert.Equal(t, "fast", val)
+    require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetStringSetting_ReturnsErrNotFound(t *testing.T) {
+    db, mock := newMockDB(t)
+    repo := NewSettingsRepository(db)
+
+    mock.ExpectQuery(`SELECT key, value`).
+        WithArgs("missing.key").
+        WillReturnRows(sqlmock.NewRows([]string{"key", "value", "description", "type", "updated_at"}))
+
+    _, err := repo.GetStringSetting(context.Background(), "missing.key")
+    require.Error(t, err)
+    assert.True(t, errors.IsNotFound(err))
+    require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetStringSetting_ReturnsErrorOnWrongType(t *testing.T) {
+    db, mock := newMockDB(t)
+    repo := NewSettingsRepository(db)
+
+    mock.ExpectQuery(`SELECT key, value`).
+        WithArgs("scan.label").
+        WillReturnRows(makeSettingRow("scan.label", `123`, "", "int")) // int, not string
+
+    _, err := repo.GetStringSetting(context.Background(), "scan.label")
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "not a JSON string")
+    require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetStringSetting_PropagatesDBError(t *testing.T) {
+    db, mock := newMockDB(t)
+    repo := NewSettingsRepository(db)
+
+    mock.ExpectQuery(`SELECT key, value`).
+        WithArgs("scan.label").
+        WillReturnError(fmt.Errorf("conn error"))
+
+    _, err := repo.GetStringSetting(context.Background(), "scan.label")
+    require.Error(t, err)
+    require.NoError(t, mock.ExpectationsWereMet())
+}
+```
+
+Repeat the same four test cases for `GetIntSetting` (value `"5"` happy path, `"true"` wrong type), `GetBoolSetting` (value `"true"` happy path, `"123"` wrong type), and `GetStringSliceSetting` (value `'["icmp","arp"]'` happy path, `"single"` wrong type).
+
+- [ ] **Step 1: Write the failing tests** (16 tests total: 4 per accessor × 4 accessors)
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+go test ./internal/db/ -run "TestSettingsRepository_Get.*Setting" -v
+```
+
+Expected: compile error or FAIL (methods not yet called — but since Task 1 already added the methods, tests should fail only if assertions are wrong).
+
+- [ ] **Step 3: Run tests to confirm they pass**
+
+```bash
+go test -race -count=1 ./internal/db/ -run "TestSettingsRepository_Get.*Setting" -v
+```
+
+Expected: 16 PASS.
+
+- [ ] **Step 4: Run full db suite to confirm no regressions**
+
+```bash
+go test -race -count=1 ./internal/db/ -short
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/db/repository_settings_unit_test.go
+git commit -m "test(db): add unit tests for typed SettingsRepository accessors"
+```
+
+---
+
+## Task 3: Migrate `PortListResolver` to use typed accessors
+
+**Files:**
+- Modify: `internal/services/portresolver.go`
+
+### Changes
+
+1. Add `settingsRepo *db.SettingsRepository` field to `PortListResolver` struct.
+2. In `NewPortListResolver`, create the repo from the existing `database *db.DB`:
+   ```go
+   return &PortListResolver{
+       db:           database,
+       settingsRepo: db.NewSettingsRepository(database),
+       logger:       logger,
+   }
+   ```
+3. Rewrite `readBasePorts` to use `r.settingsRepo.GetStringSetting`:
+
+```go
+func (r *PortListResolver) readBasePorts(ctx context.Context, stage string) string {
+    fallback, ok := stageDefaultPorts[stage]
+    if !ok {
+        r.logger.Warn("unknown stage passed to port resolver, using broad fallback", "stage", stage)
+        fallback = "1-1024"
+    }
+
+    key := "smartscan." + stage + ".ports"
+    val, err := r.settingsRepo.GetStringSetting(ctx, key)
+    if err != nil {
+        if !errors.IsNotFound(err) {
+            r.logger.Warn("failed to read base port setting, using default", "key", key, "error", err)
+        }
+        return fallback
+    }
+    if val == "" {
+        return fallback
+    }
+    return val
+}
+```
+
+4. Rewrite `readLimit` to use `r.settingsRepo.GetIntSetting`:
+
+```go
+func (r *PortListResolver) readLimit(ctx context.Context) int {
+    const key = "smartscan.top_ports_limit"
+    n, err := r.settingsRepo.GetIntSetting(ctx, key)
+    if err != nil {
+        if !errors.IsNotFound(err) {
+            r.logger.Warn("failed to read top_ports_limit setting, using default", "error", err)
+        }
+        return defaultTopPortsLimit
+    }
+    if n <= 0 {
+        r.logger.Warn("smartscan.top_ports_limit must be positive, using default", "value", n)
+        return defaultTopPortsLimit
+    }
+    return n
+}
+```
+
+5. Remove unused imports: `"database/sql"`, `"encoding/json"`, `"strings"` (used only by the old parsing code). Verify with `go build`.
+
+Note: `errors.IsNotFound` is from `github.com/anstrom/scanorama/internal/errors` — the same package used by `SettingsRepository`. Check the import alias pattern in portresolver.go and use the same.
+
+- [ ] **Step 1: Add `settingsRepo` field and update `NewPortListResolver`**
+
+- [ ] **Step 2: Rewrite `readBasePorts`**
+
+- [ ] **Step 3: Rewrite `readLimit`**
+
+- [ ] **Step 4: Remove stale imports and verify build**
+
+```bash
+go build ./internal/services/...
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/services/portresolver.go
+git commit -m "refactor(services): migrate PortListResolver to use typed SettingsRepository accessors"
+```
+
+---
+
+## Task 4: Update `portresolver_test.go` mock expectations
+
+**Files:**
+- Modify: `internal/services/portresolver_test.go`
+
+The existing tests mock `SELECT value::text FROM settings WHERE key = $1` directly. After migration, `GetStringSetting` and `GetIntSetting` each call `GetSetting`, whose query is:
+
+```
+SELECT key, value::text, COALESCE(description, ''), type, updated_at
+FROM settings WHERE key = $1
+```
+
+All tests that previously had:
+```go
+mock.ExpectQuery(`SELECT value`).
+    WithArgs("smartscan.os_detection.ports").
+    WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(`"22,443,8080"`))
+```
+
+Must become:
+```go
+mock.ExpectQuery(`SELECT key, value`).
+    WithArgs("smartscan.os_detection.ports").
+    WillReturnRows(sqlmock.NewRows([]string{"key", "value", "description", "type", "updated_at"}).
+        AddRow("smartscan.os_detection.ports", `"22,443,8080"`, "", "string", time.Now()))
+```
+
+Similarly, limit queries returning `"256"` (bare integer) become full five-column rows with `value = "256"`.
+
+All 19 existing tests in `portresolver_test.go` that set up settings mock expectations need this update. The error-return tests that use `WillReturnError` are unaffected structurally (just update the `ExpectQuery` pattern from `SELECT value` to `SELECT key, value`).
+
+A helper `settingRow(key, value string) *sqlmock.Rows` can reduce repetition:
+
+```go
+func settingRow(key, value string) *sqlmock.Rows {
+    return sqlmock.NewRows([]string{"key", "value", "description", "type", "updated_at"}).
+        AddRow(key, value, "", "string", time.Now())
+}
+```
+
+- [ ] **Step 1: Add `settingRow` helper to `portresolver_test.go`**
+
+- [ ] **Step 2: Update all settings mock expectations** (both base-ports and limit queries in every test)
+
+- [ ] **Step 3: Run tests to confirm they pass**
+
+```bash
+go test -race -count=1 ./internal/services/ -run "PortList|PortResolver" -v
+```
+
+Expected: all 19 PASS.
+
+- [ ] **Step 4: Run full services suite**
+
+```bash
+go test -race -count=1 ./internal/services/
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/services/portresolver_test.go
+git commit -m "test(services): update portresolver mocks to match SettingsRepository query shape"
+```
+
+---
+
+## Verification
+
+```bash
+go test -race ./internal/db/ ./internal/services/
+```
+
+All tests pass. No references to `strings.Trim` or manual `json.Unmarshal` remain in `portresolver.go`.

--- a/internal/db/repository_settings.go
+++ b/internal/db/repository_settings.go
@@ -4,6 +4,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	stderrors "errors"
 	"fmt"
 	"time"
@@ -75,6 +76,62 @@ func (r *SettingsRepository) GetSetting(ctx context.Context, key string) (*Setti
 		return nil, sanitizeDBError("get setting", err)
 	}
 	return &s, nil
+}
+
+// GetStringSetting returns the unquoted string value for a string-typed setting.
+// Returns ErrNotFound if the key does not exist.
+func (r *SettingsRepository) GetStringSetting(ctx context.Context, key string) (string, error) {
+	s, err := r.GetSetting(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	var val string
+	if err := json.Unmarshal([]byte(s.Value), &val); err != nil {
+		return "", fmt.Errorf("setting %q value is not a JSON string: %w", key, err)
+	}
+	return val, nil
+}
+
+// GetIntSetting returns the integer value for an int-typed setting.
+// Returns ErrNotFound if the key does not exist.
+func (r *SettingsRepository) GetIntSetting(ctx context.Context, key string) (int, error) {
+	s, err := r.GetSetting(ctx, key)
+	if err != nil {
+		return 0, err
+	}
+	var val int
+	if err := json.Unmarshal([]byte(s.Value), &val); err != nil {
+		return 0, fmt.Errorf("setting %q value is not a JSON integer: %w", key, err)
+	}
+	return val, nil
+}
+
+// GetBoolSetting returns the boolean value for a bool-typed setting.
+// Returns ErrNotFound if the key does not exist.
+func (r *SettingsRepository) GetBoolSetting(ctx context.Context, key string) (bool, error) {
+	s, err := r.GetSetting(ctx, key)
+	if err != nil {
+		return false, err
+	}
+	var val bool
+	if err := json.Unmarshal([]byte(s.Value), &val); err != nil {
+		return false, fmt.Errorf("setting %q value is not a JSON boolean: %w", key, err)
+	}
+	return val, nil
+}
+
+// GetStringSliceSetting returns the []string value for a string[]-typed setting.
+// Returns ErrNotFound if the key does not exist.
+func (r *SettingsRepository) GetStringSliceSetting(ctx context.Context, key string) ([]string, error) {
+	s, err := r.GetSetting(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	var val []string
+	if err := json.Unmarshal([]byte(s.Value), &val); err != nil {
+		return nil, fmt.Errorf("setting %q value is not a JSON string array: %w", key, err)
+	}
+	return val, nil
 }
 
 // SetSetting updates the value of an existing setting identified by key.

--- a/internal/db/repository_settings_unit_test.go
+++ b/internal/db/repository_settings_unit_test.go
@@ -132,6 +132,234 @@ func TestSettingsRepository_GetSetting_DBError(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// ── GetStringSetting ───────────────────────────────────────────────────────────
+
+func TestSettingsRepository_GetStringSetting_ReturnsUnquotedValue(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("scan.label").
+		WillReturnRows(makeSettingRow("scan.label", `"fast"`, "", "string"))
+
+	repo := NewSettingsRepository(db)
+	val, err := repo.GetStringSetting(context.Background(), "scan.label")
+
+	require.NoError(t, err)
+	assert.Equal(t, "fast", val)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetStringSetting_ReturnsErrNotFound(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("missing.key").
+		WillReturnRows(sqlmock.NewRows(settingCols))
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.GetStringSetting(context.Background(), "missing.key")
+
+	require.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetStringSetting_ReturnsErrorOnWrongType(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("scan.label").
+		WillReturnRows(makeSettingRow("scan.label", `123`, "", "int"))
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.GetStringSetting(context.Background(), "scan.label")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a JSON string")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetStringSetting_PropagatesDBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("scan.label").
+		WillReturnError(fmt.Errorf("conn error"))
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.GetStringSetting(context.Background(), "scan.label")
+
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── GetIntSetting ──────────────────────────────────────────────────────────────
+
+func TestSettingsRepository_GetIntSetting_ReturnsInteger(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("scan.max_concurrent").
+		WillReturnRows(makeSettingRow("scan.max_concurrent", `5`, "", "int"))
+
+	repo := NewSettingsRepository(db)
+	val, err := repo.GetIntSetting(context.Background(), "scan.max_concurrent")
+
+	require.NoError(t, err)
+	assert.Equal(t, 5, val)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetIntSetting_ReturnsErrNotFound(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("missing.key").
+		WillReturnRows(sqlmock.NewRows(settingCols))
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.GetIntSetting(context.Background(), "missing.key")
+
+	require.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetIntSetting_ReturnsErrorOnWrongType(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("scan.max_concurrent").
+		WillReturnRows(makeSettingRow("scan.max_concurrent", `"not-a-number"`, "", "string"))
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.GetIntSetting(context.Background(), "scan.max_concurrent")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a JSON integer")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetIntSetting_PropagatesDBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("scan.max_concurrent").
+		WillReturnError(fmt.Errorf("conn error"))
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.GetIntSetting(context.Background(), "scan.max_concurrent")
+
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── GetBoolSetting ─────────────────────────────────────────────────────────────
+
+func TestSettingsRepository_GetBoolSetting_ReturnsBoolean(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("notifications.scan_complete").
+		WillReturnRows(makeSettingRow("notifications.scan_complete", `true`, "", "bool"))
+
+	repo := NewSettingsRepository(db)
+	val, err := repo.GetBoolSetting(context.Background(), "notifications.scan_complete")
+
+	require.NoError(t, err)
+	assert.True(t, val)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetBoolSetting_ReturnsErrNotFound(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("missing.key").
+		WillReturnRows(sqlmock.NewRows(settingCols))
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.GetBoolSetting(context.Background(), "missing.key")
+
+	require.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetBoolSetting_ReturnsErrorOnWrongType(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("notifications.scan_complete").
+		WillReturnRows(makeSettingRow("notifications.scan_complete", `"yes"`, "", "string"))
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.GetBoolSetting(context.Background(), "notifications.scan_complete")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a JSON boolean")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetBoolSetting_PropagatesDBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("notifications.scan_complete").
+		WillReturnError(fmt.Errorf("conn error"))
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.GetBoolSetting(context.Background(), "notifications.scan_complete")
+
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── GetStringSliceSetting ──────────────────────────────────────────────────────
+
+func TestSettingsRepository_GetStringSliceSetting_ReturnsSlice(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("discovery.methods").
+		WillReturnRows(makeSettingRow("discovery.methods", `["icmp","arp"]`, "", "string[]"))
+
+	repo := NewSettingsRepository(db)
+	val, err := repo.GetStringSliceSetting(context.Background(), "discovery.methods")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"icmp", "arp"}, val)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetStringSliceSetting_ReturnsErrNotFound(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("missing.key").
+		WillReturnRows(sqlmock.NewRows(settingCols))
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.GetStringSliceSetting(context.Background(), "missing.key")
+
+	require.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetStringSliceSetting_ReturnsErrorOnWrongType(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("discovery.methods").
+		WillReturnRows(makeSettingRow("discovery.methods", `"single"`, "", "string"))
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.GetStringSliceSetting(context.Background(), "discovery.methods")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a JSON string array")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSettingsRepository_GetStringSliceSetting_PropagatesDBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery("SELECT key").
+		WithArgs("discovery.methods").
+		WillReturnError(fmt.Errorf("conn error"))
+
+	repo := NewSettingsRepository(db)
+	_, err := repo.GetStringSliceSetting(context.Background(), "discovery.methods")
+
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 // ── SetSetting ─────────────────────────────────────────────────────────────────
 
 func TestSettingsRepository_SetSetting_Success(t *testing.T) {

--- a/internal/enrichment/banner.go
+++ b/internal/enrichment/banner.go
@@ -38,6 +38,7 @@ const (
 	zgrabMaxRedirects = 3
 
 	serviceSSH   = "ssh"
+	serviceHTTP  = "http"
 	serviceHTTPS = "https"
 )
 
@@ -641,7 +642,7 @@ func (g *BannerGrabber) storeZGrabHTTPBanner(
 	banner.HTTPResponseHeaders = extractHeaders(resp.Header)
 
 	// Service identification and raw banner summary.
-	svc := "http"
+	svc := serviceHTTP
 	if resp.TLS != nil {
 		svc = serviceHTTPS
 	}
@@ -750,7 +751,7 @@ func parseBannerText(lower, raw string, port int) (service, version string) {
 	case strings.HasPrefix(lower, "* ok"):
 		service = "imap"
 	case strings.HasPrefix(lower, "http/") || strings.HasPrefix(lower, "http "):
-		service = "http"
+		service = serviceHTTP
 	default:
 		service = portServiceHints[port]
 	}

--- a/internal/services/portresolver.go
+++ b/internal/services/portresolver.go
@@ -2,9 +2,6 @@ package services
 
 import (
 	"context"
-	"database/sql"
-	"encoding/json"
-	"errors"
 	"log/slog"
 	"regexp"
 	"sort"
@@ -13,6 +10,7 @@ import (
 	"time"
 
 	"github.com/anstrom/scanorama/internal/db"
+	"github.com/anstrom/scanorama/internal/errors"
 )
 
 // portResolverTimeout caps all DB queries inside Resolve.
@@ -48,8 +46,9 @@ type portListResolverIface interface {
 //  2. OS-matched curated ports from port_definitions (Proposal B).
 //  3. Fleet top-N open ports from port_scans (Proposal A).
 type PortListResolver struct {
-	db     *db.DB
-	logger *slog.Logger
+	db           *db.DB
+	settingsRepo *db.SettingsRepository
+	logger       *slog.Logger
 }
 
 // NewPortListResolver creates a PortListResolver backed by the given database.
@@ -58,7 +57,11 @@ func NewPortListResolver(database *db.DB, logger *slog.Logger) *PortListResolver
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &PortListResolver{db: database, logger: logger}
+	return &PortListResolver{
+		db:           database,
+		settingsRepo: db.NewSettingsRepository(database),
+		logger:       logger,
+	}
 }
 
 // Resolve returns the merged port string for the given stage and host.
@@ -89,7 +92,6 @@ func (r *PortListResolver) Resolve(ctx context.Context, stage string, host *db.H
 
 // readBasePorts returns the base port string for the stage from settings,
 // falling back to the hardcoded default if the key is absent or empty.
-// Settings values are JSONB; string values arrive JSON-quoted ("\"22,80\"").
 func (r *PortListResolver) readBasePorts(ctx context.Context, stage string) string {
 	fallback, ok := stageDefaultPorts[stage]
 	if !ok {
@@ -98,41 +100,27 @@ func (r *PortListResolver) readBasePorts(ctx context.Context, stage string) stri
 	}
 
 	key := "smartscan." + stage + ".ports"
-	var raw string
-	if err := r.db.QueryRowContext(ctx,
-		`SELECT value::text FROM settings WHERE key = $1`, key,
-	).Scan(&raw); err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
+	val, err := r.settingsRepo.GetStringSetting(ctx, key)
+	if err != nil {
+		if !errors.IsNotFound(err) {
 			r.logger.Warn("failed to read base port setting, using default", "key", key, "error", err)
 		}
 		return fallback
 	}
-
-	var s string
-	if err := json.Unmarshal([]byte(raw), &s); err == nil && s != "" {
-		return s
+	if val == "" {
+		return fallback
 	}
-	if raw != "" {
-		return raw
-	}
-	return fallback
+	return val
 }
 
 // readLimit returns the top_ports_limit setting, defaulting to 256.
 func (r *PortListResolver) readLimit(ctx context.Context) int {
 	const key = "smartscan.top_ports_limit"
-	var raw string
-	if err := r.db.QueryRowContext(ctx,
-		`SELECT value::text FROM settings WHERE key = $1`, key,
-	).Scan(&raw); err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
+	n, err := r.settingsRepo.GetIntSetting(ctx, key)
+	if err != nil {
+		if !errors.IsNotFound(err) {
 			r.logger.Warn("failed to read top_ports_limit setting, using default", "error", err)
 		}
-		return defaultTopPortsLimit
-	}
-	n, err := strconv.Atoi(strings.Trim(raw, `"`))
-	if err != nil {
-		r.logger.Warn("smartscan.top_ports_limit is not a valid integer, using default", "raw", raw)
 		return defaultTopPortsLimit
 	}
 	if n <= 0 {

--- a/internal/services/portresolver_test.go
+++ b/internal/services/portresolver_test.go
@@ -35,18 +35,27 @@ func resolverHost(osFamily *string) *db.Host {
 
 func osPtr(s string) *string { return &s }
 
+// settingRow builds a five-column sqlmock rows value matching the GetSetting query shape.
+func settingRow(key, value string) *sqlmock.Rows {
+	cols := []string{"key", "value", "description", "type", "updated_at"}
+	return sqlmock.NewRows(cols).AddRow(key, value, "", "string", time.Now())
+}
+
+// settingEmpty returns an empty five-column rows set (simulates key not found).
+func settingEmpty() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"key", "value", "description", "type", "updated_at"})
+}
+
 func TestPortListResolver_UsesSettingsBaseWhenPresent(t *testing.T) {
 	database, mock := newResolverMockDB(t)
 	r := NewPortListResolver(database, discardLogger())
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.os_detection.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).
-			AddRow(`"22,443,8080"`))
-	mock.ExpectQuery(`SELECT value`).
+		WillReturnRows(settingRow("smartscan.os_detection.ports", `"22,443,8080"`))
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).
-			AddRow("256"))
+		WillReturnRows(settingRow("smartscan.top_ports_limit", "256"))
 	// No OS family — no port_definitions query
 	// Fleet — empty
 	mock.ExpectQuery(`SELECT port FROM port_scans`).
@@ -61,12 +70,12 @@ func TestPortListResolver_FallsBackToHardcodedDefaultWhenSettingMissing(t *testi
 	database, mock := newResolverMockDB(t)
 	r := NewPortListResolver(database, discardLogger())
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.os_detection.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}))
-	mock.ExpectQuery(`SELECT value`).
+		WillReturnRows(settingEmpty())
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}))
+		WillReturnRows(settingEmpty())
 	mock.ExpectQuery(`SELECT port FROM port_scans`).
 		WillReturnRows(sqlmock.NewRows([]string{"port"}))
 
@@ -79,10 +88,9 @@ func TestPortListResolver_ReturnsRangeBaseUnchanged(t *testing.T) {
 	database, mock := newResolverMockDB(t)
 	r := NewPortListResolver(database, discardLogger())
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.refresh.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).
-			AddRow(`"1-1024"`))
+		WillReturnRows(settingRow("smartscan.refresh.ports", `"1-1024"`))
 	// Range base → readLimit and OS/fleet queries are all skipped
 
 	result := r.Resolve(context.Background(), "refresh", resolverHost(nil))
@@ -95,12 +103,12 @@ func TestPortListResolver_MergesOSPortsWhenOSFamilyKnown(t *testing.T) {
 	r := NewPortListResolver(database, discardLogger())
 	host := resolverHost(osPtr("linux"))
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.os_detection.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(`"22"`))
-	mock.ExpectQuery(`SELECT value`).
+		WillReturnRows(settingRow("smartscan.os_detection.ports", `"22"`))
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("256"))
+		WillReturnRows(settingRow("smartscan.top_ports_limit", "256"))
 	mock.ExpectQuery(`SELECT port FROM port_definitions`).
 		WillReturnRows(sqlmock.NewRows([]string{"port"}).AddRow(111).AddRow(2049))
 	mock.ExpectQuery(`SELECT port FROM port_scans`).
@@ -115,12 +123,12 @@ func TestPortListResolver_MergesFleetTopPorts(t *testing.T) {
 	database, mock := newResolverMockDB(t)
 	r := NewPortListResolver(database, discardLogger())
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.identity_enrichment.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(`"22"`))
-	mock.ExpectQuery(`SELECT value`).
+		WillReturnRows(settingRow("smartscan.identity_enrichment.ports", `"22"`))
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("256"))
+		WillReturnRows(settingRow("smartscan.top_ports_limit", "256"))
 	// No OS family
 	mock.ExpectQuery(`SELECT port FROM port_scans`).
 		WillReturnRows(sqlmock.NewRows([]string{"port"}).AddRow(80).AddRow(443))
@@ -135,12 +143,12 @@ func TestPortListResolver_DeduplicatesOverlappingPorts(t *testing.T) {
 	r := NewPortListResolver(database, discardLogger())
 	host := resolverHost(osPtr("linux"))
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.os_detection.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(`"22,80"`))
-	mock.ExpectQuery(`SELECT value`).
+		WillReturnRows(settingRow("smartscan.os_detection.ports", `"22,80"`))
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("256"))
+		WillReturnRows(settingRow("smartscan.top_ports_limit", "256"))
 	mock.ExpectQuery(`SELECT port FROM port_definitions`).
 		WillReturnRows(sqlmock.NewRows([]string{"port"}).AddRow(80).AddRow(443))
 	mock.ExpectQuery(`SELECT port FROM port_scans`).
@@ -157,12 +165,12 @@ func TestPortListResolver_AugmentationCappedAtLimit(t *testing.T) {
 	database, mock := newResolverMockDB(t)
 	r := NewPortListResolver(database, discardLogger())
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.os_detection.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(`"22,443"`))
-	mock.ExpectQuery(`SELECT value`).
+		WillReturnRows(settingRow("smartscan.os_detection.ports", `"22,443"`))
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("3"))
+		WillReturnRows(settingRow("smartscan.top_ports_limit", "3"))
 	mock.ExpectQuery(`SELECT port FROM port_scans`).
 		WillReturnRows(sqlmock.NewRows([]string{"port"}).AddRow(80).AddRow(8080).AddRow(8443))
 
@@ -178,12 +186,12 @@ func TestPortListResolver_BasePortsPreservedBeyondLimit(t *testing.T) {
 	database, mock := newResolverMockDB(t)
 	r := NewPortListResolver(database, discardLogger())
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.os_detection.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(`"22,80,443,3389,8080,8443"`))
-	mock.ExpectQuery(`SELECT value`).
+		WillReturnRows(settingRow("smartscan.os_detection.ports", `"22,80,443,3389,8080,8443"`))
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("3"))
+		WillReturnRows(settingRow("smartscan.top_ports_limit", "3"))
 	mock.ExpectQuery(`SELECT port FROM port_scans`).
 		WillReturnRows(sqlmock.NewRows([]string{"port"}).AddRow(9000))
 
@@ -197,12 +205,12 @@ func TestPortListResolver_ZeroLimitSettingPromotedToDefault(t *testing.T) {
 	database, mock := newResolverMockDB(t)
 	r := NewPortListResolver(database, discardLogger())
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.os_detection.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(`"22"`))
-	mock.ExpectQuery(`SELECT value`).
+		WillReturnRows(settingRow("smartscan.os_detection.ports", `"22"`))
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("0"))
+		WillReturnRows(settingRow("smartscan.top_ports_limit", "0"))
 	mock.ExpectQuery(`SELECT port FROM port_scans`).
 		WillReturnRows(sqlmock.NewRows([]string{"port"}).AddRow(80))
 
@@ -217,12 +225,12 @@ func TestPortListResolver_FallsBackOnBasePortsDBError(t *testing.T) {
 	database, mock := newResolverMockDB(t)
 	r := NewPortListResolver(database, discardLogger())
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.os_detection.ports").
 		WillReturnError(fmt.Errorf("conn error"))
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("256"))
+		WillReturnRows(settingRow("smartscan.top_ports_limit", "256"))
 	mock.ExpectQuery(`SELECT port FROM port_scans`).
 		WillReturnRows(sqlmock.NewRows([]string{"port"}))
 
@@ -238,9 +246,9 @@ func TestPortListResolver_FallsBackOnUnknownStage(t *testing.T) {
 	// Unknown stage → stageDefaultPorts fallback = "1-1024" (a range).
 	// readBasePorts returns "1-1024" after ErrNoRows from DB.
 	// Resolve detects the range and returns immediately — no further queries.
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.unknown_stage.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}))
+		WillReturnRows(settingEmpty())
 
 	result := r.Resolve(context.Background(), "unknown_stage", resolverHost(nil))
 	assert.Equal(t, "1-1024", result)
@@ -251,10 +259,10 @@ func TestPortListResolver_FallsBackOnLimitDBError(t *testing.T) {
 	database, mock := newResolverMockDB(t)
 	r := NewPortListResolver(database, discardLogger())
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.os_detection.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(`"22"`))
-	mock.ExpectQuery(`SELECT value`).
+		WillReturnRows(settingRow("smartscan.os_detection.ports", `"22"`))
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
 		WillReturnError(fmt.Errorf("db error"))
 	mock.ExpectQuery(`SELECT port FROM port_scans`).
@@ -270,12 +278,12 @@ func TestPortListResolver_FallsBackOnNonIntegerLimit(t *testing.T) {
 	database, mock := newResolverMockDB(t)
 	r := NewPortListResolver(database, discardLogger())
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.os_detection.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(`"22"`))
-	mock.ExpectQuery(`SELECT value`).
+		WillReturnRows(settingRow("smartscan.os_detection.ports", `"22"`))
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(`"not-a-number"`))
+		WillReturnRows(settingRow("smartscan.top_ports_limit", `"not-a-number"`))
 	mock.ExpectQuery(`SELECT port FROM port_scans`).
 		WillReturnRows(sqlmock.NewRows([]string{"port"}).AddRow(80))
 
@@ -288,12 +296,12 @@ func TestPortListResolver_FallsBackOnNegativeLimit(t *testing.T) {
 	database, mock := newResolverMockDB(t)
 	r := NewPortListResolver(database, discardLogger())
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.os_detection.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(`"22"`))
-	mock.ExpectQuery(`SELECT value`).
+		WillReturnRows(settingRow("smartscan.os_detection.ports", `"22"`))
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("-5"))
+		WillReturnRows(settingRow("smartscan.top_ports_limit", "-5"))
 	mock.ExpectQuery(`SELECT port FROM port_scans`).
 		WillReturnRows(sqlmock.NewRows([]string{"port"}).AddRow(80))
 
@@ -307,12 +315,12 @@ func TestPortListResolver_SkipsOSPortsOnQueryError(t *testing.T) {
 	r := NewPortListResolver(database, discardLogger())
 	host := resolverHost(osPtr("linux"))
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.os_detection.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(`"22"`))
-	mock.ExpectQuery(`SELECT value`).
+		WillReturnRows(settingRow("smartscan.os_detection.ports", `"22"`))
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("256"))
+		WillReturnRows(settingRow("smartscan.top_ports_limit", "256"))
 	mock.ExpectQuery(`SELECT port FROM port_definitions`).
 		WillReturnError(fmt.Errorf("db error"))
 	mock.ExpectQuery(`SELECT port FROM port_scans`).
@@ -331,12 +339,12 @@ func TestPortListResolver_SkipsOSPortsOnIterationError(t *testing.T) {
 	r := NewPortListResolver(database, discardLogger())
 	host := resolverHost(osPtr("linux"))
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.os_detection.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(`"22"`))
-	mock.ExpectQuery(`SELECT value`).
+		WillReturnRows(settingRow("smartscan.os_detection.ports", `"22"`))
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("256"))
+		WillReturnRows(settingRow("smartscan.top_ports_limit", "256"))
 	mock.ExpectQuery(`SELECT port FROM port_definitions`).
 		WillReturnRows(sqlmock.NewRows([]string{"port"}).
 			AddRow(111).AddRow(999).RowError(1, fmt.Errorf("cursor error")))
@@ -353,12 +361,12 @@ func TestPortListResolver_SkipsFleetPortsOnQueryError(t *testing.T) {
 	database, mock := newResolverMockDB(t)
 	r := NewPortListResolver(database, discardLogger())
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.os_detection.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(`"22"`))
-	mock.ExpectQuery(`SELECT value`).
+		WillReturnRows(settingRow("smartscan.os_detection.ports", `"22"`))
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("256"))
+		WillReturnRows(settingRow("smartscan.top_ports_limit", "256"))
 	mock.ExpectQuery(`SELECT port FROM port_scans`).
 		WillReturnError(fmt.Errorf("db error"))
 
@@ -374,14 +382,15 @@ func TestPortListResolver_SkipsFleetPortsOnIterationError(t *testing.T) {
 	database, mock := newResolverMockDB(t)
 	r := NewPortListResolver(database, discardLogger())
 
-	mock.ExpectQuery(`SELECT value`).
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.os_detection.ports").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(`"22"`))
-	mock.ExpectQuery(`SELECT value`).
+		WillReturnRows(settingRow("smartscan.os_detection.ports", `"22"`))
+	mock.ExpectQuery(`SELECT key`).
 		WithArgs("smartscan.top_ports_limit").
-		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("256"))
+		WillReturnRows(settingRow("smartscan.top_ports_limit", "256"))
 	mock.ExpectQuery(`SELECT port FROM port_scans`).
-		WillReturnRows(sqlmock.NewRows([]string{"port"}).AddRow(443).AddRow(80).RowError(1, fmt.Errorf("cursor error")))
+		WillReturnRows(sqlmock.NewRows([]string{"port"}).
+			AddRow(443).AddRow(80).RowError(1, fmt.Errorf("cursor error")))
 
 	result := r.Resolve(context.Background(), "os_detection", resolverHost(nil))
 	// port 443 was accumulated but rows.Err() discards the whole fleet source


### PR DESCRIPTION
## Summary

- Adds `GetStringSetting`, `GetIntSetting`, `GetBoolSetting`, and `GetStringSliceSetting` typed accessors to `SettingsRepository`, eliminating manual JSONB unquoting at call sites
- Migrates `PortListResolver.readBasePorts` and `readLimit` from raw SQL + manual JSON parsing to the new typed accessors
- Removes stale imports (`database/sql`, `encoding/json`, stdlib `errors`) from `portresolver.go`
- Updates all `portresolver_test.go` mock expectations to match `GetSetting`'s five-column query shape

Closes #746

## Test plan

- Verify SmartScan still resolves port lists correctly in a live environment (settings values read and JSONB-unquoted as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)