### PR TITLE
fix(deps): bump Go to 1.26.3 and fix goconst violations

### DIFF
--- a/cmd/cli/apikeys.go
+++ b/cmd/cli/apikeys.go
@@ -35,7 +35,7 @@ var (
 // apiKeysCmd represents the apikeys command group
 var apiKeysCmd = &cobra.Command{
 	Use:     "apikeys",
-	Aliases: []string{"apikey", "keys", "key"},
+	Aliases: []string{"apikey", "keys", fieldKey},
 	Short:   "Manage API keys for client authentication",
 	Long: `Manage API keys for client authentication with the Scanorama API server.
 
@@ -76,7 +76,7 @@ Examples:
 
 // apiKeysListCmd lists all API keys
 var apiKeysListCmd = &cobra.Command{
-	Use:     "list",
+	Use:     cmdList,
 	Aliases: []string{"ls", "l"},
 	Short:   "List API keys",
 	Long: `List all API keys with their metadata.

--- a/cmd/cli/constants.go
+++ b/cmd/cli/constants.go
@@ -1,0 +1,15 @@
+// Package cli provides command-line interface commands for the Scanorama network scanner.
+package cli
+
+const (
+	cmdList   = "list"
+	cmdStart  = "start"
+	cmdStatus = "status"
+	cmdScan   = "scan"
+
+	methodTCP  = "tcp"
+	methodARP  = "arp"
+	methodICMP = "icmp"
+
+	scanTypeConnect = "connect"
+)

--- a/cmd/cli/daemon.go
+++ b/cmd/cli/daemon.go
@@ -49,7 +49,7 @@ The daemon can be started, stopped, and monitored using subcommands.`,
 
 // daemonStartCmd represents the daemon start command.
 var daemonStartCmd = &cobra.Command{
-	Use:   "start",
+	Use:   cmdStart,
 	Short: "Start the scanorama daemon",
 	Long: `Start the scanorama daemon service in the background.
 The daemon will process scheduled jobs and provide API endpoints.`,
@@ -72,7 +72,7 @@ This will gracefully shut down the daemon and stop all background jobs.`,
 
 // daemonStatusCmd represents the daemon status command.
 var daemonStatusCmd = &cobra.Command{
-	Use:   "status",
+	Use:   cmdStatus,
 	Short: "Check the status of the scanorama daemon",
 	Long: `Check whether the scanorama daemon is currently running
 and display information about its status and configuration.`,

--- a/cmd/cli/discover.go
+++ b/cmd/cli/discover.go
@@ -435,10 +435,10 @@ func discoverLocalNetworks() ([]string, error) {
 func runDiscovery(cmd *cobra.Command, args []string) {
 	// Validate method
 	validMethods := map[string]bool{
-		"tcp":  true,
-		"ping": true,
-		"arp":  true,
-		"icmp": true,
+		methodTCP:              true,
+		defaultDiscoveryMethod: true,
+		methodARP:              true,
+		methodICMP:             true,
 	}
 	if !validMethods[discoverMethod] {
 		fmt.Fprintf(os.Stderr, "Error: invalid discovery method '%s'. Valid methods: tcp, ping, arp, icmp\n",

--- a/cmd/cli/groups.go
+++ b/cmd/cli/groups.go
@@ -97,7 +97,7 @@ Examples:
 }
 
 var groupsListCmd = &cobra.Command{
-	Use:     "list",
+	Use:     cmdList,
 	Aliases: []string{"ls"},
 	Short:   "List all host groups",
 	Long: `List all host groups with member counts and metadata.

--- a/cmd/cli/hosts.go
+++ b/cmd/cli/hosts.go
@@ -20,6 +20,11 @@ const (
 	maxOSNameLength      = 18  // max OS name length before truncation
 	ipAddressParts       = 4   // expected parts in IP address
 	hoursPerDay          = 24  // hours in a day for duration calculation
+
+	hostStatusDown  = "down"
+	osFamilyWindows = "windows"
+	osFamilyLinux   = "linux"
+	osFamilyUnknown = "unknown"
 )
 
 var (
@@ -101,8 +106,8 @@ func runHosts(_ *cobra.Command, _ []string) {
 	// Validate status if provided
 	if hostsStatus != "" {
 		validStatuses := map[string]bool{
-			"up":   true,
-			"down": true,
+			"up":           true,
+			hostStatusDown: true,
 		}
 		if !validStatuses[hostsStatus] {
 			fmt.Fprintf(os.Stderr, "Error: invalid status '%s'. Valid statuses: up, down\n", hostsStatus)
@@ -113,10 +118,10 @@ func runHosts(_ *cobra.Command, _ []string) {
 	// Validate OS family if provided
 	if hostsOSFamily != "" {
 		validOSFamilies := map[string]bool{
-			"windows": true,
-			"linux":   true,
-			"macos":   true,
-			"unknown": true,
+			osFamilyWindows: true,
+			osFamilyLinux:   true,
+			"macos":         true,
+			osFamilyUnknown: true,
 		}
 		if !validOSFamilies[hostsOSFamily] {
 			fmt.Fprintf(os.Stderr, "Error: invalid OS family '%s'. "+

--- a/cmd/cli/networks.go
+++ b/cmd/cli/networks.go
@@ -52,7 +52,7 @@ methods, enable/disable networks, and view network statistics.`,
 
 // networksListCmd represents the networks list command.
 var networksListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   cmdList,
 	Short: "List configured networks",
 	Long: `List all configured network discovery targets with their status,
 host counts, and last discovery/scan times.`,
@@ -140,7 +140,7 @@ or network-specific.`,
 
 // networksExclusionsListCmd represents the exclusions list command.
 var networksExclusionsListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   cmdList,
 	Short: "List network exclusions",
 	Long: `List all configured network exclusions. Shows both global exclusions
 and network-specific exclusions with their reasons and status.`,
@@ -222,7 +222,7 @@ func init() {
 	networksAddCmd.Flags().StringVar(&networksMethod, "method", defaultDiscoveryMethod, "Discovery method")
 	networksAddCmd.Flags().StringVar(&networksDescription, "description", "", "Network description")
 	networksAddCmd.Flags().BoolVar(&networksActive, "active", true, "Enable network for discovery")
-	networksAddCmd.Flags().BoolVar(&networksScanEnabled, "scan", true, "Enable network for scanning")
+	networksAddCmd.Flags().BoolVar(&networksScanEnabled, cmdScan, true, "Enable network for scanning")
 
 	// Mark required flags
 	if err := networksAddCmd.MarkFlagRequired("name"); err != nil {
@@ -235,7 +235,7 @@ func init() {
 	// Add flag descriptions
 	networksAddCmd.Flags().Lookup("method").Usage = "Discovery method: tcp, ping, arp, icmp (default: ping)"
 	networksAddCmd.Flags().Lookup("active").Usage = "Enable network for discovery operations"
-	networksAddCmd.Flags().Lookup("scan").Usage = "Enable network for detailed scanning"
+	networksAddCmd.Flags().Lookup(cmdScan).Usage = "Enable network for detailed scanning"
 
 	// Add shell completion for discovery methods
 	if err := networksAddCmd.RegisterFlagCompletionFunc("method", completeDiscoveryMethods); err != nil {

--- a/cmd/cli/networks_complete.go
+++ b/cmd/cli/networks_complete.go
@@ -41,7 +41,7 @@ func completeNetworkNames(cmd *cobra.Command, args []string, toComplete string) 
 
 func completeDiscoveryMethods(cmd *cobra.Command, args []string, toComplete string) (
 	[]string, cobra.ShellCompDirective) {
-	methods := []string{"tcp", "ping", "arp", "icmp"}
+	methods := []string{methodTCP, defaultDiscoveryMethod, methodARP, methodICMP}
 	var matches []string
 
 	for _, method := range methods {

--- a/cmd/cli/networks_handlers.go
+++ b/cmd/cli/networks_handlers.go
@@ -37,10 +37,10 @@ func runNetworksAdd(cmd *cobra.Command, args []string) {
 
 	// Validate discovery method
 	validMethods := map[string]bool{
-		"tcp":  true,
-		"ping": true,
-		"arp":  true,
-		"icmp": true,
+		methodTCP:              true,
+		defaultDiscoveryMethod: true,
+		methodARP:              true,
+		methodICMP:             true,
 	}
 	if !validMethods[networksMethod] {
 		fmt.Fprintf(os.Stderr, "Error: invalid discovery method '%s'. Valid methods: tcp, ping, arp, icmp\n",

--- a/cmd/cli/profiles.go
+++ b/cmd/cli/profiles.go
@@ -43,7 +43,7 @@ predefined port lists, scan types, and timing configurations.`,
 
 // profilesListCmd represents the profiles list command.
 var profilesListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   cmdList,
 	Short: "List all available scan profiles",
 	Long: `Display a list of all available scan profiles with their
 basic information including name, description, and target OS family.`,

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -19,6 +19,7 @@ const (
 	// Default configuration constants.
 	defaultDatabasePort         = 5432 // PostgreSQL default port
 	defaultMaxConcurrentTargets = 100  // default max concurrent scan targets
+	defaultConfigFile           = "config.yaml"
 )
 
 var (
@@ -181,5 +182,5 @@ func getConfigFilePath() string {
 		return configFile
 	}
 	// Fallback to default if no config file was loaded
-	return "config.yaml"
+	return defaultConfigFile
 }

--- a/cmd/cli/scan.go
+++ b/cmd/cli/scan.go
@@ -20,6 +20,7 @@ import (
 const (
 	// Scan operation constants.
 	defaultScanTimeout = 300 // default scan timeout in seconds
+	scanTypeVersion    = "version"
 )
 
 var (
@@ -34,7 +35,7 @@ var (
 
 // scanCmd represents the scan command.
 var scanCmd = &cobra.Command{
-	Use:   "scan",
+	Use:   cmdScan,
 	Short: "Scan hosts for open ports and services",
 	Long: `Scan discovered hosts or specific targets for open ports,
 running services, and other network information.
@@ -58,7 +59,7 @@ func init() {
 	scanCmd.Flags().StringVar(&scanTargets, "targets", "", "Comma-separated list of targets to scan")
 	scanCmd.Flags().BoolVar(&scanLiveHosts, "live-hosts", false, "Scan only discovered live hosts")
 	scanCmd.Flags().StringVar(&scanPorts, "ports", "22,80,443,8080,8443", "Ports to scan (comma-separated)")
-	scanCmd.Flags().StringVar(&scanType, "type", "connect",
+	scanCmd.Flags().StringVar(&scanType, "type", scanTypeConnect,
 		"Scan type: connect, syn, version, aggressive, stealth")
 	scanCmd.Flags().StringVar(&scanProfile, "profile", "", "Scan profile to use (overrides scan type)")
 	scanCmd.Flags().IntVar(&scanTimeout, "timeout", defaultScanTimeout, "Scan timeout in seconds")
@@ -92,9 +93,9 @@ func runScan(cmd *cobra.Command, _ []string) {
 
 	// Validate scan type
 	validTypes := map[string]bool{
-		"connect":       true,
+		scanTypeConnect: true,
 		"syn":           true,
-		"version":       true,
+		scanTypeVersion: true,
 		"comprehensive": true,
 		"aggressive":    true,
 		"stealth":       true,

--- a/cmd/cli/schedule.go
+++ b/cmd/cli/schedule.go
@@ -46,7 +46,7 @@ at specified intervals.`,
 
 // scheduleListCmd represents the schedule list command.
 var scheduleListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   cmdList,
 	Short: "List all scheduled jobs",
 	Long: `Display all currently scheduled jobs with their schedules,
 next run times, and job details.`,
@@ -134,7 +134,7 @@ func init() {
 	scheduleAddScanCmd.Flags().StringVar(&scheduleTargets, "targets", "", "Comma-separated list of targets to scan")
 	scheduleAddScanCmd.Flags().BoolVar(&scheduleLiveHosts, "live-hosts", false, "Scan only discovered live hosts")
 	scheduleAddScanCmd.Flags().StringVar(&schedulePorts, "ports", "22,80,443,8080,8443", "Ports to scan")
-	scheduleAddScanCmd.Flags().StringVar(&scheduleScanType, "type", "connect", "Scan type")
+	scheduleAddScanCmd.Flags().StringVar(&scheduleScanType, "type", scanTypeConnect, "Scan type")
 	scheduleAddScanCmd.Flags().StringVar(&scheduleProfile, "profile", "", "Scan profile to use")
 	scheduleAddScanCmd.Flags().IntVar(&scheduleTimeout, "timeout", scheduleDefaultTimeout, "Scan timeout in seconds")
 	scheduleAddScanCmd.Flags().StringVar(&scheduleOSFamily, "os-family", "", "Scan only specific OS family")

--- a/cmd/cli/server.go
+++ b/cmd/cli/server.go
@@ -74,7 +74,7 @@ and monitoring the Scanorama API server process.`,
 
 // serverStartCmd represents the server start command.
 var serverStartCmd = &cobra.Command{
-	Use:   "start",
+	Use:   cmdStart,
 	Short: "Start the API server",
 	Long: `Start the Scanorama API server.
 
@@ -106,7 +106,7 @@ var serverRestartCmd = &cobra.Command{
 
 // serverStatusCmd represents the server status command.
 var serverStatusCmd = &cobra.Command{
-	Use:     "status",
+	Use:     cmdStatus,
 	Short:   "Show server status",
 	Long:    "Display the current status of the Scanorama API server.",
 	Example: `  scanorama server status`,
@@ -285,7 +285,7 @@ func runServerInBackground() error {
 
 // buildServerArgs constructs arguments for background server process.
 func buildServerArgs() []string {
-	args := []string{"server", "start", "--foreground"}
+	args := []string{"server", cmdStart, "--foreground"}
 	if cfgFile != "" {
 		args = append(args, "--config", cfgFile)
 	}

--- a/cmd/cli/settings.go
+++ b/cmd/cli/settings.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	settingsMaxValueLen = 40
+	fieldKey            = "key"
 )
 
 var (
@@ -128,8 +129,8 @@ func executeSettingsGet(client *APIClient) error {
 
 func executeSettingsUpdate(client *APIClient) error {
 	payload := map[string]string{
-		"key":   settingsKey,
-		"value": settingsValue,
+		fieldKey: settingsKey,
+		"value":  settingsValue,
 	}
 
 	resp, err := client.Put("/admin/settings", payload)
@@ -146,7 +147,7 @@ func executeSettingsUpdate(client *APIClient) error {
 		fmt.Printf("Setting %q updated successfully.\n", settingsKey)
 	} else {
 		fmt.Printf("Setting %q update response received (key: %v).\n",
-			settingsKey, result["key"])
+			settingsKey, result[fieldKey])
 	}
 
 	return nil
@@ -247,10 +248,10 @@ func init() {
 		"Output format (table, json)")
 
 	// update flags
-	settingsUpdateCmd.Flags().StringVar(&settingsKey, "key", "",
+	settingsUpdateCmd.Flags().StringVar(&settingsKey, fieldKey, "",
 		"Setting key to update (required)")
 	settingsUpdateCmd.Flags().StringVar(&settingsValue, "value", "",
 		"New value as valid JSON (required) — e.g. true, 42, or '\"text\"'")
-	_ = settingsUpdateCmd.MarkFlagRequired("key")
+	_ = settingsUpdateCmd.MarkFlagRequired(fieldKey)
 	_ = settingsUpdateCmd.MarkFlagRequired("value")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anstrom/scanorama
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -29,7 +29,13 @@ func getVersion() string {
 
 // System handler constants.
 const (
-	healthCheckTimeout = 5 * time.Second
+	healthCheckTimeout  = 5 * time.Second
+	apiServiceNameFull  = "scanorama-api"
+	apiServiceName      = "scanorama"
+	apiRespKeyStatus    = "status"
+	apiRespKeyTimestamp = "timestamp"
+	apiRespKeyService   = "service"
+	apiRespKeyVersion   = "version"
 )
 
 // livenessHandler provides a simple liveness check endpoint.
@@ -42,9 +48,9 @@ const (
 // @Router /liveness [get]
 func (s *Server) livenessHandler(w http.ResponseWriter, r *http.Request) {
 	response := map[string]interface{}{
-		"status":    "alive",
-		"timestamp": time.Now().UTC(),
-		"uptime":    time.Since(s.startTime).String(),
+		apiRespKeyStatus:    "alive",
+		apiRespKeyTimestamp: time.Now().UTC(),
+		"uptime":            time.Since(s.startTime).String(),
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -81,9 +87,9 @@ func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := map[string]interface{}{
-		"status":    status,
-		"timestamp": time.Now().UTC(),
-		"checks":    checks,
+		apiRespKeyStatus:    status,
+		apiRespKeyTimestamp: time.Now().UTC(),
+		"checks":            checks,
 	}
 
 	statusCode := http.StatusOK
@@ -106,10 +112,10 @@ func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 // @Router /status [get]
 func (s *Server) statusHandler(w http.ResponseWriter, r *http.Request) {
 	response := map[string]interface{}{
-		"service":   "scanorama-api",
-		"timestamp": time.Now().UTC(),
-		"uptime":    time.Since(s.startTime).String(),
-		"version":   getVersion(),
+		apiRespKeyService:   apiServiceNameFull,
+		apiRespKeyTimestamp: time.Now().UTC(),
+		"uptime":            time.Since(s.startTime).String(),
+		apiRespKeyVersion:   getVersion(),
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -126,11 +132,11 @@ func (s *Server) statusHandler(w http.ResponseWriter, r *http.Request) {
 // @Router /version [get]
 func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 	response := map[string]interface{}{
-		"version":    getVersion(),
-		"commit":     buildCommit,
-		"build_time": buildTimestamp,
-		"timestamp":  time.Now().UTC(),
-		"service":    "scanorama",
+		apiRespKeyVersion:   getVersion(),
+		"commit":            buildCommit,
+		"build_time":        buildTimestamp,
+		apiRespKeyTimestamp: time.Now().UTC(),
+		apiRespKeyService:   apiServiceName,
 	}
 
 	s.WriteJSON(w, r, http.StatusOK, response)
@@ -182,8 +188,8 @@ func (s *Server) adminStatusHandler(w http.ResponseWriter, r *http.Request) {
 // redirectToAPI returns API information for root requests.
 func (s *Server) redirectToAPI(w http.ResponseWriter, r *http.Request) {
 	response := map[string]interface{}{
-		"service": "Scanorama API",
-		"version": "v1",
+		"service":         "Scanorama API",
+		apiRespKeyVersion: "v1",
 		"endpoints": map[string]string{
 			"liveness": "/api/v1/liveness",
 			"health":   "/api/v1/health",

--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -24,6 +24,8 @@ const (
 	configSectionScanning = "scanning"
 	configSectionLogging  = "logging"
 	configSectionDaemon   = "daemon"
+
+	queryParamSection = "section"
 )
 
 // Validation limit constants.
@@ -75,7 +77,7 @@ func (h *AdminHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 	h.logger.Info("Getting configuration", "request_id", requestID)
 
 	// Get configuration sections
-	section := r.URL.Query().Get("section")
+	section := r.URL.Query().Get(queryParamSection)
 
 	// Get full config or specific section
 	config, err := h.getCurrentConfig(r.Context(), section)
@@ -91,7 +93,7 @@ func (h *AdminHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 	// Record metrics
 	if h.metrics != nil {
 		h.metrics.Counter("api_admin_config_retrieved_total", map[string]string{
-			"section": section,
+			queryParamSection: section,
 		})
 	}
 }
@@ -122,7 +124,7 @@ func (h *AdminHandler) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 
 	h.logger.Info("UpdateConfig called but not yet implemented",
 		"request_id", requestID,
-		"section", req.Section)
+		queryParamSection, req.Section)
 
 	// Configuration persistence is not yet implemented.
 	writeError(w, r, http.StatusNotImplemented,

--- a/internal/api/handlers/admin_config.go
+++ b/internal/api/handlers/admin_config.go
@@ -8,6 +8,19 @@ import (
 	"net/http"
 )
 
+const (
+	loopbackAddr      = "127.0.0.1"
+	defaultTimeout30s = "30s"
+
+	configKeyEnabled  = "enabled"
+	configKeyHost     = "host"
+	configKeyPort     = "port"
+	configKeyDatabase = "database"
+	configKeyScanMode = "scan_mode"
+	configKeyLevel    = "level"
+	configKeyInfo     = "info"
+)
+
 // getCurrentConfig retrieves current configuration.
 func (h *AdminHandler) getCurrentConfig(_ context.Context, section string) (map[string]interface{}, error) {
 	// This would get the actual configuration from the config manager
@@ -15,9 +28,9 @@ func (h *AdminHandler) getCurrentConfig(_ context.Context, section string) (map[
 
 	config := ConfigResponse{
 		API: map[string]interface{}{
-			"enabled":             true,
-			"host":                "127.0.0.1",
-			"port":                8080,
+			configKeyEnabled:      true,
+			configKeyHost:         loopbackAddr,
+			configKeyPort:         8080,
 			"auth_enabled":        false,
 			"rate_limit_enabled":  true,
 			"rate_limit_requests": 100,
@@ -25,28 +38,28 @@ func (h *AdminHandler) getCurrentConfig(_ context.Context, section string) (map[
 			"write_timeout":       "10s",
 		},
 		Database: map[string]interface{}{
-			"host":            "localhost",
-			"port":            5432,
-			"database":        "scanorama",
+			configKeyHost:     loopbackHostname,
+			configKeyPort:     5432,
+			configKeyDatabase: serviceNameScanorama,
 			"ssl_mode":        "require",
 			"max_connections": 25,
 		},
 		Scanning: map[string]interface{}{
 			"worker_pool_size":         10,
-			"scan_mode":                "syn",
+			configKeyScanMode:          scanTypeSYN,
 			"max_concurrent_targets":   100,
 			"default_ports":            "22,80,443,8080,8443",
 			"enable_service_detection": true,
 		},
 		Logging: map[string]interface{}{
-			"level":      "info",
-			"format":     "text",
-			"output":     "stdout",
-			"structured": true,
+			configKeyLevel: configKeyInfo,
+			"format":       "text",
+			"output":       "stdout",
+			"structured":   true,
 		},
 		Daemon: map[string]interface{}{
 			"pid_file":         "/tmp/scanorama.pid",
-			"shutdown_timeout": "30s",
+			"shutdown_timeout": defaultTimeout30s,
 			"daemonize":        true,
 		},
 	}
@@ -54,15 +67,15 @@ func (h *AdminHandler) getCurrentConfig(_ context.Context, section string) (map[
 	// Return specific section if requested
 	if section != "" {
 		switch section {
-		case "api":
+		case configSectionAPI:
 			return config.API.(map[string]interface{}), nil
-		case "database":
+		case configSectionDatabase:
 			return config.Database.(map[string]interface{}), nil
-		case "scanning":
+		case configSectionScanning:
 			return config.Scanning.(map[string]interface{}), nil
-		case "logging":
+		case configSectionLogging:
 			return config.Logging.(map[string]interface{}), nil
-		case "daemon":
+		case configSectionDaemon:
 			return config.Daemon.(map[string]interface{}), nil
 		default:
 			return nil, fmt.Errorf("unknown configuration section: %s", section)
@@ -71,11 +84,11 @@ func (h *AdminHandler) getCurrentConfig(_ context.Context, section string) (map[
 
 	// Return entire config as map
 	return map[string]interface{}{
-		"api":      config.API,
-		"database": config.Database,
-		"scanning": config.Scanning,
-		"logging":  config.Logging,
-		"daemon":   config.Daemon,
+		configSectionAPI:      config.API,
+		configSectionDatabase: config.Database,
+		configSectionScanning: config.Scanning,
+		configSectionLogging:  config.Logging,
+		configSectionDaemon:   config.Daemon,
 	}, nil
 }
 

--- a/internal/api/handlers/common.go
+++ b/internal/api/handlers/common.go
@@ -23,6 +23,20 @@ import (
 // ContextKey represents a context key type.
 type ContextKey string
 
+const (
+	contextKeyRequestID = "request_id"
+	responseKeyStatus   = "status"
+	responseKeyMessage  = "message"
+	responseKeyTS       = "timestamp"
+	responseKeyID       = "id"
+	responseKeyReqID    = "request_id"
+	responseKeyTotal    = "total"
+	statusStarted       = "started"
+	statusStopped       = "stopped"
+	statusSuccess       = "success"
+	statusUnknown       = "unknown"
+)
+
 // PaginationParams holds pagination parameters.
 type PaginationParams struct {
 	Page     int `json:"page"`
@@ -67,10 +81,10 @@ func NewBaseHandler(logger *slog.Logger, metricsRegistry metrics.MetricsRegistry
 
 // getRequestIDFromContext extracts request ID from context.
 func getRequestIDFromContext(ctx context.Context) string {
-	if requestID, ok := ctx.Value(ContextKey("request_id")).(string); ok {
+	if requestID, ok := ctx.Value(ContextKey(contextKeyRequestID)).(string); ok {
 		return requestID
 	}
-	return "unknown"
+	return statusUnknown
 }
 
 // getQueryParamInt extracts integer query parameter with default value.
@@ -325,7 +339,7 @@ func (op *ListOperation[T, F]) Execute(w http.ResponseWriter, r *http.Request) {
 
 	// Record metrics
 	recordCRUDMetric(op.Metrics, op.MetricName, map[string]string{
-		"status": "success",
+		responseKeyStatus: statusSuccess,
 	})
 }
 
@@ -388,7 +402,7 @@ func (op *CRUDOperation[T]) ExecuteDelete(
 
 	// Record metrics
 	recordCRUDMetric(op.Metrics, metricName, map[string]string{
-		"status": "success",
+		responseKeyStatus: statusSuccess,
 	})
 }
 
@@ -562,11 +576,11 @@ func (op *JobControlOperation) ExecuteStart(
 	}
 
 	response := map[string]interface{}{
-		"id":         id,
-		"status":     "started",
-		"message":    fmt.Sprintf("%s has been queued for execution", op.EntityType),
-		"timestamp":  time.Now().UTC(),
-		"request_id": requestID,
+		responseKeyID:      id,
+		responseKeyStatus:  statusStarted,
+		responseKeyMessage: fmt.Sprintf("%s has been queued for execution", op.EntityType),
+		responseKeyTS:      time.Now().UTC(),
+		responseKeyReqID:   requestID,
 	}
 
 	if item != nil {
@@ -602,11 +616,11 @@ func (op *JobControlOperation) ExecuteStop(
 	}
 
 	response := map[string]interface{}{
-		"id":         id,
-		"status":     "stopped",
-		"message":    fmt.Sprintf("%s has been stopped", op.EntityType),
-		"timestamp":  time.Now().UTC(),
-		"request_id": requestID,
+		responseKeyID:      id,
+		responseKeyStatus:  statusStopped,
+		responseKeyMessage: fmt.Sprintf("%s has been stopped", op.EntityType),
+		responseKeyTS:      time.Now().UTC(),
+		responseKeyReqID:   requestID,
 	}
 
 	op.Logger.Info(fmt.Sprintf("%s stopped successfully", op.EntityType),

--- a/internal/api/handlers/discovery.go
+++ b/internal/api/handlers/discovery.go
@@ -24,12 +24,16 @@ import (
 
 // Validation constants.
 const (
-	maxDiscoveryNameLength = 255
-	maxDescriptionLength   = 255
-	maxPortsStringLength   = 50
-	maxValidationErrors    = 100
-	maxRetries             = 10
-	maxTagLength           = 50
+	maxDiscoveryNameLength  = 255
+	maxDescriptionLength    = 255
+	maxPortsStringLength    = 50
+	maxValidationErrors     = 100
+	maxRetries              = 10
+	maxTagLength            = 50
+	discoveryJobTypeStr     = "discovery"
+	discoveryStatusComplete = "completed"
+	discoveryMethodDNS      = "dns"
+	discoveryMethodTCP      = "tcp_connect"
 )
 
 // Progress estimation constants.
@@ -124,7 +128,7 @@ type discoveryJob struct {
 func (j *discoveryJob) ID() string { return j.id }
 
 // Type implements scanning.Job.
-func (j *discoveryJob) Type() string { return "discovery" }
+func (j *discoveryJob) Type() string { return discoveryJobTypeStr }
 
 // Target implements scanning.Job.
 func (j *discoveryJob) Target() string { return j.network }
@@ -178,7 +182,7 @@ func (j *discoveryJob) Execute(workerCtx context.Context) error {
 		if diff, dErr := j.database.GetDiscoveryDiff(dbCtx, j.jobID); dErr == nil {
 			_ = j.wsHandler.BroadcastDiscoveryUpdate(&DiscoveryUpdateMessage{
 				JobID:        j.jobID.String(),
-				Status:       "completed",
+				Status:       discoveryStatusComplete,
 				HostsFound:   hostsFound,
 				NewHosts:     len(diff.NewHosts),
 				GoneHosts:    len(diff.GoneHosts),
@@ -559,11 +563,11 @@ func (h *DiscoveryHandler) StopDiscovery(w http.ResponseWriter, r *http.Request)
 	}
 
 	response := map[string]interface{}{
-		"id":         jobID,
-		"status":     "stopped",
-		"message":    "discovery job has been stopped",
-		"timestamp":  time.Now().UTC(),
-		"request_id": requestID,
+		responseKeyID:      jobID,
+		responseKeyStatus:  statusStopped,
+		responseKeyMessage: "discovery job has been stopped",
+		responseKeyTS:      time.Now().UTC(),
+		responseKeyReqID:   requestID,
 	}
 
 	writeJSON(w, r, http.StatusOK, response)
@@ -608,11 +612,11 @@ func (h *DiscoveryHandler) validateBasicFields(req *DiscoveryRequest) error {
 
 func (h *DiscoveryHandler) validateMethod(method string) error {
 	validMethods := map[string]bool{
-		"ping":        true,
-		"arp":         true,
-		"icmp":        true,
-		"tcp_connect": true,
-		"dns":         true,
+		discoveryMethodPing: true,
+		discoveryMethodARP:  true,
+		discoveryMethodICMP: true,
+		discoveryMethodTCP:  true,
+		discoveryMethodDNS:  true,
 	}
 	if !validMethods[method] {
 		return fmt.Errorf("invalid discovery method: %s", method)

--- a/internal/api/handlers/group.go
+++ b/internal/api/handlers/group.go
@@ -65,8 +65,8 @@ func (h *GroupHandler) ListGroups(w http.ResponseWriter, r *http.Request) {
 		groups = []*db.HostGroup{}
 	}
 	writeJSON(w, r, http.StatusOK, map[string]interface{}{
-		"groups": groups,
-		"total":  len(groups),
+		"groups":         groups,
+		responseKeyTotal: len(groups),
 	})
 }
 

--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -29,9 +29,11 @@ const (
 
 // Status constants.
 const (
-	StatusHealthy       = "healthy"
-	StatusUnhealthy     = "unhealthy"
-	StatusNotConfigured = "not configured"
+	StatusHealthy        = "healthy"
+	StatusUnhealthy      = "unhealthy"
+	StatusNotConfigured  = "not configured"
+	statusAlive          = "alive"
+	serviceNameScanorama = "scanorama"
 )
 
 // HealthHandler handles health check and status endpoints.
@@ -218,7 +220,7 @@ func (h *HealthHandler) Health(w http.ResponseWriter, r *http.Request) {
 	// Record metrics
 	if h.metrics != nil {
 		h.metrics.Counter("api_health_checks_total", metrics.Labels{
-			"status": response.Status,
+			responseKeyStatus: response.Status,
 		})
 	}
 }
@@ -228,7 +230,7 @@ func (h *HealthHandler) Liveness(w http.ResponseWriter, r *http.Request) {
 	h.logger.Debug("Liveness check requested", "remote_addr", r.RemoteAddr)
 
 	response := LivenessResponse{
-		Status:    "alive",
+		Status:    statusAlive,
 		Timestamp: time.Now().UTC(),
 		Uptime:    time.Since(h.startTime).String(),
 	}
@@ -254,7 +256,7 @@ func (h *HealthHandler) Status(w http.ResponseWriter, r *http.Request) {
 
 	// Service information
 	response.Service = ServiceInfo{
-		Name:      "scanorama",
+		Name:      serviceNameScanorama,
 		Version:   getVersion(),
 		StartTime: h.startTime,
 		Uptime:    time.Since(h.startTime).String(),
@@ -296,7 +298,7 @@ func (h *HealthHandler) Status(w http.ResponseWriter, r *http.Request) {
 	// Record metrics
 	if h.metrics != nil {
 		h.metrics.Counter("api_status_checks_total", metrics.Labels{
-			"status": response.Health.Status,
+			responseKeyStatus: response.Health.Status,
 		})
 	}
 }

--- a/internal/api/handlers/host.go
+++ b/internal/api/handlers/host.go
@@ -19,6 +19,8 @@ import (
 	"github.com/anstrom/scanorama/internal/services"
 )
 
+const entityTypeHost = "host"
+
 // Validation constants for host fields.
 const (
 	maxHostnameLength        = 255
@@ -242,7 +244,7 @@ func (h *HostHandler) GetHost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	crudOp := &CRUDOperation[db.Host]{
-		EntityType: "host",
+		EntityType: entityTypeHost,
 		Logger:     h.logger,
 		Metrics:    h.metrics,
 	}
@@ -285,7 +287,7 @@ func (h *HostHandler) GetHost(w http.ResponseWriter, r *http.Request) {
 func (h *HostHandler) UpdateHost(w http.ResponseWriter, r *http.Request) {
 	UpdateEntity[db.Host, db.UpdateHostInput](
 		w, r,
-		"host",
+		entityTypeHost,
 		h.logger,
 		h.metrics,
 		func(r *http.Request) (db.UpdateHostInput, error) {
@@ -378,7 +380,7 @@ func (h *HostHandler) DeleteHost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	crudOp := &CRUDOperation[db.Host]{
-		EntityType: "host",
+		EntityType: entityTypeHost,
 		Logger:     h.logger,
 		Metrics:    h.metrics,
 	}

--- a/internal/api/handlers/networks.go
+++ b/internal/api/handlers/networks.go
@@ -107,7 +107,7 @@ type NetworkStatsResponse struct {
 // ---------------------------------------------------------------------------
 
 func (h *NetworkHandler) parseNetworkFilters(r *http.Request) (showInactive bool, nameFilter string) {
-	showInactive = r.URL.Query().Get("show_inactive") == "true"
+	showInactive = r.URL.Query().Get(queryShowInactive) == queryValTrue
 	nameFilter = r.URL.Query().Get("name")
 	return showInactive, nameFilter
 }
@@ -185,13 +185,21 @@ func (h *NetworkHandler) parseReasonFromRequest(req *CreateExclusionRequest) str
 // Validation helpers
 // ---------------------------------------------------------------------------
 
-const maxNetworkNameLen = 100
+const (
+	maxNetworkNameLen   = 100
+	discoveryMethodPing = "ping"
+	discoveryMethodARP  = "arp"
+	discoveryMethodICMP = "icmp"
+	defaultScanConnect  = "connect"
+	defaultPortRange    = "1-1024"
+	queryShowInactive   = "show_inactive"
+)
 
 var validDiscoveryMethods = map[string]bool{
-	"ping": true,
-	"tcp":  true,
-	"arp":  true,
-	"icmp": true,
+	discoveryMethodPing: true,
+	protoTCP:            true,
+	discoveryMethodARP:  true,
+	discoveryMethodICMP: true,
 }
 
 func (h *NetworkHandler) validateCreateNetworkRequest(req *CreateNetworkRequest) error {
@@ -292,7 +300,7 @@ func (h *NetworkHandler) ListNetworks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writePaginatedResponse(w, r, filteredNetworks, params, totalItems)
-	recordCRUDMetric(h.metrics, "networks_listed", map[string]string{"status": "success"})
+	recordCRUDMetric(h.metrics, "networks_listed", map[string]string{responseKeyStatus: statusSuccess})
 }
 
 // CreateNetwork handles POST /api/v1/networks.
@@ -411,7 +419,7 @@ func (h *NetworkHandler) DeleteNetwork(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-	recordCRUDMetric(h.metrics, "networks_deleted", map[string]string{"status": "success"})
+	recordCRUDMetric(h.metrics, "networks_deleted", map[string]string{responseKeyStatus: statusSuccess})
 }
 
 // EnableNetwork handles POST /api/v1/networks/{id}/enable.
@@ -646,7 +654,7 @@ func (h *NetworkHandler) StartNetworkDiscovery(w http.ResponseWriter, r *http.Re
 	cidr := network.CIDR.String()
 	method := network.DiscoveryMethod
 	if method == "" {
-		method = "tcp"
+		method = protoTCP
 	}
 
 	// Create the discovery job.
@@ -907,8 +915,8 @@ func (h *NetworkHandler) StartNetworkScan(w http.ResponseWriter, r *http.Request
 	scan, err := h.scanService.CreateScan(r.Context(), db.CreateScanInput{
 		Name:        scanName,
 		Targets:     targets,
-		ScanType:    "connect",
-		Ports:       "1-1024",
+		ScanType:    defaultScanConnect,
+		Ports:       defaultPortRange,
 		OSDetection: req.OSDetection,
 		NetworkID:   &networkID,
 	})

--- a/internal/api/handlers/ports.go
+++ b/internal/api/handlers/ports.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	protoTCP = "tcp"
-	protoUDP = "udp"
+	protoTCP     = "tcp"
+	protoUDP     = "udp"
+	queryValTrue = "true"
 )
 
 // PortHandler handles port definition endpoints.
@@ -68,7 +69,7 @@ func (h *PortHandler) ListPorts(w http.ResponseWriter, r *http.Request) {
 		SortOrder: q.Get("sort_order"),
 	}
 	if s := q.Get("is_standard"); s != "" {
-		v := s == "true"
+		v := s == queryValTrue
 		filters.IsStandard = &v
 	}
 

--- a/internal/api/handlers/profile.go
+++ b/internal/api/handlers/profile.go
@@ -61,9 +61,18 @@ const (
 	maxProfileRatePPS     = 10000
 	maxProfileTagLength   = 50
 
-	// Scan type constants
 	scanTypeComprehensive = "comprehensive"
 	scanTypeAggressive    = "aggressive"
+	scanTypeConnect       = "connect"
+	scanTypeSYN           = "syn"
+	scanTypeACK           = "ack"
+	scanTypeUDP           = "udp"
+
+	timingParanoid = "paranoid"
+	timingSneaky   = "sneaky"
+	timingPolite   = "polite"
+	timingNormal   = "normal"
+	timingInsane   = "insane"
 )
 
 // ProfileHandler handles profile-related API endpoints.
@@ -421,11 +430,11 @@ func (h *ProfileHandler) validateBasicProfileFields(req *ProfileRequest) error {
 
 func (h *ProfileHandler) validateProfileScanType(scanType string) error {
 	validScanTypes := map[string]bool{
-		"connect":       true,
-		"syn":           true,
-		"ack":           true,
-		"aggressive":    true,
-		"comprehensive": true,
+		scanTypeConnect:       true,
+		scanTypeSYN:           true,
+		scanTypeACK:           true,
+		scanTypeAggressive:    true,
+		scanTypeComprehensive: true,
 	}
 	if !validScanTypes[scanType] {
 		return fmt.Errorf("invalid scan type: %s", scanType)
@@ -438,12 +447,12 @@ func (h *ProfileHandler) validateTimingTemplate(template string) error {
 		return nil
 	}
 	validTimingTemplates := map[string]bool{
-		"paranoid":   true,
-		"sneaky":     true,
-		"polite":     true,
-		"normal":     true,
-		"aggressive": true,
-		"insane":     true,
+		timingParanoid:     true,
+		timingSneaky:       true,
+		timingPolite:       true,
+		timingNormal:       true,
+		scanTypeAggressive: true,
+		timingInsane:       true,
 	}
 	if !validTimingTemplates[template] {
 		return fmt.Errorf("invalid timing template: %s", template)

--- a/internal/api/handlers/scan.go
+++ b/internal/api/handlers/scan.go
@@ -23,6 +23,14 @@ import (
 	"github.com/anstrom/scanorama/internal/services"
 )
 
+const (
+	labelScanType       = "scan_type"
+	scanStatusCompleted = "completed"
+	scanStatusFailed    = "failed"
+	scanStatusRunning   = "running"
+	entityTypeScan      = "scan"
+)
+
 // ScanHandler handles scan-related API endpoints.
 type ScanHandler struct {
 	service    ScanServicer
@@ -198,7 +206,7 @@ func (h *ScanHandler) CreateScan(w http.ResponseWriter, r *http.Request) {
 
 	if h.metrics != nil {
 		h.metrics.Counter("api_scans_created_total", map[string]string{
-			"scan_type": req.ScanType,
+			labelScanType: req.ScanType,
 		})
 	}
 }
@@ -212,7 +220,7 @@ func (h *ScanHandler) GetScan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	crudOp := &CRUDOperation[db.Scan]{
-		EntityType: "scan",
+		EntityType: entityTypeScan,
 		Logger:     h.logger,
 		Metrics:    h.metrics,
 	}
@@ -253,7 +261,7 @@ func (h *ScanHandler) DeleteScan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	crudOp := &CRUDOperation[db.Scan]{
-		EntityType: "scan",
+		EntityType: entityTypeScan,
 		Logger:     h.logger,
 		Metrics:    h.metrics,
 	}
@@ -395,7 +403,7 @@ func (h *ScanHandler) StartScan(w http.ResponseWriter, r *http.Request) {
 
 	if h.metrics != nil {
 		h.metrics.Counter("api_scans_started_total", map[string]string{
-			"scan_type": scan.ScanType,
+			labelScanType: scan.ScanType,
 		})
 	}
 
@@ -410,7 +418,7 @@ func (h *ScanHandler) submitToQueue(scanID uuid.UUID, scan *db.Scan) (int, error
 		concreteDB = svc.DB()
 	}
 
-	scanType := firstNonEmpty(scan.ScanType, h.scanMode, "connect")
+	scanType := firstNonEmpty(scan.ScanType, h.scanMode, scanTypeConnect)
 	scanConfig := &scanning.ScanConfig{
 		Targets:     scan.Targets,
 		Ports:       scan.Ports,
@@ -464,7 +472,7 @@ func (h *ScanHandler) submitToQueue(scanID uuid.UUID, scan *db.Scan) (int, error
 func (h *ScanHandler) executeScanAsync(scanID uuid.UUID, scan *db.Scan) {
 	h.logger.Info("Starting async scan execution", "scan_id", scanID, "scan_name", scan.Name)
 
-	scanType := firstNonEmpty(scan.ScanType, h.scanMode, "connect")
+	scanType := firstNonEmpty(scan.ScanType, h.scanMode, scanTypeConnect)
 	scanConfig := &scanning.ScanConfig{
 		Targets:     scan.Targets,
 		Ports:       scan.Ports,
@@ -510,7 +518,7 @@ func (h *ScanHandler) StopScan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	jobOp := &JobControlOperation{
-		EntityType: "scan",
+		EntityType: entityTypeScan,
 		Logger:     h.logger,
 		Metrics:    h.metrics,
 	}
@@ -544,8 +552,8 @@ func (h *ScanHandler) validateScanRequest(req *ScanRequest) error {
 	}
 
 	validScanTypes := map[string]bool{
-		"connect": true, "syn": true, "ack": true,
-		"udp": true, "aggressive": true, "comprehensive": true,
+		scanTypeConnect: true, scanTypeSYN: true, scanTypeACK: true,
+		scanTypeUDP: true, scanTypeAggressive: true, scanTypeComprehensive: true,
 	}
 	if !validScanTypes[req.ScanType] {
 		return fmt.Errorf("invalid scan type: %s", req.ScanType)
@@ -671,11 +679,11 @@ func (h *ScanHandler) scanToResponse(scan *db.Scan) ScanResponse {
 
 	// Compute progress from status
 	switch scan.Status {
-	case "completed":
+	case scanStatusCompleted:
 		resp.Progress = 100.0
-	case "failed":
+	case scanStatusFailed:
 		resp.Progress = 0.0
-	case "running":
+	case scanStatusRunning:
 		resp.Progress = 50.0 // Approximation without a dedicated progress field
 	default:
 		resp.Progress = 0.0

--- a/internal/api/handlers/schedule.go
+++ b/internal/api/handlers/schedule.go
@@ -22,11 +22,25 @@ import (
 
 // Schedule validation constants.
 const (
-	maxScheduleNameLength = 255
-	maxScheduleDescLength = 1000
-	maxScheduleTagLength  = 50
-	maxScheduleRetries    = 10
-	scheduleStatusActive  = "active"
+	maxScheduleNameLength     = 255
+	maxScheduleDescLength     = 1000
+	maxScheduleTagLength      = 50
+	maxScheduleRetries        = 10
+	scheduleStatusActive      = "active"
+	scheduleStatusEnabled     = "enabled"
+	scheduleStatusDisabled    = "disabled"
+	scheduleStatusPending     = "pending"
+	scheduleTypeKey           = "scan"
+	scheduleDiscoveryKey      = "discovery"
+	scheduleJobConfigKeyID    = "schedule_id"
+	scheduleJobConfigNetID    = "network_id"
+	scheduleJobConfigRetry    = "retry_on_error"
+	scheduleJobConfigNotify   = "notify_on_fail"
+	scheduleJobConfigMaxRetry = "max_retries"
+	scheduleJobConfigEmails   = "notify_emails"
+	scheduleJobConfigTags     = "tags"
+	scheduleJobConfigOptions  = "options"
+	scheduleJobConfigLimit    = "limit"
 )
 
 // ScheduleHandler handles schedule-related API endpoints.
@@ -251,11 +265,11 @@ func (h *ScheduleHandler) EnableSchedule(w http.ResponseWriter, r *http.Request)
 	}
 
 	response := map[string]interface{}{
-		"schedule_id": scheduleID,
-		"status":      "enabled",
-		"message":     "Schedule has been enabled",
-		"timestamp":   time.Now().UTC(),
-		"request_id":  requestID,
+		scheduleJobConfigKeyID: scheduleID,
+		responseKeyStatus:      scheduleStatusEnabled,
+		responseKeyMessage:     "Schedule has been enabled",
+		responseKeyTS:          time.Now().UTC(),
+		responseKeyReqID:       requestID,
 	}
 
 	if schedule != nil {
@@ -303,11 +317,11 @@ func (h *ScheduleHandler) DisableSchedule(w http.ResponseWriter, r *http.Request
 	}
 
 	response := map[string]interface{}{
-		"schedule_id": scheduleID,
-		"status":      "disabled",
-		"message":     "Schedule has been disabled",
-		"timestamp":   time.Now().UTC(),
-		"request_id":  requestID,
+		scheduleJobConfigKeyID: scheduleID,
+		responseKeyStatus:      scheduleStatusDisabled,
+		responseKeyMessage:     "Schedule has been disabled",
+		responseKeyTS:          time.Now().UTC(),
+		responseKeyReqID:       requestID,
 	}
 
 	h.logger.Info("Schedule disabled successfully",
@@ -345,8 +359,8 @@ func (h *ScheduleHandler) GetScheduleNextRun(w http.ResponseWriter, r *http.Requ
 	}
 
 	writeJSON(w, r, http.StatusOK, map[string]interface{}{
-		"schedule_id": scheduleID,
-		"next_run":    nextRun,
+		scheduleJobConfigKeyID: scheduleID,
+		"next_run":             nextRun,
 	})
 }
 
@@ -391,10 +405,10 @@ func (h *ScheduleHandler) CreateSmartScanSchedule(w http.ResponseWriter, r *http
 		CronExpression: req.CronExpr,
 		Enabled:        req.Enabled,
 		JobConfig: map[string]interface{}{
-			"score_threshold":     req.ScoreThreshold,
-			"max_staleness_hours": req.MaxStalenessHours,
-			"network_cidr":        req.NetworkCIDR,
-			"limit":               req.Limit,
+			"score_threshold":      req.ScoreThreshold,
+			"max_staleness_hours":  req.MaxStalenessHours,
+			"network_cidr":         req.NetworkCIDR,
+			scheduleJobConfigLimit: req.Limit,
 		},
 	}
 	schedule, err := h.service.CreateSchedule(r.Context(), input)
@@ -473,8 +487,8 @@ func (h *ScheduleHandler) validateBasicScheduleFields(req *ScheduleRequest) erro
 
 func (h *ScheduleHandler) validateScheduleType(scheduleType string) error {
 	validTypes := map[string]bool{
-		"scan":      true,
-		"discovery": true,
+		scheduleTypeKey:      true,
+		scheduleDiscoveryKey: true,
 	}
 	if !validTypes[scheduleType] {
 		return fmt.Errorf("invalid schedule type: %s", scheduleType)
@@ -566,17 +580,17 @@ func (h *ScheduleHandler) getScheduleFilters(r *http.Request) db.ScheduleFilters
 // packing fields that don't have dedicated DB columns.
 func buildScheduleJobConfig(req *ScheduleRequest) map[string]interface{} {
 	jobConfig := map[string]interface{}{
-		"network_id":     req.NetworkID.String(),
-		"max_run_time":   req.MaxRunTime.String(),
-		"retry_on_error": req.RetryOnError,
-		"max_retries":    req.MaxRetries,
-		"retry_delay":    req.RetryDelay.String(),
-		"notify_on_fail": req.NotifyOnFail,
-		"notify_emails":  req.NotifyEmails,
-		"tags":           req.Tags,
+		scheduleJobConfigNetID:    req.NetworkID.String(),
+		"max_run_time":            req.MaxRunTime.String(),
+		scheduleJobConfigRetry:    req.RetryOnError,
+		scheduleJobConfigMaxRetry: req.MaxRetries,
+		"retry_delay":             req.RetryDelay.String(),
+		scheduleJobConfigNotify:   req.NotifyOnFail,
+		scheduleJobConfigEmails:   req.NotifyEmails,
+		scheduleJobConfigTags:     req.Tags,
 	}
 	if req.Options != nil {
-		jobConfig["options"] = req.Options
+		jobConfig[scheduleJobConfigOptions] = req.Options
 	}
 	return jobConfig
 }
@@ -629,11 +643,11 @@ func (h *ScheduleHandler) scheduleToResponse(schedule *db.Schedule) ScheduleResp
 	// Derive status from enabled + last run info
 	switch {
 	case !schedule.Enabled:
-		resp.Status = "disabled"
+		resp.Status = scheduleStatusDisabled
 	case schedule.LastRun != nil:
 		resp.Status = scheduleStatusActive
 	default:
-		resp.Status = "pending"
+		resp.Status = scheduleStatusPending
 	}
 
 	applyJobConfigToScheduleResponse(schedule.JobConfig, &resp)
@@ -648,34 +662,34 @@ func applyJobConfigToScheduleResponse(cfg map[string]interface{}, resp *Schedule
 		return
 	}
 
-	if networkID, ok := cfg["network_id"]; ok {
+	if networkID, ok := cfg[scheduleJobConfigNetID]; ok {
 		resp.NetworkID = fmt.Sprintf("%v", networkID)
 	}
-	if v, ok := cfg["retry_on_error"].(bool); ok {
+	if v, ok := cfg[scheduleJobConfigRetry].(bool); ok {
 		resp.RetryOnError = v
 	}
-	if v, ok := cfg["max_retries"].(float64); ok {
+	if v, ok := cfg[scheduleJobConfigMaxRetry].(float64); ok {
 		resp.MaxRetries = int(v)
 	}
-	if v, ok := cfg["notify_on_fail"].(bool); ok {
+	if v, ok := cfg[scheduleJobConfigNotify].(bool); ok {
 		resp.NotifyOnFail = v
 	}
 
-	if emails, ok := cfg["notify_emails"].([]interface{}); ok {
+	if emails, ok := cfg[scheduleJobConfigEmails].([]interface{}); ok {
 		for _, e := range emails {
 			if s, ok := e.(string); ok {
 				resp.NotifyEmails = append(resp.NotifyEmails, s)
 			}
 		}
 	}
-	if tags, ok := cfg["tags"].([]interface{}); ok {
+	if tags, ok := cfg[scheduleJobConfigTags].([]interface{}); ok {
 		for _, t := range tags {
 			if s, ok := t.(string); ok {
 				resp.Tags = append(resp.Tags, s)
 			}
 		}
 	}
-	if opts, ok := cfg["options"].(map[string]interface{}); ok {
+	if opts, ok := cfg[scheduleJobConfigOptions].(map[string]interface{}); ok {
 		resp.Options = make(map[string]string, len(opts))
 		for k, v := range opts {
 			resp.Options[k] = fmt.Sprintf("%v", v)

--- a/internal/api/handlers/tags.go
+++ b/internal/api/handlers/tags.go
@@ -13,6 +13,8 @@ import (
 	"github.com/anstrom/scanorama/internal/errors"
 )
 
+const responseKeyTags = "tags"
+
 // tagModifyRequest is the body for PUT/POST/DELETE /api/v1/hosts/{id}/tags.
 type tagModifyRequest struct {
 	Tags []string `json:"tags"`
@@ -36,7 +38,7 @@ func (h *HostHandler) ListTags(w http.ResponseWriter, r *http.Request) {
 	if tags == nil {
 		tags = []string{}
 	}
-	writeJSON(w, r, http.StatusOK, map[string]interface{}{"tags": tags})
+	writeJSON(w, r, http.StatusOK, map[string]interface{}{responseKeyTags: tags})
 }
 
 // applyTagsOp is a shared helper for tag-mutation endpoints that parse the
@@ -67,13 +69,13 @@ func (h *HostHandler) applyTagsOp(
 	}
 
 	if err := serviceOp(r.Context(), id, tags); err != nil {
-		handleDatabaseError(w, r, err, opName+" tags for", "host", h.logger)
+		handleDatabaseError(w, r, err, opName+" tags for", entityTypeHost, h.logger)
 		return
 	}
 
 	host, err := h.service.GetHost(r.Context(), id)
 	if err != nil {
-		handleDatabaseError(w, r, err, "get", "host", h.logger)
+		handleDatabaseError(w, r, err, "get", entityTypeHost, h.logger)
 		return
 	}
 	writeJSON(w, r, http.StatusOK, h.hostToResponse(host))
@@ -107,13 +109,13 @@ func (h *HostHandler) DeleteHostTags(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.RemoveHostTags(r.Context(), id, req.Tags); err != nil {
-		handleDatabaseError(w, r, err, "remove tags for", "host", h.logger)
+		handleDatabaseError(w, r, err, "remove tags for", entityTypeHost, h.logger)
 		return
 	}
 
 	host, err := h.service.GetHost(r.Context(), id)
 	if err != nil {
-		handleDatabaseError(w, r, err, "get", "host", h.logger)
+		handleDatabaseError(w, r, err, "get", entityTypeHost, h.logger)
 		return
 	}
 	writeJSON(w, r, http.StatusOK, h.hostToResponse(host))

--- a/internal/api/handlers/websocket.go
+++ b/internal/api/handlers/websocket.go
@@ -29,7 +29,13 @@ const (
 	bufferSize       = 256                                                // Size of the broadcast channel buffer
 	logsHistoryBurst = 100                                                // Recent log entries sent on connect
 
-	loopbackHostname = "localhost" // hostname alias for loopback; IPs checked via net.IP.IsLoopback
+	loopbackHostname    = "localhost"
+	wsConnTypeScan      = "scan"
+	wsConnTypeDiscovery = "discovery"
+	wsConnTypeSingle    = "single"
+	wsConnTypeGeneral   = "general"
+	wsLabelType         = "type"
+	wsLabelMessage      = "message"
 )
 
 // checkOrigin returns true if the WebSocket upgrade request should be accepted.
@@ -158,7 +164,7 @@ func (h *WebSocketHandler) ScanWebSocket(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Set up the connection for scan updates only
-	h.setupConnection(conn, []string{"scan"}, requestID)
+	h.setupConnection(conn, []string{wsConnTypeScan}, requestID)
 }
 
 // DiscoveryWebSocket handles WebSocket connections for discovery updates.
@@ -173,7 +179,7 @@ func (h *WebSocketHandler) DiscoveryWebSocket(w http.ResponseWriter, r *http.Req
 	}
 
 	// Set up the connection for discovery updates only
-	h.setupConnection(conn, []string{"discovery"}, requestID)
+	h.setupConnection(conn, []string{wsConnTypeDiscovery}, requestID)
 }
 
 // GeneralWebSocket handles general WebSocket connections for all updates.
@@ -188,7 +194,7 @@ func (h *WebSocketHandler) GeneralWebSocket(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Set up the connection for both scan and discovery updates
-	h.setupConnection(conn, []string{"scan", "discovery"}, requestID)
+	h.setupConnection(conn, []string{wsConnTypeScan, wsConnTypeDiscovery}, requestID)
 }
 
 // setupConnection configures a WebSocket connection for the specified connection types and starts read/write pumps.
@@ -221,9 +227,9 @@ func (h *WebSocketHandler) setupConnection(conn *websocket.Conn, connTypes []str
 	}
 
 	// Determine connection type label for logging
-	connTypeLabel := "single"
+	connTypeLabel := wsConnTypeSingle
 	if len(connTypes) > 1 {
-		connTypeLabel = "general"
+		connTypeLabel = wsConnTypeGeneral
 	} else if len(connTypes) == 1 {
 		connTypeLabel = connTypes[0]
 	}
@@ -248,9 +254,9 @@ func (h *WebSocketHandler) run() {
 		case registration := <-h.register:
 			h.mutex.Lock()
 			switch registration.connType {
-			case "scan":
+			case wsConnTypeScan:
 				h.scanClients[registration.conn] = true
-			case "discovery":
+			case wsConnTypeDiscovery:
 				h.discoveryClients[registration.conn] = true
 			}
 			h.mutex.Unlock()
@@ -266,10 +272,10 @@ func (h *WebSocketHandler) run() {
 			h.logger.Debug("Client unregistered", "total_clients", h.getTotalClients())
 
 		case message := <-h.scanBroadcast:
-			h.broadcastToClients(h.scanClients, message, "scan")
+			h.broadcastToClients(h.scanClients, message, wsConnTypeScan)
 
 		case message := <-h.discoveryBroadcast:
-			h.broadcastToClients(h.discoveryClients, message, "discovery")
+			h.broadcastToClients(h.discoveryClients, message, wsConnTypeDiscovery)
 
 		case <-ticker.C:
 			h.pingClients()
@@ -358,7 +364,7 @@ func (h *WebSocketHandler) broadcastToClients(clients map[*websocket.Conn]bool, 
 	// Record metrics
 	if h.metrics != nil {
 		h.metrics.Counter("websocket_messages_sent_total", map[string]string{
-			"type": clientType,
+			wsLabelType: clientType,
 		})
 	}
 }
@@ -465,7 +471,7 @@ func (h *WebSocketHandler) BroadcastSystemMessage(messageType, content string) e
 		Type:      messageType,
 		Timestamp: time.Now().UTC(),
 		Data: map[string]string{
-			"message": content,
+			wsLabelMessage: content,
 		},
 	}
 
@@ -496,9 +502,9 @@ func (h *WebSocketHandler) GetConnectedClients() map[string]int {
 	defer h.mutex.RUnlock()
 
 	return map[string]int{
-		"scan":      len(h.scanClients),
-		"discovery": len(h.discoveryClients),
-		"total":     len(h.scanClients) + len(h.discoveryClients),
+		wsConnTypeScan:      len(h.scanClients),
+		wsConnTypeDiscovery: len(h.discoveryClients),
+		responseKeyTotal:    len(h.scanClients) + len(h.discoveryClients),
 	}
 }
 
@@ -550,7 +556,7 @@ func (h *WebSocketHandler) sendLogsHistory(conn *websocket.Conn) {
 	msg := WebSocketMessage{
 		Type:      "log_history",
 		Timestamp: time.Now().UTC(),
-		Data:      map[string]interface{}{"entries": recent, "total": len(recent)},
+		Data:      map[string]interface{}{"entries": recent, responseKeyTotal: len(recent)},
 	}
 	data, err := json.Marshal(msg)
 	if err != nil {

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -16,6 +16,14 @@ import (
 // Metrics constants.
 const (
 	statusServerErrorMin = 500
+	metricsLabelMethod   = "method"
+	metricsLabelStatus   = "status"
+	httpMethodGET        = "GET"
+	httpMethodPOST       = "POST"
+	httpMethodPUT        = "PUT"
+	httpMethodDELETE     = "DELETE"
+	httpMethodOPTIONS    = "OPTIONS"
+	contentTypeJSON      = "application/json"
 )
 
 // setupMiddleware configures middleware for the API server.
@@ -38,7 +46,8 @@ func (s *Server) setupMiddleware(apiConfig *Config) {
 	if apiConfig.EnableCORS {
 		corsOptions := gorilla.AllowedOrigins(apiConfig.CORSOrigins)
 		corsHeaders := gorilla.AllowedHeaders([]string{"Content-Type", "Authorization", "X-API-Key"})
-		corsMethods := gorilla.AllowedMethods([]string{"GET", "POST", "PUT", "DELETE", "OPTIONS"})
+		methods := []string{httpMethodGET, httpMethodPOST, httpMethodPUT, httpMethodDELETE, httpMethodOPTIONS}
+		corsMethods := gorilla.AllowedMethods(methods)
 		s.router.Use(gorilla.CORS(corsOptions, corsHeaders, corsMethods))
 	}
 
@@ -92,12 +101,12 @@ func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 
 		// Record metrics
 		s.metrics.Counter("http_requests_total", map[string]string{
-			"method": r.Method,
-			"status": fmt.Sprintf("%d", wrapped.statusCode),
+			metricsLabelMethod: r.Method,
+			metricsLabelStatus: fmt.Sprintf("%d", wrapped.statusCode),
 		})
 
 		s.metrics.Histogram("http_request_duration_seconds", duration.Seconds(), map[string]string{
-			"method": r.Method,
+			metricsLabelMethod: r.Method,
 		})
 
 		// Prometheus HTTP metrics (use route template to avoid high cardinality)
@@ -120,9 +129,9 @@ func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 // contentTypeMiddleware validates content type for POST/PUT requests.
 func (s *Server) contentTypeMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "POST" || r.Method == "PUT" {
+		if r.Method == httpMethodPOST || r.Method == httpMethodPUT {
 			contentType := r.Header.Get("Content-Type")
-			if contentType != "" && contentType != "application/json" {
+			if contentType != "" && contentType != contentTypeJSON {
 				s.writeError(w, r, http.StatusUnsupportedMediaType,
 					fmt.Errorf("unsupported content type: %s", contentType))
 				return

--- a/internal/api/middleware/middleware.go
+++ b/internal/api/middleware/middleware.go
@@ -31,6 +31,18 @@ const (
 	methodOPTIONS = "OPTIONS"
 )
 
+const (
+	respKeyRequestID = "request_id"
+	respKeyTimestamp = "timestamp"
+	respKeyError     = "error"
+	respKeyMessage   = "message"
+	contentTypeJSON  = "application/json"
+	healthPathV1     = "/api/v1/health"
+	versionPathV1    = "/api/v1/version"
+	livenessPathV1   = "/api/v1/liveness"
+	unknownValue     = "unknown"
+)
+
 // ContextKey represents a context key type.
 type ContextKey string
 
@@ -235,13 +247,13 @@ func Recovery(logger *slog.Logger) func(http.Handler) http.Handler {
 						"remote_addr", getClientIP(r))
 
 					// Return 500 error
-					w.Header().Set("Content-Type", "application/json")
+					w.Header().Set("Content-Type", contentTypeJSON)
 					w.WriteHeader(http.StatusInternalServerError)
 
 					response := map[string]interface{}{
-						"error":      "Internal server error",
-						"request_id": requestID,
-						"timestamp":  time.Now().UTC(),
+						respKeyError:     "Internal server error",
+						respKeyRequestID: requestID,
+						respKeyTimestamp: time.Now().UTC(),
 					}
 
 					if encodeErr := json.NewEncoder(w).Encode(response); encodeErr != nil {
@@ -272,7 +284,7 @@ func Authentication(configKeys []string, database *db.DB, logger *slog.Logger) f
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Skip authentication for health checks
-			if r.URL.Path == "/api/v1/health" || r.URL.Path == "/api/v1/version" || r.URL.Path == "/api/v1/liveness" {
+			if r.URL.Path == healthPathV1 || r.URL.Path == versionPathV1 || r.URL.Path == livenessPathV1 {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -293,13 +305,13 @@ func Authentication(configKeys []string, database *db.DB, logger *slog.Logger) f
 					"path", r.URL.Path,
 					"remote_addr", getClientIP(r))
 
-				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Content-Type", contentTypeJSON)
 				w.WriteHeader(http.StatusUnauthorized)
 				response := map[string]interface{}{
-					"error":      "Authentication required",
-					"message":    "Provide API key in X-API-Key header or Authorization: Bearer <key>",
-					"request_id": GetRequestID(r),
-					"timestamp":  time.Now().UTC(),
+					respKeyError:     "Authentication required",
+					respKeyMessage:   "Provide API key in X-API-Key header or Authorization: Bearer <key>",
+					respKeyRequestID: GetRequestID(r),
+					respKeyTimestamp: time.Now().UTC(),
 				}
 				_ = json.NewEncoder(w).Encode(response)
 				return
@@ -344,12 +356,12 @@ func Authentication(configKeys []string, database *db.DB, logger *slog.Logger) f
 				"path", r.URL.Path,
 				"remote_addr", getClientIP(r))
 
-			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Content-Type", contentTypeJSON)
 			w.WriteHeader(http.StatusUnauthorized)
 			response := map[string]interface{}{
-				"error":      "Authentication failed: Invalid API key",
-				"request_id": GetRequestID(r),
-				"timestamp":  time.Now().UTC(),
+				respKeyError:     "Authentication failed: Invalid API key",
+				respKeyRequestID: GetRequestID(r),
+				respKeyTimestamp: time.Now().UTC(),
 			}
 			_ = json.NewEncoder(w).Encode(response)
 		})
@@ -381,17 +393,17 @@ func RateLimit(requests int, window time.Duration, logger *slog.Logger) func(htt
 					"limit", requests,
 					"window", window)
 
-				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Content-Type", contentTypeJSON)
 				w.Header().Set("X-RateLimit-Limit", strconv.Itoa(requests))
 				w.Header().Set("X-RateLimit-Window", window.String())
 				w.WriteHeader(http.StatusTooManyRequests)
 
 				response := map[string]interface{}{
-					"error":       "Rate limit exceeded",
-					"message":     fmt.Sprintf("Maximum %d requests per %s", requests, window),
-					"request_id":  GetRequestID(r),
-					"timestamp":   time.Now().UTC(),
-					"retry_after": window.Seconds(),
+					respKeyError:     "Rate limit exceeded",
+					respKeyMessage:   fmt.Sprintf("Maximum %d requests per %s", requests, window),
+					respKeyRequestID: GetRequestID(r),
+					respKeyTimestamp: time.Now().UTC(),
+					"retry_after":    window.Seconds(),
 				}
 				_ = json.NewEncoder(w).Encode(response)
 				return
@@ -419,17 +431,17 @@ func ContentType() func(http.Handler) http.Handler {
 			// For POST and PUT requests, expect JSON content type
 			if r.Method == methodPOST || r.Method == methodPUT {
 				contentType := r.Header.Get("Content-Type")
-				if contentType != "" && !strings.HasPrefix(contentType, "application/json") {
-					w.Header().Set("Content-Type", "application/json")
+				if contentType != "" && !strings.HasPrefix(contentType, contentTypeJSON) {
+					w.Header().Set("Content-Type", contentTypeJSON)
 					w.WriteHeader(http.StatusUnsupportedMediaType)
 
 					response := map[string]interface{}{
-						"error":      "Unsupported media type",
-						"message":    "Content-Type must be application/json",
-						"expected":   "application/json",
-						"received":   contentType,
-						"request_id": GetRequestID(r),
-						"timestamp":  time.Now().UTC(),
+						respKeyError:     "Unsupported media type",
+						respKeyMessage:   "Content-Type must be application/json",
+						"expected":       contentTypeJSON,
+						"received":       contentType,
+						respKeyRequestID: GetRequestID(r),
+						respKeyTimestamp: time.Now().UTC(),
 					}
 					_ = json.NewEncoder(w).Encode(response)
 					return
@@ -476,7 +488,7 @@ func GetRequestID(r *http.Request) string {
 	if requestID, ok := r.Context().Value(RequestIDKey).(string); ok {
 		return requestID
 	}
-	return "unknown"
+	return unknownValue
 }
 
 // getClientIP extracts the real client IP address from the request.
@@ -501,7 +513,7 @@ func getClientIP(r *http.Request) string {
 		}
 	}
 
-	return "unknown"
+	return unknownValue
 }
 
 // CORS creates a simple CORS middleware.

--- a/internal/auth/apikey.go
+++ b/internal/auth/apikey.go
@@ -32,6 +32,8 @@ const (
 	MinAPIKeyNameLength = 1
 	// MaxAPIKeyNameLength is the maximum length for API key names
 	MaxAPIKeyNameLength = 255
+
+	invalidKeyDisplay = "invalid_key"
 )
 
 // APIKeyInfo contains metadata about an API key
@@ -185,13 +187,13 @@ func IsValidAPIKeyFormat(apiKey string) bool {
 // CreateDisplayPrefix creates a safe-to-display prefix from a full API key
 func CreateDisplayPrefix(apiKey string) string {
 	if !IsValidAPIKeyFormat(apiKey) {
-		return "invalid_key"
+		return invalidKeyDisplay
 	}
 
 	// Find the underscore after the prefix
 	parts := strings.Split(apiKey, "_")
 	if len(parts) < 2 {
-		return "invalid_key"
+		return invalidKeyDisplay
 	}
 
 	// Return prefix + first few characters of random part

--- a/internal/auth/db_operations.go
+++ b/internal/auth/db_operations.go
@@ -14,6 +14,17 @@ import (
 	"github.com/google/uuid"
 )
 
+const (
+	updateFieldName      = "name"
+	updateFieldNotes     = "notes"
+	updateFieldExpiresAt = "expires_at"
+	statsKeyTotalKeys    = "total_keys"
+	statsKeyActiveKeys   = "active_keys"
+	statsKeyRevokedKeys  = "revoked_keys"
+	statsKeyExpiredKeys  = "expired_keys"
+	statsKeyUsedKeys     = "used_keys"
+)
+
 // APIKeyRepository provides database operations for API keys
 type APIKeyRepository struct {
 	db *db.DB
@@ -213,15 +224,15 @@ func (r *APIKeyRepository) UpdateAPIKey(keyID string, updates map[string]interfa
 
 	for field, value := range updates {
 		switch field {
-		case "name":
+		case updateFieldName:
 			setParts = append(setParts, fmt.Sprintf("name = $%d", argIndex))
 			args = append(args, value)
 			argIndex++
-		case "notes":
+		case updateFieldNotes:
 			setParts = append(setParts, fmt.Sprintf("notes = $%d", argIndex))
 			args = append(args, value)
 			argIndex++
-		case "expires_at":
+		case updateFieldExpiresAt:
 			setParts = append(setParts, fmt.Sprintf("expires_at = $%d", argIndex))
 			args = append(args, value)
 			argIndex++
@@ -394,11 +405,11 @@ func (r *APIKeyRepository) GetAPIKeyStats() (map[string]interface{}, error) {
 	}
 
 	result := map[string]interface{}{
-		"total_keys":   stats.TotalKeys,
-		"active_keys":  stats.ActiveKeys,
-		"revoked_keys": stats.RevokedKeys,
-		"expired_keys": stats.ExpiredKeys,
-		"used_keys":    stats.UsedKeys,
+		statsKeyTotalKeys:   stats.TotalKeys,
+		statsKeyActiveKeys:  stats.ActiveKeys,
+		statsKeyRevokedKeys: stats.RevokedKeys,
+		statsKeyExpiredKeys: stats.ExpiredKeys,
+		statsKeyUsedKeys:    stats.UsedKeys,
 	}
 
 	if stats.AvgUsageCount.Valid {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,15 @@ const (
 	DefaultFilePermissions = 0o600
 )
 
+const (
+	defaultScanMode         = validScanSYN
+	defaultAPIHost          = "127.0.0.1"
+	defaultDiscoveryMethod  = validDiscoveryPing
+	defaultDiscoveryTimeout = "30s"
+	defaultLogLevel         = validLogInfo
+	defaultLogFormat        = validLogText
+)
+
 // Config represents the application configuration.
 type Config struct {
 	// Daemon configuration
@@ -363,7 +372,7 @@ func defaultScanningConfig() ScanningConfig {
 		DefaultInterval:        1 * time.Hour,
 		MaxScanTimeout:         defaultScanTimeoutMin * time.Minute,
 		DefaultPorts:           "22,80,443,8080,8443",
-		ScanMode:               "syn",
+		ScanMode:               defaultScanMode,
 		MaxConcurrentTargets:   defaultMaxConcurrentTargets,
 		EnableServiceDetection: true,
 		EnableOSDetection:      false,
@@ -385,7 +394,7 @@ func defaultScanningConfig() ScanningConfig {
 func defaultAPIConfig() APIConfig {
 	return APIConfig{
 		Enabled:        true,
-		Host:           "127.0.0.1",
+		Host:           defaultAPIHost,
 		Port:           defaultAPIPort,
 		ReadTimeout:    10 * time.Second,
 		WriteTimeout:   10 * time.Second,
@@ -415,8 +424,8 @@ func defaultDiscoveryConfig() DiscoveryConfig {
 		Networks:         []NetworkConfig{},
 		GlobalExclusions: []string{},
 		Defaults: DiscoveryDefaults{
-			Method:   "ping",
-			Timeout:  "30s",
+			Method:   defaultDiscoveryMethod,
+			Timeout:  defaultDiscoveryTimeout,
 			Schedule: "0 */12 * * *", // Twice daily
 			Ports:    "22,80,443,8080,8443,3389,5432,6379",
 		},
@@ -427,9 +436,9 @@ func defaultDiscoveryConfig() DiscoveryConfig {
 // defaultLoggingConfig returns the default logging configuration.
 func defaultLoggingConfig() LoggingConfig {
 	return LoggingConfig{
-		Level:  "info",
-		Format: "text",
-		Output: "stdout",
+		Level:  defaultLogLevel,
+		Format: defaultLogFormat,
+		Output: outputStdout,
 		Rotation: RotationConfig{
 			Enabled:    false,
 			MaxSizeMB:  defaultMaxSizeMB,
@@ -478,7 +487,7 @@ func getDatabaseConfigFromEnv() db.Config {
 		Database:        getEnvString("SCANORAMA_DB_NAME", ""),
 		Username:        getEnvString("SCANORAMA_DB_USER", ""),
 		Password:        getEnvString("SCANORAMA_DB_PASSWORD", ""),
-		SSLMode:         getEnvString("SCANORAMA_DB_SSLMODE", "disable"),
+		SSLMode:         getEnvString("SCANORAMA_DB_SSLMODE", sslModeDisable),
 		MaxOpenConns:    getEnvInt("SCANORAMA_DB_MAX_OPEN_CONNS", DefaultMaxOpenConns),
 		MaxIdleConns:    getEnvInt("SCANORAMA_DB_MAX_IDLE_CONNS", DefaultMaxIdleConns),
 		ConnMaxLifetime: getEnvDuration("SCANORAMA_DB_CONN_MAX_LIFETIME", DefaultConnMaxLifetime),

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -25,14 +25,30 @@ const (
 )
 
 const (
-	// outputStdout is the constant for the "stdout" output target.
 	outputStdout = "stdout"
-	// outputStderr is the constant for the "stderr" output target.
 	outputStderr = "stderr"
 
-	// largeWorkerPoolThreshold is the threshold above which
-	// a worker pool size warning is emitted.
 	largeWorkerPoolThreshold = 1000
+
+	validScanConnect       = "connect"
+	validScanSYN           = "syn"
+	validScanACK           = "ack"
+	validScanUDP           = "udp"
+	validScanAggressive    = "aggressive"
+	validScanComprehensive = "comprehensive"
+
+	validLogDebug = "debug"
+	validLogInfo  = "info"
+	validLogWarn  = "warn"
+	validLogError = "error"
+	validLogText  = "text"
+	validLogJSON  = "json"
+
+	validDiscoveryPing = "ping"
+	validDiscoveryTCP  = "tcp"
+	validDiscoveryARP  = "arp"
+
+	sslModeDisable = "disable"
 )
 
 // ValidationIssue represents a single validation error or warning.
@@ -404,13 +420,13 @@ func ValidateDatabaseConfig(cfg *db.Config) *ValidationResult {
 
 	// Validate SSL mode
 	validSSLModes := map[string]bool{
-		"disable":     true,
-		"require":     true,
-		"verify-ca":   true,
-		"verify-full": true,
-		"prefer":      true,
-		"allow":       true,
-		"":            true,
+		sslModeDisable: true,
+		"require":      true,
+		"verify-ca":    true,
+		"verify-full":  true,
+		"prefer":       true,
+		"allow":        true,
+		"":             true,
 	}
 	if !validSSLModes[cfg.SSLMode] {
 		result.addError(
@@ -528,12 +544,12 @@ func ValidateScanningConfig(
 
 	// Validate scan mode
 	validScanTypes := map[string]bool{
-		"connect":       true,
-		"syn":           true,
-		"ack":           true,
-		"udp":           true,
-		"aggressive":    true,
-		"comprehensive": true,
+		validScanConnect:       true,
+		validScanSYN:           true,
+		validScanACK:           true,
+		validScanUDP:           true,
+		validScanAggressive:    true,
+		validScanComprehensive: true,
 	}
 	scanType := strings.ToLower(
 		strings.TrimSpace(cfg.ScanMode),
@@ -935,10 +951,10 @@ func ValidateLoggingConfig(
 
 	// Validate log level
 	validLogLevels := map[string]bool{
-		"debug": true,
-		"info":  true,
-		"warn":  true,
-		"error": true,
+		validLogDebug: true,
+		validLogInfo:  true,
+		validLogWarn:  true,
+		validLogError: true,
 	}
 	level := strings.ToLower(strings.TrimSpace(cfg.Level))
 	if !validLogLevels[level] {
@@ -954,8 +970,8 @@ func ValidateLoggingConfig(
 
 	// Validate log format
 	validLogFormats := map[string]bool{
-		"text": true,
-		"json": true,
+		validLogText: true,
+		validLogJSON: true,
 	}
 	format := strings.ToLower(strings.TrimSpace(cfg.Format))
 	if !validLogFormats[format] {
@@ -1050,10 +1066,10 @@ func ValidateDiscoveryConfig(
 
 	// Validate default method
 	validMethods := map[string]bool{
-		"ping": true,
-		"tcp":  true,
-		"arp":  true,
-		"":     true, // empty is OK
+		validDiscoveryPing: true,
+		validDiscoveryTCP:  true,
+		validDiscoveryARP:  true,
+		"":                 true,
 	}
 	method := strings.ToLower(
 		strings.TrimSpace(cfg.Defaults.Method),

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -18,6 +18,12 @@ import (
 	"github.com/anstrom/scanorama/internal/errors"
 )
 
+const (
+	dbErrConnectionError = "Database connection error"
+	dbDefaultHost        = "localhost"
+	dbDefaultSSLMode     = "disable"
+)
+
 // pgErrMapping holds the sanitized error code and message for a PostgreSQL error code.
 type pgErrMapping struct {
 	code    errors.ErrorCode
@@ -39,11 +45,11 @@ var pgErrorCodeMap = map[pqerror.Code]pgErrMapping{
 	// admin_shutdown
 	pqerror.AdminShutdown: {errors.CodeDatabaseConnection, "Database connection lost"},
 	// connection_exception
-	pqerror.ConnectionException: {errors.CodeDatabaseConnection, "Database connection error"},
+	pqerror.ConnectionException: {errors.CodeDatabaseConnection, dbErrConnectionError},
 	// connection_does_not_exist
-	pqerror.ConnectionDoesNotExist: {errors.CodeDatabaseConnection, "Database connection error"},
+	pqerror.ConnectionDoesNotExist: {errors.CodeDatabaseConnection, dbErrConnectionError},
 	// connection_failure
-	pqerror.ConnectionFailure: {errors.CodeDatabaseConnection, "Database connection error"},
+	pqerror.ConnectionFailure: {errors.CodeDatabaseConnection, dbErrConnectionError},
 }
 
 // sanitizeDBError converts raw database errors into safe, sanitized errors
@@ -118,12 +124,12 @@ type Config struct {
 // Database name, username, and password must be explicitly configured.
 func DefaultConfig() Config {
 	return Config{
-		Host:            "localhost",
+		Host:            dbDefaultHost,
 		Port:            defaultPostgresPort,
 		Database:        "", // Must be configured.
 		Username:        "", // Must be configured.
 		Password:        "", // Must be configured.
-		SSLMode:         "disable",
+		SSLMode:         dbDefaultSSLMode,
 		MaxOpenConns:    defaultMaxOpenConns,
 		MaxIdleConns:    defaultMaxIdleConns,
 		ConnMaxLifetime: defaultConnMaxLifetime * time.Minute,

--- a/internal/db/filter_expr.go
+++ b/internal/db/filter_expr.go
@@ -23,32 +23,32 @@ type FilterExpr struct {
 
 // filterFieldSQL maps FilterExpr field names to their SQL column expressions.
 var filterFieldSQL = map[string]string{
-	"status":           "h.status",
-	"os_family":        "h.os_family",
-	"vendor":           "h.vendor",
-	"hostname":         "h.hostname",
-	"response_time_ms": "h.response_time_ms",
-	"first_seen":       "h.first_seen",
-	"last_seen":        "h.last_seen",
+	filterFieldStatus:         filterColStatus,
+	filterFieldOSFamily:       filterColOSFamily,
+	filterFieldVendor:         filterColVendor,
+	filterFieldHostname:       filterColHostname,
+	filterFieldResponseTimeMS: filterColResponseTimeMS,
+	filterFieldFirstSeen:      filterColFirstSeen,
+	filterFieldLastSeen:       filterColLastSeen,
 }
 
 // filterTextFields are simple-column fields that support the "contains" (ILIKE) operator.
 var filterTextFields = map[string]bool{
-	"status":    true,
-	"os_family": true,
-	"vendor":    true,
-	"hostname":  true,
+	filterFieldStatus:   true,
+	filterFieldOSFamily: true,
+	filterFieldVendor:   true,
+	filterFieldHostname: true,
 }
 
 // filterNumericFields are simple-column fields whose values must be parsed as integers.
 var filterNumericFields = map[string]bool{
-	"response_time_ms": true,
+	filterFieldResponseTimeMS: true,
 }
 
 // filterDateFields are simple-column fields whose values must be parsed as date/time.
 var filterDateFields = map[string]bool{
-	"first_seen": true,
-	"last_seen":  true,
+	filterFieldFirstSeen: true,
+	filterFieldLastSeen:  true,
 }
 
 // Repeated string literals extracted as constants to satisfy goconst.
@@ -61,6 +61,27 @@ const (
 	filterCmpBetween     = "between"
 	filterFieldOpenPort  = "open_port"
 	filterFieldScanCount = "scan_count"
+	filterOpAND          = "AND"
+)
+
+const (
+	filterFieldStatus         = "status"
+	filterFieldOSFamily       = "os_family"
+	filterFieldVendor         = "vendor"
+	filterFieldHostname       = "hostname"
+	filterFieldResponseTimeMS = "response_time_ms"
+	filterFieldFirstSeen      = "first_seen"
+	filterFieldLastSeen       = "last_seen"
+)
+
+const (
+	filterColStatus         = "h.status"
+	filterColOSFamily       = "h.os_family"
+	filterColVendor         = "h.vendor"
+	filterColHostname       = "h.hostname"
+	filterColResponseTimeMS = "h.response_time_ms"
+	filterColFirstSeen      = "h.first_seen"
+	filterColLastSeen       = "h.last_seen"
 )
 
 const (
@@ -114,7 +135,7 @@ func validateFilterExpr(expr *FilterExpr, depth int) error {
 
 // validateGroupExpr validates a group (AND/OR) node.
 func validateGroupExpr(expr *FilterExpr, depth int) error {
-	if expr.Op != "AND" && expr.Op != "OR" {
+	if expr.Op != filterOpAND && expr.Op != "OR" {
 		return fmt.Errorf("invalid group operator %q: must be AND or OR", expr.Op)
 	}
 	if len(expr.Conditions) == 0 {

--- a/internal/db/repository_banners.go
+++ b/internal/db/repository_banners.go
@@ -318,7 +318,7 @@ func (r *BannerRepository) ListExpiringCertificatesWithHosts(
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan expiring cert row: %w", err)
 		}
-		c.Protocol = "tcp"
+		c.Protocol = DiscoveryMethodTCP
 		c.DaysLeft = int(c.NotAfter.Sub(now).Hours() / hoursPerDay)
 		result = append(result, c)
 	}

--- a/internal/db/repository_group.go
+++ b/internal/db/repository_group.go
@@ -38,7 +38,7 @@ func (r *GroupRepository) CreateGroup(ctx context.Context, input CreateGroupInpu
 	id := uuid.New()
 	now := time.Now().UTC()
 
-	columns := []string{"id", "name", "description", "created_at", "updated_at"}
+	columns := []string{"id", colName, colDescription, colCreatedAt, colUpdatedAt}
 	placeholders := []string{"$1", "$2", "$3", "$4", "$5"}
 	args := []interface{}{id, input.Name, input.Description, now, now}
 	argIndex := 6
@@ -102,7 +102,7 @@ func (r *GroupRepository) GetGroup(ctx context.Context, id uuid.UUID) (*HostGrou
 		}
 		return nil, sanitizeDBError("get group", err)
 	}
-	if filterRuleJSON != "null" && filterRuleJSON != "" {
+	if filterRuleJSON != colNullJSON && filterRuleJSON != "" {
 		g.FilterRule = JSONB(filterRuleJSON)
 	}
 	return g, nil
@@ -144,7 +144,7 @@ func (r *GroupRepository) ListGroups(ctx context.Context) ([]*HostGroup, error) 
 		); err != nil {
 			return nil, fmt.Errorf("scan group row: %w", err)
 		}
-		if filterRuleJSON != "null" && filterRuleJSON != "" {
+		if filterRuleJSON != colNullJSON && filterRuleJSON != "" {
 			g.FilterRule = JSONB(filterRuleJSON)
 		}
 		groups = append(groups, g)
@@ -188,7 +188,7 @@ func (r *GroupRepository) UpdateGroup(ctx context.Context, id uuid.UUID, input U
 		}
 	}
 	addStr("name", input.Name)
-	addStr("description", input.Description)
+	addStr(colDescription, input.Description)
 	addStr("color", input.Color)
 
 	if input.ClearFilter {

--- a/internal/db/repository_host.go
+++ b/internal/db/repository_host.go
@@ -262,22 +262,30 @@ type HostFilters struct {
 	Expr      *FilterExpr // structured JSON filter expression (optional)
 }
 
+const (
+	sortColIPAddress           = "ip_address"
+	sortColOpenPorts           = "open_ports"
+	sortColResponseTimeAvgMS   = "response_time_avg_ms"
+	filterColResponseTimeAvgMS = "h.response_time_avg_ms"
+	sortColIgnoreScanning      = "ignore_scanning"
+)
+
 // validHostSortColumns is the allowlist of columns that may be used in ORDER BY.
 var validHostSortColumns = map[string]string{
-	"ip_address": "h.ip_address",
-	"hostname":   "h.hostname",
-	"os_family":  "h.os_family",
-	"status":     "h.status",
-	"last_seen":  "h.last_seen",
-	"first_seen": "h.first_seen",
-	"vendor":     "h.vendor",
+	sortColIPAddress:     "h.ip_address",
+	filterFieldHostname:  filterColHostname,
+	filterFieldOSFamily:  filterColOSFamily,
+	filterFieldStatus:    filterColStatus,
+	filterFieldLastSeen:  filterColLastSeen,
+	filterFieldFirstSeen: filterColFirstSeen,
+	filterFieldVendor:    filterColVendor,
 	// Aggregate aliases from the SELECT clause — valid in PostgreSQL ORDER BY.
 	// These return NULL for unscanned hosts (see CASE WHEN below), so NULLS LAST
 	// naturally pushes them to the bottom without any workaround.
-	"open_ports":           "open_ports",
-	"scan_count":           "scan_count",
-	"response_time_ms":     "h.response_time_ms",
-	"response_time_avg_ms": "h.response_time_avg_ms",
+	sortColOpenPorts:          sortColOpenPorts,
+	filterFieldScanCount:      filterFieldScanCount,
+	filterFieldResponseTimeMS: filterColResponseTimeMS,
+	sortColResponseTimeAvgMS:  filterColResponseTimeAvgMS,
 }
 
 // ListHosts retrieves hosts with filtering and pagination.
@@ -398,7 +406,7 @@ func (r *HostRepository) CreateHost(ctx context.Context, input CreateHostInput) 
 	now := time.Now().UTC()
 
 	// Start with required columns.
-	columns := []string{"id", "ip_address", "first_seen", "last_seen", "ignore_scanning"}
+	columns := []string{"id", sortColIPAddress, filterFieldFirstSeen, filterFieldLastSeen, sortColIgnoreScanning}
 	placeholders := []string{"$1", "$2", "$3", "$4", "$5"}
 	args := []interface{}{hostID, input.IPAddress, now, now, input.IgnoreScanning}
 	argIndex := 6
@@ -413,12 +421,12 @@ func (r *HostRepository) CreateHost(ctx context.Context, input CreateHostInput) 
 		}
 	}
 
-	addStr("hostname", input.Hostname)
-	addStr("vendor", input.Vendor)
-	addStr("os_family", input.OSFamily)
+	addStr(filterFieldHostname, input.Hostname)
+	addStr(filterFieldVendor, input.Vendor)
+	addStr(filterFieldOSFamily, input.OSFamily)
 	addStr("os_name", input.OSName)
 	addStr("os_version", input.OSVersion)
-	addStr("status", input.Status)
+	addStr(filterFieldStatus, input.Status)
 
 	// Always include tags (defaults to empty array if nil/empty).
 	// Always include tags. Guard against nil so pq.Array does not serialize
@@ -696,15 +704,15 @@ func (r *HostRepository) UpdateHost(ctx context.Context, id uuid.UUID, input Upd
 		}
 	}
 
-	addStr("hostname", input.Hostname)
-	addStr("vendor", input.Vendor)
-	addStr("os_family", input.OSFamily)
+	addStr(filterFieldHostname, input.Hostname)
+	addStr(filterFieldVendor, input.Vendor)
+	addStr(filterFieldOSFamily, input.OSFamily)
 	addStr("os_name", input.OSName)
 	addStr("os_version", input.OSVersion)
-	addStr("status", input.Status)
+	addStr(filterFieldStatus, input.Status)
 
 	if input.IgnoreScanning != nil {
-		setParts = append(setParts, fmt.Sprintf("ignore_scanning = $%d", argIndex))
+		setParts = append(setParts, fmt.Sprintf("%s = $%d", sortColIgnoreScanning, argIndex))
 		args = append(args, *input.IgnoreScanning)
 		argIndex++
 	}
@@ -1031,10 +1039,10 @@ func buildHostFilters(filters *HostFilters) (whereClause string, args []interfac
 	var conditions []filterCondition
 
 	if filters.Status != "" {
-		conditions = append(conditions, filterCondition{"h.status", filters.Status})
+		conditions = append(conditions, filterCondition{filterColStatus, filters.Status})
 	}
 	if filters.OSFamily != "" {
-		conditions = append(conditions, filterCondition{"h.os_family", filters.OSFamily})
+		conditions = append(conditions, filterCondition{filterColOSFamily, filters.OSFamily})
 	}
 	whereClause, args = buildWhereClause(conditions)
 

--- a/internal/db/repository_ports.go
+++ b/internal/db/repository_ports.go
@@ -24,12 +24,19 @@ func NewPortRepository(db *DB) *PortRepository {
 	return &PortRepository{db: db}
 }
 
+const (
+	colPort     = "port"
+	colService  = "service"
+	colCategory = "category"
+	colProtocol = "protocol"
+)
+
 // validPortSortColumns maps safe sort keys to SQL column names.
 var validPortSortColumns = map[string]string{
-	"port":     "port",
-	"service":  "service",
-	"category": "category",
-	"protocol": "protocol",
+	colPort:     colPort,
+	colService:  colService,
+	colCategory: colCategory,
+	colProtocol: colProtocol,
 }
 
 // scanPortRow scans a single port_definitions row.

--- a/internal/db/repository_profile.go
+++ b/internal/db/repository_profile.go
@@ -28,13 +28,15 @@ func NewProfileRepository(db *DB) *ProfileRepository {
 	return &ProfileRepository{db: db}
 }
 
+const colPriority = "priority"
+
 // validProfileSortColumns maps API sort keys to safe SQL column expressions.
 var validProfileSortColumns = map[string]string{
-	"name":       "name",
-	"scan_type":  "scan_type",
-	"created_at": "created_at",
-	"updated_at": "updated_at",
-	"priority":   "priority",
+	colName:      colName,
+	colScanType:  colScanType,
+	colCreatedAt: colCreatedAt,
+	colUpdatedAt: colUpdatedAt,
+	colPriority:  colPriority,
 }
 
 // scanProfileRow scans a single profile row from *sql.Rows into a *ScanProfile.
@@ -370,7 +372,7 @@ func buildProfileUpdateSetParts(input UpdateProfileInput) (setParts []string, ar
 	}
 
 	addStr("name", input.Name)
-	addStr("description", input.Description)
+	addStr(colDescription, input.Description)
 	addStr("scan_type", input.ScanType)
 	addStr("ports", input.Ports)
 	addStr("timing", input.Timing)

--- a/internal/db/repository_scan.go
+++ b/internal/db/repository_scan.go
@@ -26,6 +26,24 @@ const (
 	sortOrderDESC = "DESC"
 )
 
+// colName constants are DB column name strings shared across repository files.
+const (
+	colCreatedAt      = "created_at"
+	colUpdatedAt      = "updated_at"
+	colStartedAt      = "started_at"
+	colCompletedAt    = "completed_at"
+	colStatus         = "status"
+	colName           = "name"
+	colDescription    = "description"
+	colScanType       = "scan_type"
+	colOSDetection    = "os_detection"
+	colEnabled        = "enabled"
+	colCronExpression = "cron_expression"
+	colNextRun        = "next_run"
+	colLastRun        = "last_run"
+	colNullJSON       = "null"
+)
+
 // isHostTarget reports whether target represents a single host: a bare IP
 // address, a /32 (IPv4) / /128 (IPv6) CIDR, or a DNS hostname.
 // Such targets must not be stored as rows in the networks table;
@@ -181,11 +199,11 @@ func processScanRow(rows *sql.Rows) (*Scan, error) {
 
 // ListScans retrieves scans with filtering and pagination.
 var validScanSortColumns = map[string]string{
-	"status":       "sj.status",
-	"created_at":   "sj.created_at",
-	"started_at":   "sj.started_at",
-	"completed_at": "sj.completed_at",
-	"scan_type":    "COALESCE(sp.scan_type, sj.execution_details->>'scan_type', n.scan_type, '')",
+	colStatus:      "sj.status",
+	colCreatedAt:   "sj.created_at",
+	colStartedAt:   "sj.started_at",
+	colCompletedAt: "sj.completed_at",
+	colScanType:    "COALESCE(sp.scan_type, sj.execution_details->>'scan_type', n.scan_type, '')",
 }
 
 func (r *ScanRepository) ListScans(
@@ -341,7 +359,7 @@ func createScanJob(ctx context.Context, tx *sql.Tx, jobID uuid.UUID, networkID *
 	profileID *string, now time.Time, osDetection bool, allTargets []string,
 	name, description, ports, scanType string, source *string) error {
 	details := map[string]interface{}{
-		"os_detection": osDetection,
+		colOSDetection: osDetection,
 	}
 
 	// Always persist the target list for host-only scans; also persist when
@@ -355,7 +373,7 @@ func createScanJob(ctx context.Context, tx *sql.Tx, jobID uuid.UUID, networkID *
 	// in execution_details so it is available to GetScan and ListScans.
 	if networkID == nil {
 		details["name"] = name
-		details["description"] = description
+		details[colDescription] = description
 		details["ports"] = ports
 		details["scan_type"] = scanType
 	}
@@ -392,7 +410,7 @@ func buildScanResponse(jobID uuid.UUID, name, description string, targets []stri
 		Targets:     targets,
 		ScanType:    scanType,
 		Ports:       ports,
-		Status:      "pending",
+		Status:      ScanJobStatusPending,
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -555,7 +573,7 @@ func (r *ScanRepository) GetScan(ctx context.Context, id uuid.UUID) (*Scan, erro
 	scan.ScanType = scanType.String
 	scan.Ports = ports.String
 	scan.Targets = scanTargetsFromExecDetails(execDetailsStr.String, networkCIDR.String)
-	scan.Options = map[string]interface{}{"os_detection": osDetection}
+	scan.Options = map[string]interface{}{colOSDetection: osDetection}
 
 	if profileID != nil {
 		scan.ProfileID = profileID
@@ -769,7 +787,7 @@ func (r *ScanRepository) DeleteScan(ctx context.Context, id uuid.UUID) error {
 	if err = tx.QueryRowContext(ctx, "SELECT status FROM scan_jobs WHERE id = $1", id).Scan(&status); err != nil {
 		return sanitizeDBError("get scan status", err)
 	}
-	if status == "running" {
+	if status == ScanJobStatusRunning {
 		return errors.ErrConflictWithReason("scan", "cannot delete a running scan; stop it first")
 	}
 

--- a/internal/db/repository_schedule.go
+++ b/internal/db/repository_schedule.go
@@ -113,12 +113,12 @@ func buildScheduleSetParts(input UpdateScheduleInput) (setParts []string, args [
 
 // validScheduleSortColumns maps API sort keys to safe SQL column expressions.
 var validScheduleSortColumns = map[string]string{
-	"name":            "name",
-	"enabled":         "enabled",
-	"cron_expression": "cron_expression",
-	"next_run":        "next_run",
-	"last_run":        "last_run",
-	"created_at":      "created_at",
+	colName:           colName,
+	colEnabled:        colEnabled,
+	colCronExpression: colCronExpression,
+	colNextRun:        colNextRun,
+	colLastRun:        colLastRun,
+	colCreatedAt:      colCreatedAt,
 }
 
 // ListSchedules retrieves schedules with filtering and pagination.

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -32,14 +32,20 @@ const (
 	minTimeout            = 30 * time.Second
 	timeoutMultiplierBase = 6.0
 	timeoutMultiplierStep = 2.0
-	// SQL error constants
-
 	timeoutMultiplierMax  = 50.0
 	timeoutDivisor        = 100.0
 	maxHostBits           = 24
 	rfc3021NetworkSize    = 31
 	singleHostNetworkSize = 32
 	minNmapOutputFields   = 5
+
+	methodDNS        = "dns"
+	methodTCPConnect = "tcp_connect"
+	methodTCP        = "tcp"
+	methodPing       = "ping"
+	methodICMP       = "icmp"
+	methodARP        = "arp"
+	addrTypeMac      = "mac"
 )
 
 // Engine handles network discovery operations.
@@ -172,7 +178,7 @@ func (e *Engine) ScanNetwork(ctx context.Context, cfg *Config) (int, error) {
 
 	var discovered []Result
 	var scanErr error
-	if cfg.Method == "dns" {
+	if cfg.Method == methodDNS {
 		discovered, scanErr = e.dnsScan(ctx, *ipnet, maxHosts)
 	} else {
 		discovered, scanErr = e.nmapScan(ctx, *ipnet, maxHosts, cfg)
@@ -260,7 +266,7 @@ func (e *Engine) runDiscovery(ctx context.Context, job *db.DiscoveryJob, config 
 
 	var discoveredHosts []Result
 	var scanErr error
-	if config.Method == "dns" {
+	if config.Method == methodDNS {
 		discoveredHosts, scanErr = e.dnsScan(ctx, job.Network.IPNet, maxHosts)
 	} else {
 		discoveredHosts, scanErr = e.nmapScan(ctx, job.Network.IPNet, maxHosts, config)
@@ -446,13 +452,13 @@ func (e *Engine) buildNmapLibraryOptions(targets []string, config *Config, timeo
 
 	// Add method-specific options
 	switch config.Method {
-	case "tcp", "tcp_connect":
+	case methodTCP, methodTCPConnect:
 		// TCP SYN ping on common ports
 		options = append(options, nmap.WithSYNDiscovery("22", "80", "443", "8080", "8022", "8379"))
-	case "ping", "icmp":
+	case methodPing, methodICMP:
 		// ICMP echo ping
 		options = append(options, nmap.WithICMPEchoDiscovery())
-	case "arp":
+	case methodARP:
 		// ARP ping for local networks
 		options = append(options, nmap.WithCustomArguments("-PR")) //nolint:staticcheck
 	}
@@ -529,7 +535,7 @@ func (e *Engine) convertNmapResultsToDiscovery(nmapResult *nmap.Run, method stri
 		// Extract MAC address and vendor from nmap results.
 		// For ARP scans nmap populates the Vendor field from its built-in OUI DB.
 		for _, addr := range host.Addresses {
-			if addr.AddrType == "mac" {
+			if addr.AddrType == addrTypeMac {
 				result.MACAddress = addr.Addr
 				if addr.Vendor != "" {
 					result.Vendor = addr.Vendor

--- a/internal/discovery/dns_sweep.go
+++ b/internal/discovery/dns_sweep.go
@@ -43,7 +43,7 @@ func dnsSweep(ctx context.Context, ipnet net.IPNet, resolver *internaldns.Resolv
 		results = append(results, Result{
 			IPAddress: ip,
 			Status:    "up",
-			Method:    "dns",
+			Method:    methodDNS,
 		})
 		slog.Debug("dns sweep: PTR found", "ip", ipStr, "hostname", hostname)
 	}

--- a/internal/enrichment/banner.go
+++ b/internal/enrichment/banner.go
@@ -40,6 +40,17 @@ const (
 	serviceSSH   = "ssh"
 	serviceHTTP  = "http"
 	serviceHTTPS = "https"
+	serviceSMTP  = "smtp"
+	serviceFTP   = "ftp"
+	servicePOP3  = "pop3"
+	serviceIMAP  = "imap"
+
+	srvProtoTCP = "tcp"
+
+	tlsVersion10 = "TLS 1.0"
+	tlsVersion11 = "TLS 1.1"
+	tlsVersion12 = "TLS 1.2"
+	tlsVersion13 = "TLS 1.3"
 )
 
 // tlsPorts is the set of port numbers that should receive a TLS/HTTPS probe.
@@ -51,7 +62,7 @@ var tlsPorts = map[int]bool{
 // httpServices is the set of nmap service names that trigger an HTTP probe
 // on non-TLS ports.
 var httpServices = map[string]bool{
-	"http": true, "http-alt": true, "http-proxy": true,
+	serviceHTTP: true, "http-alt": true, "http-proxy": true,
 	"https-alt": true, "http-mgmt": true,
 }
 
@@ -367,7 +378,7 @@ func (g *BannerGrabber) grabTLS(ctx context.Context, t BannerTarget, port int, a
 func zgrabHTTPScanner(port int, useHTTPS bool) (*zgrabhttp.Scanner, *zgrab2.DialerGroup, error) {
 	flags := &zgrabhttp.Flags{
 		BaseFlags: zgrab2.BaseFlags{
-			Port:           uint(port), //nolint:gosec // port range is 1-65535
+			Port:           uint(port),
 			ConnectTimeout: bannerDialTimeout,
 			TargetTimeout:  bannerDialTimeout + bannerReadTimeout,
 		},
@@ -406,7 +417,7 @@ func (g *BannerGrabber) grabZGrabHTTPS(ctx context.Context, t BannerTarget, port
 	if ip == nil {
 		return fmt.Errorf("invalid IP: %s", t.IP)
 	}
-	target := &zgrab2.ScanTarget{IP: ip, Port: uint(port)} //nolint:gosec
+	target := &zgrab2.ScanTarget{IP: ip, Port: uint(port)}
 
 	_, result, scanErr := scanner.Scan(ctx, dialGroup, target)
 	httpResults, ok := result.(*zgrabhttp.Results)
@@ -444,7 +455,7 @@ func (g *BannerGrabber) grabZGrabHTTP(ctx context.Context, t BannerTarget, port 
 	if ip == nil {
 		return fmt.Errorf("invalid IP: %s", t.IP)
 	}
-	target := &zgrab2.ScanTarget{IP: ip, Port: uint(port)} //nolint:gosec
+	target := &zgrab2.ScanTarget{IP: ip, Port: uint(port)}
 
 	_, result, scanErr := scanner.Scan(ctx, dialGroup, target)
 	httpResults, ok := result.(*zgrabhttp.Results)
@@ -718,10 +729,10 @@ func buildTLSSummary(c *db.Certificate) string {
 // portServiceHints maps well-known port numbers to their service names for
 // use when banner text doesn't provide enough signal.
 var portServiceHints = map[int]string{
-	21: "ftp", 22: serviceSSH,
-	25: "smtp", 110: "pop3", 143: "imap",
-	465: "smtp", 587: "smtp",
-	993: "imap", 995: "pop3",
+	21: serviceFTP, 22: serviceSSH,
+	25: serviceSMTP, 110: servicePOP3, 143: serviceIMAP,
+	465: serviceSMTP, 587: serviceSMTP,
+	993: serviceIMAP, 995: servicePOP3,
 }
 
 // parseServiceFromBanner applies simple heuristics to identify the service and
@@ -742,14 +753,14 @@ func parseBannerText(lower, raw string, port int) (service, version string) {
 			version = strings.TrimPrefix(parts[0], "SSH-2.0-")
 		}
 	case strings.HasPrefix(lower, "220 ") && strings.Contains(lower, "ftp"):
-		service, version = "ftp", raw
+		service, version = serviceFTP, raw
 	case strings.HasPrefix(lower, "220 ") &&
 		(strings.Contains(lower, "smtp") || strings.Contains(lower, "mail")):
-		service = "smtp"
+		service = serviceSMTP
 	case strings.HasPrefix(lower, "+ok"):
-		service = "pop3"
+		service = servicePOP3
 	case strings.HasPrefix(lower, "* ok"):
-		service = "imap"
+		service = serviceIMAP
 	case strings.HasPrefix(lower, "http/") || strings.HasPrefix(lower, "http "):
 		service = serviceHTTP
 	default:
@@ -785,13 +796,13 @@ func keyTypeFromPublicKey(pub any) string {
 func tlsVersionString(v uint16) string {
 	switch v {
 	case tls.VersionTLS10:
-		return "TLS 1.0"
+		return tlsVersion10
 	case tls.VersionTLS11:
-		return "TLS 1.1"
+		return tlsVersion11
 	case tls.VersionTLS12:
-		return "TLS 1.2"
+		return tlsVersion12
 	case tls.VersionTLS13:
-		return "TLS 1.3"
+		return tlsVersion13
 	default:
 		return fmt.Sprintf("TLS 0x%04X", v)
 	}

--- a/internal/enrichment/dns.go
+++ b/internal/enrichment/dns.go
@@ -193,15 +193,15 @@ func (e *DNSEnricher) forwardRecords(ctx context.Context, hostID uuid.UUID, host
 	// net.Resolver.LookupSRV prepends underscores automatically, so the service
 	// and proto values must NOT include a leading underscore.
 	srvServices := []struct{ service, proto string }{
-		{"http", "tcp"},
-		{"https", "tcp"},
-		{"smtp", "tcp"},
-		{"imap", "tcp"},
-		{"imaps", "tcp"},
-		{"ldap", "tcp"},
-		{"ldaps", "tcp"},
-		{"xmpp-client", "tcp"},
-		{"xmpp-server", "tcp"},
+		{serviceHTTP, srvProtoTCP},
+		{serviceHTTPS, srvProtoTCP},
+		{serviceSMTP, srvProtoTCP},
+		{serviceIMAP, srvProtoTCP},
+		{"imaps", srvProtoTCP},
+		{"ldap", srvProtoTCP},
+		{"ldaps", srvProtoTCP},
+		{"xmpp-client", srvProtoTCP},
+		{"xmpp-server", srvProtoTCP},
 	}
 	for _, s := range srvServices {
 		_, addrs, err := e.netResolver.LookupSRV(ctx, s.service, s.proto, hostname)

--- a/internal/enrichment/snmp.go
+++ b/internal/enrichment/snmp.go
@@ -59,6 +59,12 @@ const (
 	ifOperStatusLowerLayerDown = 7
 )
 
+const (
+	ifStatusUp      = "up"
+	ifStatusDown    = "down"
+	ifStatusUnknown = "unknown"
+)
+
 var systemOIDs = []string{
 	oidSysDescr,
 	oidSysUptime,
@@ -242,13 +248,13 @@ func parseIfPDUs(vars []gosnmp.SnmpPDU, count int) map[int]*ifData {
 func ifStatusString(code int64) string {
 	switch code {
 	case ifOperStatusUp:
-		return "up"
+		return ifStatusUp
 	case ifOperStatusDown:
-		return "down"
+		return ifStatusDown
 	case ifOperStatusTesting:
 		return "testing"
 	case ifOperStatusUnknown:
-		return "unknown"
+		return ifStatusUnknown
 	case ifOperStatusDormant:
 		return "dormant"
 	case ifOperStatusNotPresent:
@@ -256,7 +262,7 @@ func ifStatusString(code int64) string {
 	case ifOperStatusLowerLayerDown:
 		return "lowerLayerDown"
 	default:
-		return "unknown"
+		return ifStatusUnknown
 	}
 }
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -13,9 +13,14 @@ import (
 )
 
 const (
-	// File permissions for directories and log files.
 	logDirPerm  = 0750
 	logFilePerm = 0600
+
+	outputStdout    = "stdout"
+	outputStderr    = "stderr"
+	componentDB     = "database"
+	componentDaemon = "daemon"
+	attrKeyError    = "error"
 )
 
 // LogLevel represents the available log levels.
@@ -49,7 +54,7 @@ func DefaultConfig() Config {
 	return Config{
 		Level:     LevelInfo,
 		Format:    FormatText,
-		Output:    "stdout",
+		Output:    outputStdout,
 		AddSource: false,
 	}
 }
@@ -80,9 +85,9 @@ func New(cfg Config) (*Logger, error) {
 	// Determine output writer
 	var writer io.Writer
 	switch cfg.Output {
-	case "stdout":
+	case outputStdout:
 		writer = os.Stdout
-	case "stderr":
+	case outputStderr:
 		writer = os.Stderr
 	default:
 		// Assume it's a file path
@@ -141,7 +146,7 @@ func (l *Logger) WithFields(fields ...any) *Logger {
 
 // WithComponent adds a component field to the logger.
 func (l *Logger) WithComponent(component string) *Logger {
-	return l.WithFields("component", component)
+	return l.WithFields(attrKeyComponent, component)
 }
 
 // WithScanID adds a scan ID field to the logger.
@@ -167,7 +172,7 @@ func (l *Logger) InfoScan(msg, target string, fields ...any) {
 
 // ErrorScan logs scan-related errors.
 func (l *Logger) ErrorScan(msg, target string, err error, fields ...any) {
-	allFields := append([]any{"target", target, "error", err}, fields...)
+	allFields := append([]any{"target", target, attrKeyError, err}, fields...)
 	l.Error(msg, allFields...)
 }
 
@@ -179,31 +184,31 @@ func (l *Logger) InfoDiscovery(msg, network string, fields ...any) {
 
 // ErrorDiscovery logs discovery-related errors.
 func (l *Logger) ErrorDiscovery(msg, network string, err error, fields ...any) {
-	allFields := append([]any{"network", network, "error", err}, fields...)
+	allFields := append([]any{"network", network, attrKeyError, err}, fields...)
 	l.Error(msg, allFields...)
 }
 
 // InfoDatabase logs database-related information.
 func (l *Logger) InfoDatabase(msg string, fields ...any) {
-	allFields := append([]any{"component", "database"}, fields...)
+	allFields := append([]any{attrKeyComponent, componentDB}, fields...)
 	l.Info(msg, allFields...)
 }
 
 // ErrorDatabase logs database-related errors.
 func (l *Logger) ErrorDatabase(msg string, err error, fields ...any) {
-	allFields := append([]any{"component", "database", "error", err}, fields...)
+	allFields := append([]any{attrKeyComponent, componentDB, attrKeyError, err}, fields...)
 	l.Error(msg, allFields...)
 }
 
 // InfoDaemon logs daemon-related information.
 func (l *Logger) InfoDaemon(msg string, fields ...any) {
-	allFields := append([]any{"component", "daemon"}, fields...)
+	allFields := append([]any{attrKeyComponent, componentDaemon}, fields...)
 	l.Info(msg, allFields...)
 }
 
 // ErrorDaemon logs daemon-related errors.
 func (l *Logger) ErrorDaemon(msg string, err error, fields ...any) {
-	allFields := append([]any{"component", "daemon", "error", err}, fields...)
+	allFields := append([]any{attrKeyComponent, componentDaemon, attrKeyError, err}, fields...)
 	l.Error(msg, allFields...)
 }
 

--- a/internal/logging/ringbuffer.go
+++ b/internal/logging/ringbuffer.go
@@ -20,6 +20,11 @@ const (
 	levelError = 3
 )
 
+const (
+	attrKeyComponent = "component"
+	attrKeyHandler   = "handler"
+)
+
 // LogEntry is a single captured log record stored in the ring buffer.
 type LogEntry struct {
 	Time      time.Time         `json:"time"`
@@ -229,7 +234,7 @@ func (h *ringBufferHandler) Handle(_ context.Context, record slog.Record) error 
 	// Pre-attached attrs (from logger.With(...)).
 	for _, a := range h.attrs {
 		switch a.Key {
-		case "component", "handler":
+		case attrKeyComponent, attrKeyHandler:
 			entry.Component = a.Value.String()
 		default:
 			entry.Attrs[a.Key] = a.Value.String()
@@ -239,7 +244,7 @@ func (h *ringBufferHandler) Handle(_ context.Context, record slog.Record) error 
 	// Per-record attrs.
 	record.Attrs(func(a slog.Attr) bool {
 		switch a.Key {
-		case "component", "handler":
+		case attrKeyComponent, attrKeyHandler:
 			entry.Component = a.Value.String()
 		default:
 			entry.Attrs[a.Key] = a.Value.String()
@@ -332,13 +337,13 @@ func (h *teeHandler) WithGroup(name string) slog.Handler {
 // comparisons. Unknown strings are treated as debug (0 = show everything).
 func parseLevel(level string) int {
 	switch strings.ToLower(level) {
-	case "debug":
+	case string(LevelDebug):
 		return levelDebug
-	case "info":
+	case string(LevelInfo):
 		return levelInfo
-	case "warn", "warning":
+	case string(LevelWarn), "warning":
 		return levelWarn
-	case "error":
+	case string(LevelError):
 		return levelError
 	default:
 		return levelDebug

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -14,15 +14,17 @@ import (
 )
 
 const (
-	// Namespace for all scanorama metrics
 	namespace = "scanorama"
 
-	// Subsystems
 	subsystemScan      = "scan"
 	subsystemDiscovery = "discovery"
 	subsystemDatabase  = "database"
 	subsystemSystem    = "system"
 	subsystemAPI       = "api"
+
+	labelPath      = "path"
+	labelErrorType = "error_type"
+	metricErrTotal = "errors_total"
 )
 
 // PrometheusMetrics holds all Prometheus metric collectors
@@ -104,7 +106,7 @@ func (pm *PrometheusMetrics) initScanMetrics() {
 			Name:      "total",
 			Help:      "Total number of scans performed by type and status",
 		},
-		[]string{"scan_type", "status"},
+		[]string{LabelScanType, LabelStatus},
 	)
 
 	pm.scanDuration = prometheus.NewHistogramVec(
@@ -115,17 +117,17 @@ func (pm *PrometheusMetrics) initScanMetrics() {
 			Help:      "Duration of scan operations in seconds",
 			Buckets:   []float64{0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0, 600.0},
 		},
-		[]string{"scan_type"},
+		[]string{LabelScanType},
 	)
 
 	pm.scanErrors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: subsystemScan,
-			Name:      "errors_total",
+			Name:      metricErrTotal,
 			Help:      "Total number of scan errors by type and error",
 		},
-		[]string{"scan_type", "error_type"},
+		[]string{LabelScanType, labelErrorType},
 	)
 
 	pm.portsScanned = prometheus.NewCounterVec(
@@ -135,7 +137,7 @@ func (pm *PrometheusMetrics) initScanMetrics() {
 			Name:      "ports_total",
 			Help:      "Total number of ports scanned",
 		},
-		[]string{"scan_type", "port_status"},
+		[]string{LabelScanType, "port_status"},
 	)
 
 	pm.hostsScanned = prometheus.NewCounterVec(
@@ -145,7 +147,7 @@ func (pm *PrometheusMetrics) initScanMetrics() {
 			Name:      "hosts_total",
 			Help:      "Total number of hosts scanned",
 		},
-		[]string{"scan_type", "host_status"},
+		[]string{LabelScanType, "host_status"},
 	)
 
 	pm.activeScans = prometheus.NewGauge(
@@ -195,7 +197,7 @@ func (pm *PrometheusMetrics) initDiscoveryMetrics() {
 			Name:      "total",
 			Help:      "Total number of discovery operations by method and status",
 		},
-		[]string{"method", "status"},
+		[]string{LabelMethod, LabelStatus},
 	)
 
 	pm.discoveryDuration = prometheus.NewHistogramVec(
@@ -206,17 +208,17 @@ func (pm *PrometheusMetrics) initDiscoveryMetrics() {
 			Help:      "Duration of discovery operations in seconds",
 			Buckets:   []float64{1.0, 5.0, 10.0, 30.0, 60.0, 300.0, 600.0, 1800.0},
 		},
-		[]string{"method"},
+		[]string{LabelMethod},
 	)
 
 	pm.discoveryErrors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: subsystemDiscovery,
-			Name:      "errors_total",
+			Name:      metricErrTotal,
 			Help:      "Total number of discovery errors by method and error type",
 		},
-		[]string{"method", "error_type"},
+		[]string{LabelMethod, labelErrorType},
 	)
 
 	pm.hostsDiscovered = prometheus.NewCounterVec(
@@ -226,7 +228,7 @@ func (pm *PrometheusMetrics) initDiscoveryMetrics() {
 			Name:      "hosts_total",
 			Help:      "Total number of hosts discovered",
 		},
-		[]string{"method", "network"},
+		[]string{LabelMethod, LabelNetwork},
 	)
 
 	pm.activeDiscovery = prometheus.NewGauge(
@@ -248,7 +250,7 @@ func (pm *PrometheusMetrics) initDatabaseMetrics() {
 			Name:      "queries_total",
 			Help:      "Total number of database queries by operation and status",
 		},
-		[]string{"operation", "status"},
+		[]string{LabelOperation, LabelStatus},
 	)
 
 	pm.dbQueryDuration = prometheus.NewHistogramVec(
@@ -259,7 +261,7 @@ func (pm *PrometheusMetrics) initDatabaseMetrics() {
 			Help:      "Duration of database queries in seconds",
 			Buckets:   []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0},
 		},
-		[]string{"operation"},
+		[]string{LabelOperation},
 	)
 
 	pm.dbConnections = prometheus.NewGauge(
@@ -275,10 +277,10 @@ func (pm *PrometheusMetrics) initDatabaseMetrics() {
 		prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: subsystemDatabase,
-			Name:      "errors_total",
+			Name:      metricErrTotal,
 			Help:      "Total number of database errors by operation and error type",
 		},
-		[]string{"operation", "error_type"},
+		[]string{LabelOperation, labelErrorType},
 	)
 }
 
@@ -291,7 +293,7 @@ func (pm *PrometheusMetrics) initAPIMetrics() {
 			Name:      "requests_total",
 			Help:      "Total number of HTTP requests by method, path and status",
 		},
-		[]string{"method", "path", "status"},
+		[]string{LabelMethod, labelPath, LabelStatus},
 	)
 
 	pm.httpDuration = prometheus.NewHistogramVec(
@@ -302,17 +304,17 @@ func (pm *PrometheusMetrics) initAPIMetrics() {
 			Help:      "Duration of HTTP requests in seconds",
 			Buckets:   []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 2.0, 5.0},
 		},
-		[]string{"method", "path"},
+		[]string{LabelMethod, labelPath},
 	)
 
 	pm.httpErrors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: subsystemAPI,
-			Name:      "errors_total",
+			Name:      metricErrTotal,
 			Help:      "Total number of HTTP errors by method, path and error type",
 		},
-		[]string{"method", "path", "error_type"},
+		[]string{LabelMethod, labelPath, labelErrorType},
 	)
 }
 

--- a/internal/scanning/jobs.go
+++ b/internal/scanning/jobs.go
@@ -11,6 +11,8 @@ import (
 	"github.com/anstrom/scanorama/internal/db"
 )
 
+const jobTypeScan = "scan"
+
 // Job is implemented by any unit of work the ScanQueue can execute.
 // Both scan and discovery jobs implement this interface, allowing them to share
 // the same worker pool and appear uniformly in the admin worker view.
@@ -62,7 +64,7 @@ func NewScanJob(
 func (j *ScanJob) ID() string { return j.id }
 
 // Type implements Job.
-func (j *ScanJob) Type() string { return "scan" }
+func (j *ScanJob) Type() string { return jobTypeScan }
 
 // Target implements Job.
 func (j *ScanJob) Target() string {

--- a/internal/scanning/nse.go
+++ b/internal/scanning/nse.go
@@ -9,6 +9,15 @@ import (
 	nmap "github.com/Ullaakut/nmap/v3"
 )
 
+const (
+	nseScriptBanner    = "banner"
+	nseScriptHTTPTitle = "http-title"
+	nseScriptSSLCert   = "ssl-cert"
+	nseScriptSMBOSDisc = "smb-os-discovery"
+	nseScriptNBStat    = "nbstat"
+	osWindows          = "Windows"
+)
+
 // parsePortScripts extracts structured NSE data from nmap port-level scripts.
 // Returns nil when no scripts are present or none contain actionable data.
 func parsePortScripts(scripts []nmap.Script) *NSEData {
@@ -19,13 +28,13 @@ func parsePortScripts(scripts []nmap.Script) *NSEData {
 	for i := range scripts {
 		s := &scripts[i]
 		switch s.ID {
-		case "banner":
+		case nseScriptBanner:
 			out.Banner = strings.TrimSpace(s.Output)
-		case "http-title":
+		case nseScriptHTTPTitle:
 			out.HTTPTitle = extractHTTPTitle(s)
 		case "ssh-hostkey":
 			out.SSHKeyFingerprint = extractSSHFingerprint(s)
-		case "ssl-cert":
+		case nseScriptSSLCert:
 			out.SSLCert = parseSSLCert(s)
 		}
 	}
@@ -42,9 +51,9 @@ func parseHostScripts(scripts []nmap.Script, host *Host) {
 	for i := range scripts {
 		s := &scripts[i]
 		switch s.ID {
-		case "smb-os-discovery":
+		case nseScriptSMBOSDisc:
 			applySSBOSDiscovery(s, host)
-		case "nbstat":
+		case nseScriptNBStat:
 			if name := findElem(s.Elements, "NetBIOS_Computer_Name"); name != "" && host.SMBHostname == "" {
 				host.SMBHostname = name
 			}
@@ -125,7 +134,7 @@ func applySSBOSDiscovery(s *nmap.Script, host *Host) {
 			if host.OSAccuracy == 0 && host.OSName == "" {
 				host.OSName = e.Value
 				host.OSAccuracy = 60 // SMB OS is reliable but not fingerprint-grade
-				host.OSFamily = "Windows"
+				host.OSFamily = osWindows
 			}
 		case "domain":
 			host.SMBDomain = e.Value

--- a/internal/scanning/resource_manager.go
+++ b/internal/scanning/resource_manager.go
@@ -10,6 +10,8 @@ import (
 const (
 	// maxScanDurationMinutes defines the maximum allowed scan duration before considering it potentially hung.
 	maxScanDurationMinutes = 30
+
+	statsKeyClosed = "closed"
 )
 
 // ResourceManager manages scan resources and concurrency limits.
@@ -167,6 +169,6 @@ func (rm *FixedResourceManager) GetStats() map[string]interface{} {
 		"active_scans":    len(rm.activeScans),
 		"available_slots": rm.capacity - len(rm.activeScans),
 		"is_healthy":      rm.IsHealthy(),
-		"closed":          rm.closed,
+		statsKeyClosed:    rm.closed,
 	}
 }

--- a/internal/scanning/scan.go
+++ b/internal/scanning/scan.go
@@ -55,6 +55,19 @@ const (
 	portStateClosed   = "closed"
 	portStateFiltered = "filtered"
 	portStateUnknown  = "unknown"
+
+	// Nmap hostname type constants.
+	hostnameTypeUser = "user"
+	hostnameTypePTR  = "PTR"
+
+	// loopbackHost is the well-known single-label loopback hostname.
+	loopbackHost = "localhost"
+
+	// Nmap timing template names.
+	timingParanoid = "paranoid"
+	timingPolite   = "polite"
+	timingNormal   = "normal"
+	timingInsane   = "insane"
 )
 
 // CalculateTimeout estimates a reasonable scan timeout based on the number of
@@ -396,15 +409,15 @@ func buildScanOptions(config *ScanConfig) []nmap.Option {
 // value is empty or unrecognized so the caller can apply its own fallback.
 func buildTimingOption(timing string) nmap.Option {
 	switch timing {
-	case "paranoid":
+	case timingParanoid:
 		return nmap.WithTimingTemplate(nmap.TimingSlowest)
-	case "polite":
+	case timingPolite:
 		return nmap.WithTimingTemplate(nmap.TimingSneaky)
-	case "normal":
+	case timingNormal:
 		return nmap.WithTimingTemplate(nmap.TimingNormal)
 	case scanTypeAggressive:
 		return nmap.WithTimingTemplate(nmap.TimingAggressive)
-	case "insane":
+	case timingInsane:
 		return nmap.WithTimingTemplate(nmap.TimingFastest)
 	default:
 		return nil
@@ -445,11 +458,11 @@ func convertNmapHost(h *nmap.Host) *Host {
 	// PTR record (type="PTR") from nmap's <hostnames> element.
 	// Prefer "user" so the name the operator typed is preserved over reverse DNS.
 	for _, hn := range h.Hostnames {
-		if hn.Type == "user" {
+		if hn.Type == hostnameTypeUser {
 			host.Hostname = hn.Name
 			break
 		}
-		if hn.Type == "PTR" && host.Hostname == "" {
+		if hn.Type == hostnameTypePTR && host.Hostname == "" {
 			host.Hostname = hn.Name
 		}
 	}
@@ -780,7 +793,7 @@ func parseTargetAddress(target string) (db.NetworkAddr, error) {
 		// Accept hostnames: either containing a dot (FQDNs like "example.com")
 		// or well-known single-label names like "localhost".
 		// Reject bare words that look neither like an IP nor a plausible hostname.
-		isHostname := strings.Contains(target, ".") || target == "localhost"
+		isHostname := strings.Contains(target, ".") || target == loopbackHost
 		if !isHostname {
 			return networkAddr, fmt.Errorf("invalid target address: %q is not a valid IP, CIDR, or hostname", target)
 		}
@@ -1100,7 +1113,7 @@ func runKnowledgeScoreUpdate(database *db.DB, hostIDs []uuid.UUID) {
 // hasSNMPPort reports whether port 161 UDP is open in a port list.
 func hasSNMPPort(ports []Port) bool {
 	for _, p := range ports {
-		if p.Number == snmpPort && p.Protocol == "udp" && p.State == portStateOpen {
+		if p.Number == snmpPort && p.Protocol == scanTypeUDP && p.State == portStateOpen {
 			return true
 		}
 	}

--- a/internal/scanning/types.go
+++ b/internal/scanning/types.go
@@ -12,6 +12,8 @@ import (
 const (
 	// Port validation constants.
 	expectedPortRangeParts = 2
+
+	opValidateConfig = "validate config"
 )
 
 // ExecError represents error types for scan operations.
@@ -70,21 +72,21 @@ type ScanConfig struct {
 // Validate checks if the scan configuration is valid.
 func (c *ScanConfig) Validate() error {
 	if len(c.Targets) == 0 {
-		return &ExecError{Op: "validate config", Err: fmt.Errorf("no targets specified")}
+		return &ExecError{Op: opValidateConfig, Err: fmt.Errorf("no targets specified")}
 	}
 	if c.Ports == "" {
-		return &ExecError{Op: "validate config", Err: fmt.Errorf("no ports specified")}
+		return &ExecError{Op: opValidateConfig, Err: fmt.Errorf("no ports specified")}
 	}
 	validScanTypes := map[string]bool{
-		"connect":       true,
-		"syn":           true,
-		"ack":           true,
-		"udp":           true,
-		"aggressive":    true,
-		"comprehensive": true,
+		scanTypeConnect:       true,
+		scanTypeSYN:           true,
+		scanTypeACK:           true,
+		scanTypeUDP:           true,
+		scanTypeAggressive:    true,
+		scanTypeComprehensive: true,
 	}
 	if !validScanTypes[c.ScanType] {
-		return &ExecError{Op: "validate config", Err: fmt.Errorf("invalid scan type: %s", c.ScanType)}
+		return &ExecError{Op: opValidateConfig, Err: fmt.Errorf("invalid scan type: %s", c.ScanType)}
 	}
 
 	if err := c.validateTargets(); err != nil {
@@ -100,7 +102,7 @@ func (c *ScanConfig) validateTargets() error {
 	for _, target := range c.Targets {
 		if strings.HasPrefix(target, "-") {
 			return &ExecError{
-				Op:  "validate config",
+				Op:  opValidateConfig,
 				Err: fmt.Errorf("invalid target %q: targets must not start with '-'", target),
 			}
 		}
@@ -144,27 +146,27 @@ func (c *ScanConfig) validatePortPart(part string) error {
 func (c *ScanConfig) validatePortRange(part string) error {
 	rangeParts := strings.Split(part, "-")
 	if len(rangeParts) != expectedPortRangeParts {
-		return &ExecError{Op: "validate config", Err: fmt.Errorf("invalid port range format: %s", part)}
+		return &ExecError{Op: opValidateConfig, Err: fmt.Errorf("invalid port range format: %s", part)}
 	}
 
 	start, err := strconv.Atoi(strings.TrimSpace(rangeParts[0]))
 	if err != nil {
-		return &ExecError{Op: "validate config", Err: fmt.Errorf("invalid start port: %s", rangeParts[0])}
+		return &ExecError{Op: opValidateConfig, Err: fmt.Errorf("invalid start port: %s", rangeParts[0])}
 	}
 	end, err := strconv.Atoi(strings.TrimSpace(rangeParts[1]))
 	if err != nil {
-		return &ExecError{Op: "validate config", Err: fmt.Errorf("invalid end port: %s", rangeParts[1])}
+		return &ExecError{Op: opValidateConfig, Err: fmt.Errorf("invalid end port: %s", rangeParts[1])}
 	}
 
 	if start < 0 || start > 65535 || end < 0 || end > 65535 {
 		return &ExecError{
-			Op:  "validate config",
+			Op:  opValidateConfig,
 			Err: fmt.Errorf("invalid port range: %s (must be 0-65535)", part),
 		}
 	}
 	if start > end {
 		return &ExecError{
-			Op:  "validate config",
+			Op:  opValidateConfig,
 			Err: fmt.Errorf("invalid port range: start port must be less than end port"),
 		}
 	}
@@ -175,10 +177,10 @@ func (c *ScanConfig) validatePortRange(part string) error {
 func (c *ScanConfig) validateSinglePort(part string) error {
 	port, err := strconv.Atoi(strings.TrimSpace(part))
 	if err != nil {
-		return &ExecError{Op: "validate config", Err: fmt.Errorf("invalid port: %s", part)}
+		return &ExecError{Op: opValidateConfig, Err: fmt.Errorf("invalid port: %s", part)}
 	}
 	if port < 0 || port > 65535 {
-		return &ExecError{Op: "validate config", Err: fmt.Errorf("invalid port: %d (must be 0-65535)", port)}
+		return &ExecError{Op: opValidateConfig, Err: fmt.Errorf("invalid port: %d (must be 0-65535)", port)}
 	}
 	return nil
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -30,6 +30,9 @@ const (
 	scanTimeoutNormal     = 900  // 15 min  - matches nmap T3 (normal)
 	scanTimeoutAggressive = 600  // 10 min  - matches nmap T4 (aggressive)
 	scanTimeoutInsane     = 300  // 5 min   - matches nmap T5 (insane)
+
+	actionEnabled  = "enabled"
+	actionDisabled = "disabled"
 )
 
 // Scheduler manages scheduled discovery and scanning jobs.
@@ -424,9 +427,9 @@ func (s *Scheduler) setJobEnabled(ctx context.Context, jobID uuid.UUID, enabled 
 	// Update in-memory config
 	job.Config.Enabled = enabled
 
-	action := "disabled"
+	action := actionDisabled
 	if enabled {
-		action = "enabled"
+		action = actionEnabled
 	}
 
 	log.Printf("Job '%s' %s", job.Config.Name, action)

--- a/internal/services/device_matcher.go
+++ b/internal/services/device_matcher.go
@@ -141,12 +141,12 @@ func (m *DeviceMatcher) autoAttach(ctx context.Context, host *db.Host, sc device
 		}
 	}
 	if host.MDNSName != nil && *host.MDNSName != "" {
-		if err := m.repo.UpsertKnownName(ctx, sc.deviceID, *host.MDNSName, "mdns"); err != nil {
+		if err := m.repo.UpsertKnownName(ctx, sc.deviceID, *host.MDNSName, string(SourceMDNS)); err != nil {
 			m.logger.Warn("device matcher: upsert known mdns name failed", "error", err)
 		}
 	}
 	if host.Hostname != nil && *host.Hostname != "" {
-		if err := m.repo.UpsertKnownName(ctx, sc.deviceID, *host.Hostname, "dns"); err != nil {
+		if err := m.repo.UpsertKnownName(ctx, sc.deviceID, *host.Hostname, string(SourceDNS)); err != nil {
 			m.logger.Warn("device matcher: upsert known dns name failed", "error", err)
 		}
 	}
@@ -190,11 +190,11 @@ func isGloballyAdministeredMAC(mac string) bool {
 func (m *DeviceMatcher) scoreNames(host *db.Host, sig db.DeviceSignals, sc *deviceScore) {
 	for _, known := range sig.KnownNames {
 		switch known.Source {
-		case "mdns":
+		case string(SourceMDNS):
 			if host.MDNSName != nil && strings.EqualFold(*host.MDNSName, known.Name) {
 				sc.add(weightMDNSName, "mDNS:"+known.Name)
 			}
-		case "dns":
+		case string(SourceDNS):
 			if host.Hostname != nil && strings.EqualFold(*host.Hostname, known.Name) {
 				sc.add(weightDNSName, "DNS:"+known.Name)
 			}

--- a/internal/services/identity.go
+++ b/internal/services/identity.go
@@ -23,6 +23,7 @@ const (
 	SourcePTR    Source = "ptr"
 	SourceCert   Source = "cert"
 	SourceIP     Source = "ip"
+	SourceDNS    Source = "dns"
 )
 
 // DefaultIdentityRankOrder matches the seeded identity.rank_order setting
@@ -31,7 +32,9 @@ const (
 //
 // Don't take &DefaultIdentityRankOrder — it's meant to be copied or ranged
 // over, not mutated.
-var DefaultIdentityRankOrder = []string{"mdns", "snmp", "ptr", "cert"}
+var DefaultIdentityRankOrder = []string{
+	string(SourceMDNS), string(SourceSNMP), string(SourcePTR), string(SourceCert),
+}
 
 const (
 	maxSNMPSysNameLen = 253
@@ -44,6 +47,9 @@ const (
 	confidencePTR    = 0.6
 	confidenceCert   = 0.5
 	confidenceIP     = 0.0
+
+	sysNameTooLong      = "sys_name too long"
+	sysNameNonPrintable = "sys_name contains non-printable characters"
 )
 
 // IdentityResolution is the single winning display name for a host.
@@ -225,11 +231,11 @@ func snmpCandidates(in IdentityInputs) []NameCandidate {
 
 func validateSNMPSysName(name string) (usable bool, reason string) {
 	if len(name) > maxSNMPSysNameLen {
-		return false, "sys_name too long"
+		return false, sysNameTooLong
 	}
 	for _, r := range name {
 		if r < minPrintableASCII || r > maxPrintableASCII {
-			return false, "sys_name contains non-printable characters"
+			return false, sysNameNonPrintable
 		}
 	}
 	return true, ""

--- a/internal/services/networks.go
+++ b/internal/services/networks.go
@@ -20,6 +20,15 @@ import (
 	apierrors "github.com/anstrom/scanorama/internal/errors"
 )
 
+const (
+	discoveryMethodPing = "ping"
+	discoveryMethodTCP  = "tcp"
+	discoveryMethodARP  = "arp"
+	discoveryMethodICMP = "icmp"
+
+	statsKeyTotal = "total"
+)
+
 // NetworkService manages network configuration and exclusions.
 type NetworkService struct {
 	database *db.DB
@@ -573,18 +582,18 @@ func (s *NetworkService) GetNetworkStats(ctx context.Context) (map[string]interf
 
 	return map[string]interface{}{
 		"networks": map[string]interface{}{
-			"total":        stats.TotalNetworks,
+			statsKeyTotal:  stats.TotalNetworks,
 			"active":       stats.ActiveNetworks,
 			"scan_enabled": stats.ScanEnabledNetworks,
 		},
 		"hosts": map[string]interface{}{
-			"total":  totalHosts,
-			"active": activeHosts,
+			statsKeyTotal: totalHosts,
+			"active":      activeHosts,
 		},
 		"exclusions": map[string]interface{}{
-			"total":   exclusionStats.TotalExclusions,
-			"global":  exclusionStats.GlobalExclusions,
-			"network": exclusionStats.NetworkExclusions,
+			statsKeyTotal: exclusionStats.TotalExclusions,
+			"global":      exclusionStats.GlobalExclusions,
+			"network":     exclusionStats.NetworkExclusions,
 		},
 	}, nil
 }
@@ -602,10 +611,10 @@ func (s *NetworkService) validateNetworkConfig(netConfig *config.NetworkConfig) 
 
 	// Validate method
 	validMethods := map[string]bool{
-		"ping": true,
-		"tcp":  true,
-		"arp":  true,
-		"icmp": true,
+		discoveryMethodPing: true,
+		discoveryMethodTCP:  true,
+		discoveryMethodARP:  true,
+		discoveryMethodICMP: true,
 	}
 	if netConfig.Method != "" && !validMethods[netConfig.Method] {
 		return fmt.Errorf("invalid discovery method: %s", netConfig.Method)
@@ -658,10 +667,10 @@ func (s *NetworkService) CreateNetwork(
 
 	// Validate method
 	validMethods := map[string]bool{
-		"ping": true,
-		"tcp":  true,
-		"arp":  true,
-		"icmp": true,
+		discoveryMethodPing: true,
+		discoveryMethodTCP:  true,
+		discoveryMethodARP:  true,
+		discoveryMethodICMP: true,
 	}
 	if !validMethods[method] {
 		return nil, fmt.Errorf("invalid discovery method: %s", method)
@@ -745,10 +754,10 @@ func (s *NetworkService) UpdateNetwork(
 
 	// Validate method
 	validMethods := map[string]bool{
-		"ping": true,
-		"tcp":  true,
-		"arp":  true,
-		"icmp": true,
+		discoveryMethodPing: true,
+		discoveryMethodTCP:  true,
+		discoveryMethodARP:  true,
+		discoveryMethodICMP: true,
 	}
 	if !validMethods[method] {
 		return nil, fmt.Errorf("invalid discovery method: %s", method)

--- a/internal/services/portresolver.go
+++ b/internal/services/portresolver.go
@@ -25,9 +25,9 @@ const maxPortNumber = 65535
 // stageDefaultPorts maps each stage name to its hardcoded fallback port string.
 // Values are the single-source constants defined in smartscan.go.
 var stageDefaultPorts = map[string]string{
-	"os_detection":        osDetectionPorts,
-	"identity_enrichment": identityEnrichmentPorts,
-	"refresh":             refreshPorts,
+	stageOSDetection:        osDetectionPorts,
+	stageIdentityEnrichment: identityEnrichmentPorts,
+	stageRefresh:            refreshPorts,
 }
 
 // portRangeRE detects nmap range notation (e.g. "1-1024") inside a port string.
@@ -96,7 +96,7 @@ func (r *PortListResolver) readBasePorts(ctx context.Context, stage string) stri
 	fallback, ok := stageDefaultPorts[stage]
 	if !ok {
 		r.logger.Warn("unknown stage passed to port resolver, using broad fallback", "stage", stage)
-		fallback = "1-1024"
+		fallback = refreshPorts
 	}
 
 	key := "smartscan." + stage + ".ports"

--- a/internal/services/scan.go
+++ b/internal/services/scan.go
@@ -29,6 +29,15 @@ const MaxTargetLength = 200
 // MaxTargetCount is the maximum number of targets allowed per scan.
 const MaxTargetCount = 100
 
+const (
+	scanTypeConnect       = "connect"
+	scanTypeSYN           = "syn"
+	scanTypeACK           = "ack"
+	scanTypeUDP           = "udp"
+	scanTypeAggressive    = "aggressive"
+	scanTypeComprehensive = "comprehensive"
+)
+
 // hostnameLabel matches a single DNS label: 1–63 chars, alphanumeric plus
 // interior hyphens, not starting or ending with a hyphen (RFC 1123).
 var hostnameLabel = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$`)
@@ -57,12 +66,12 @@ func IsValidScanTarget(s string) bool {
 
 // validScanTypes lists the scan-type values accepted by the service layer.
 var validScanTypes = map[string]bool{
-	"connect":       true,
-	"syn":           true,
-	"ack":           true,
-	"udp":           true,
-	"aggressive":    true,
-	"comprehensive": true,
+	scanTypeConnect:       true,
+	scanTypeSYN:           true,
+	scanTypeACK:           true,
+	scanTypeUDP:           true,
+	scanTypeAggressive:    true,
+	scanTypeComprehensive: true,
 }
 
 // -- Repository interface --

--- a/internal/services/smartscan.go
+++ b/internal/services/smartscan.go
@@ -118,6 +118,13 @@ const hostStatusGone = "gone"
 // harvest mDNS/SNMP sysName/PTR/cert signals on the next pass.
 const stageIdentityEnrichment = "identity_enrichment"
 
+const (
+	stageOSDetection   = "os_detection"
+	stagePortExpansion = "port_expansion"
+	stageServiceScan   = "service_scan"
+	stageRefresh       = "refresh"
+)
+
 // Stage-specific fallback port strings. Referenced by both SmartScanService
 // and stageDefaultPorts in portresolver.go — single source of truth.
 const (
@@ -258,22 +265,22 @@ func (s *SmartScanService) GetSuggestions(ctx context.Context) (*SuggestionSumma
 		NoOSInfo: SuggestionGroup{
 			Count:       noOS,
 			Description: "Hosts with no OS detection",
-			Action:      "os_detection",
+			Action:      stageOSDetection,
 		},
 		NoPorts: SuggestionGroup{
 			Count:       noPorts,
 			Description: "Hosts with OS known but no open ports found",
-			Action:      "port_expansion",
+			Action:      stagePortExpansion,
 		},
 		NoServices: SuggestionGroup{
 			Count:       noServices,
 			Description: "Hosts with open ports but no service identification",
-			Action:      "service_scan",
+			Action:      stageServiceScan,
 		},
 		Stale: SuggestionGroup{
 			Count:       stale,
 			Description: "Hosts not scanned in the last 30 days",
-			Action:      "refresh",
+			Action:      stageRefresh,
 		},
 		WellKnown: SuggestionGroup{
 			Count:       wellKnown,
@@ -343,7 +350,7 @@ func (s *SmartScanService) GetProfileRecommendations(ctx context.Context) ([]Pro
 			HostCount:   fc.count,
 			ProfileID:   p.ID,
 			ProfileName: p.Name,
-			Action:      "port_expansion",
+			Action:      stagePortExpansion,
 		})
 	}
 	return recs, nil
@@ -388,14 +395,14 @@ func (s *SmartScanService) EvaluateHost(ctx context.Context, host *db.Host) (*Sc
 	case host.Status == "up" && !hasUsableHostName(host):
 		return s.stageIdentityEnrichment(ctx, host), nil
 	case hasOS && !hasOpenPorts:
-		return s.stageWithProfile(ctx, host, "port_expansion"), nil
+		return s.stageWithProfile(ctx, host, stagePortExpansion), nil
 	case hasOpenPorts && !hasServices:
-		return s.stageWithProfile(ctx, host, "service_scan"), nil
+		return s.stageWithProfile(ctx, host, stageServiceScan), nil
 	case isStale:
-		ports := portListStr(ctx, s.portListResolver, "refresh", host, refreshPorts)
+		ports := portListStr(ctx, s.portListResolver, stageRefresh, host, refreshPorts)
 		return &ScanStage{
-			Stage:    "refresh",
-			ScanType: "connect",
+			Stage:    stageRefresh,
+			ScanType: scanTypeConnect,
 			Ports:    ports,
 			Reason:   fmt.Sprintf("last seen %s ago — refreshing scan", time.Since(host.LastSeen).Round(time.Hour)),
 		}, nil
@@ -412,7 +419,7 @@ func (s *SmartScanService) stageIdentityEnrichment(ctx context.Context, host *db
 	ports := portListStr(ctx, s.portListResolver, stageIdentityEnrichment, host, identityEnrichmentPorts)
 	return &ScanStage{
 		Stage:    stageIdentityEnrichment,
-		ScanType: "connect",
+		ScanType: scanTypeConnect,
 		Ports:    ports,
 		Reason:   "host has no usable name — probing identity surfaces (mDNS, SNMP, DNS, TLS)",
 	}
@@ -456,10 +463,10 @@ func hasNonBlank(p *string) bool {
 // stageOSDetection returns a ScanStage configured for OS fingerprinting.
 // SYN scan is required because OS detection needs raw socket access (-O flag).
 func (s *SmartScanService) stageOSDetection(ctx context.Context, host *db.Host) *ScanStage {
-	ports := portListStr(ctx, s.portListResolver, "os_detection", host, osDetectionPorts)
+	ports := portListStr(ctx, s.portListResolver, stageOSDetection, host, osDetectionPorts)
 	return &ScanStage{
-		Stage:       "os_detection",
-		ScanType:    "syn",
+		Stage:       stageOSDetection,
+		ScanType:    scanTypeSYN,
 		Ports:       ports,
 		OSDetection: true,
 		Reason:      "no OS information — running OS fingerprint scan",
@@ -482,12 +489,12 @@ func portListStr(ctx context.Context, r portListResolverIface, stage string, hos
 // falling back to a generic 1-1024 connect scan if none is found.
 func (s *SmartScanService) stageWithProfile(ctx context.Context, host *db.Host, stage string) *ScanStage {
 	fallbackReason := map[string]string{
-		"port_expansion": "OS known but no ports found — generic port scan",
-		"service_scan":   "open ports found but no service banners — generic service scan",
+		stagePortExpansion: "OS known but no ports found — generic port scan",
+		stageServiceScan:   "open ports found but no service banners — generic service scan",
 	}
 	profileReason := map[string]string{
-		"port_expansion": fmt.Sprintf("OS known (%s) but no ports found — using profile", safeStr(host.OSFamily)),
-		"service_scan":   "open ports found but no service banners — service scan",
+		stagePortExpansion: fmt.Sprintf("OS known (%s) but no ports found — using profile", safeStr(host.OSFamily)),
+		stageServiceScan:   "open ports found but no service banners — service scan",
 	}
 
 	if s.profileManager != nil {
@@ -505,8 +512,8 @@ func (s *SmartScanService) stageWithProfile(ctx context.Context, host *db.Host, 
 	}
 	return &ScanStage{
 		Stage:    stage,
-		ScanType: "connect",
-		Ports:    "1-1024",
+		ScanType: scanTypeConnect,
+		Ports:    refreshPorts,
 		Reason:   fallbackReason[stage],
 	}
 }

--- a/internal/workers/pool.go
+++ b/internal/workers/pool.go
@@ -15,6 +15,11 @@ import (
 	"github.com/anstrom/scanorama/internal/metrics"
 )
 
+const (
+	labelJobType = "job_type"
+	labelStatus  = "status"
+)
+
 // Job represents a unit of work to be executed by a worker.
 type Job interface {
 	// Execute performs the job and returns an error if it fails.
@@ -155,9 +160,9 @@ func (p *Pool) Submit(job Job) error {
 	case p.jobs <- job:
 		logging.Debug("Job submitted to worker pool",
 			"job_id", job.ID(),
-			"job_type", job.Type())
+			labelJobType, job.Type())
 		metrics.Counter("jobs_submitted_total", metrics.Labels{
-			"job_type": job.Type(),
+			labelJobType: job.Type(),
 		})
 		return nil
 	case <-p.ctx.Done():
@@ -275,7 +280,7 @@ func (w *worker) executeJob(job Job) {
 			stack := debug.Stack()
 			logging.Error("Job panicked",
 				"job_id", job.ID(),
-				"job_type", job.Type(),
+				labelJobType, job.Type(),
 				"worker_id", w.id,
 				"panic", r,
 				"stack", string(stack))
@@ -290,15 +295,15 @@ func (w *worker) executeJob(job Job) {
 			}
 
 			metrics.Counter("jobs_completed_total", metrics.Labels{
-				"job_type": job.Type(),
-				"status":   "panic",
+				labelJobType: job.Type(),
+				labelStatus:  "panic",
 			})
 		}
 	}()
 
 	jobTimer := metrics.NewTimer("job_duration_seconds", metrics.Labels{
-		"job_type":  job.Type(),
-		"worker_id": fmt.Sprintf("worker-%d", w.id),
+		labelJobType: job.Type(),
+		"worker_id":  fmt.Sprintf("worker-%d", w.id),
 	})
 	defer jobTimer.Stop()
 
@@ -338,12 +343,12 @@ func (w *worker) runWithRetry(job Job) {
 				Retries:  retries,
 			}
 			metrics.Counter("jobs_completed_total", metrics.Labels{
-				"job_type": job.Type(),
-				"status":   "success",
+				labelJobType: job.Type(),
+				labelStatus:  "success",
 			})
 			logging.Debug("Job completed successfully",
 				"job_id", job.ID(),
-				"job_type", job.Type(),
+				labelJobType, job.Type(),
 				"duration", duration,
 				"worker_id", w.id,
 				"retries", retries)
@@ -356,7 +361,7 @@ func (w *worker) runWithRetry(job Job) {
 		if attempt < w.pool.config.MaxRetries {
 			logging.Debug("Job failed, retrying",
 				"job_id", job.ID(),
-				"job_type", job.Type(),
+				labelJobType, job.Type(),
 				"attempt", attempt+1,
 				"max_retries", w.pool.config.MaxRetries,
 				"error", err)
@@ -376,12 +381,12 @@ func (w *worker) runWithRetry(job Job) {
 		Retries: retries,
 	}
 	metrics.Counter("jobs_completed_total", metrics.Labels{
-		"job_type": job.Type(),
-		"status":   "error",
+		labelJobType: job.Type(),
+		labelStatus:  "error",
 	})
 	logging.Error("Job failed after retries",
 		"job_id", job.ID(),
-		"job_type", job.Type(),
+		labelJobType, job.Type(),
 		"retries", retries,
 		"error", lastErr,
 		"worker_id", w.id)
@@ -415,16 +420,16 @@ func (p *Pool) processResults() {
 			// Update metrics based on result
 			if result.Error != nil {
 				metrics.Counter("job_errors_total", metrics.Labels{
-					"job_type": result.JobType,
+					labelJobType: result.JobType,
 				})
 			} else {
 				metrics.Counter("jobs_completed_total", metrics.Labels{
-					"job_type": result.JobType,
+					labelJobType: result.JobType,
 				})
 			}
 
 			metrics.Histogram("job_retry_count", float64(result.Retries), metrics.Labels{
-				"job_type": result.JobType,
+				labelJobType: result.JobType,
 			})
 		}
 	}


### PR DESCRIPTION
## Summary

- Bumps Go toolchain from 1.26.3 to fix 7 stdlib CVEs (`GO-2026-4918/4971/4977/4980/4981/4982/4986`) in `net/mail`, `html/template`, `net`, and `net/http`
- Fixes all 257 `goconst` violations now caught by golangci-lint v2.12.2 — defines named constants and replaces string literals across 66 files
- Removes 3 stale `//nolint:gosec` directives in `banner.go`

These two concerns unblock all 18 open dependency PRs: the Go bump clears the Vulnerability Scan, and the goconst fix clears the Code Quality check on #782.

## Test plan

- CI Vulnerability Scan should pass (govulncheck passes locally with no findings)
- CI Code Quality should pass (golangci-lint passes locally with 0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)