### PR TITLE
feat(ux): v0.27 UX Polish & Quality of Life

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ act-*
 .claude/HANDOFF.md
 HANDOFF.md
 
+# ── Git worktrees ─────────────────────────────────────────────────────────────
+.worktrees/
+
 # ── Superpowers brainstorm session artifacts ─────────────────────────────────
 .superpowers/
 

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -3613,6 +3613,74 @@ const docTemplate = `{
                 }
             }
         },
+        "/scans/diff": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Compare two scans of the same host and return a structured port diff.\nNew ports are marked \"new\", ports that disappeared are \"closed\",\nports with changed service or state are \"changed\", the rest are \"unchanged\".",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Scans"
+                ],
+                "summary": "Compare two scans",
+                "operationId": "getScanDiff",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Scan A ID (older/baseline)",
+                        "name": "a",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Scan B ID (newer/current)",
+                        "name": "b",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ScanDiffResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/scans/{scanId}": {
             "get": {
                 "security": [
@@ -6763,6 +6831,104 @@ const docTemplate = `{
                 "tx_bytes": {
                     "type": "integer",
                     "example": 524288
+                }
+            }
+        },
+        "docs.ScanDiffEntryResponse": {
+            "type": "object",
+            "properties": {
+                "port": {
+                    "type": "integer",
+                    "example": 443
+                },
+                "prev_service_name": {
+                    "type": "string",
+                    "example": "http"
+                },
+                "prev_service_version": {
+                    "type": "string"
+                },
+                "prev_state": {
+                    "type": "string",
+                    "example": "filtered"
+                },
+                "protocol": {
+                    "type": "string",
+                    "example": "tcp"
+                },
+                "service_name": {
+                    "type": "string",
+                    "example": "https"
+                },
+                "service_version": {
+                    "type": "string",
+                    "example": "nginx/1.24.0"
+                },
+                "state": {
+                    "type": "string",
+                    "example": "open"
+                },
+                "status": {
+                    "description": "Status is \"new\" | \"closed\" | \"changed\" | \"unchanged\"",
+                    "type": "string",
+                    "enum": [
+                        "new",
+                        "closed",
+                        "changed",
+                        "unchanged"
+                    ],
+                    "example": "new"
+                }
+            }
+        },
+        "docs.ScanDiffResponse": {
+            "type": "object",
+            "properties": {
+                "changed_count": {
+                    "type": "integer",
+                    "example": 2
+                },
+                "closed_count": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "curr_os_name": {
+                    "type": "string",
+                    "example": "Ubuntu 22.04"
+                },
+                "host_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440002"
+                },
+                "new_count": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "os_changed": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "ports": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/docs.ScanDiffEntryResponse"
+                    }
+                },
+                "prev_os_name": {
+                    "type": "string",
+                    "example": "Ubuntu 20.04"
+                },
+                "scan_a_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "scan_b_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440001"
+                },
+                "unchanged_count": {
+                    "type": "integer",
+                    "example": 47
                 }
             }
         },

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -5285,6 +5285,16 @@ const docTemplate = `{
                     "type": "string",
                     "example": "Primary web server"
                 },
+                "device_id": {
+                    "description": "DeviceID is the stable device this host is attached to, if any.",
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440001"
+                },
+                "device_name": {
+                    "description": "DeviceName is the canonical name of the attached device, populated by JOIN in GetHost.",
+                    "type": "string",
+                    "example": "Andreas's iPhone"
+                },
                 "display_name": {
                     "description": "DisplayName is the winning display name chosen by the identity resolver.\nAlways set; falls back to IPAddress when no source produced a usable name.",
                     "type": "string",

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1540,6 +1540,90 @@ const docTemplate = `{
                 }
             }
         },
+        "/hosts/export": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Streams all hosts matching the active filters as a file download.\nUses chunked DB reads so large exports do not buffer in memory.",
+                "produces": [
+                    "text/csv",
+                    "application/json"
+                ],
+                "tags": [
+                    "Hosts"
+                ],
+                "summary": "Export hosts as CSV or JSON",
+                "operationId": "exportHosts",
+                "parameters": [
+                    {
+                        "enum": [
+                            "csv",
+                            "json"
+                        ],
+                        "type": "string",
+                        "description": "Output format: csv (default) or json",
+                        "name": "format",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by host status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by OS family",
+                        "name": "os",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by network CIDR",
+                        "name": "network",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by vendor",
+                        "name": "vendor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Full-text search",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort direction: asc or desc",
+                        "name": "sort_order",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "CSV or JSON file download"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/hosts/{hostId}": {
             "get": {
                 "security": [
@@ -3671,6 +3755,78 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/docs.ErrorResponse"
                         }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/scans/export": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Streams all scans matching the active filters as a file download.\nUses chunked DB reads so large exports do not buffer in memory.",
+                "produces": [
+                    "text/csv",
+                    "application/json"
+                ],
+                "tags": [
+                    "Scans"
+                ],
+                "summary": "Export scans as CSV or JSON",
+                "operationId": "exportScans",
+                "parameters": [
+                    {
+                        "enum": [
+                            "csv",
+                            "json"
+                        ],
+                        "type": "string",
+                        "description": "Output format: csv (default) or json",
+                        "name": "format",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by scan status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by scan type",
+                        "name": "scan_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by profile ID",
+                        "name": "profile_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort direction: asc or desc",
+                        "name": "sort_order",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "CSV or JSON file download"
                     },
                     "500": {
                         "description": "Internal Server Error",

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -4535,6 +4535,360 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/webhooks": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns all registered webhook delivery endpoints.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Webhooks"
+                ],
+                "summary": "List webhook endpoints",
+                "operationId": "listWebhooks",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Registers a new webhook delivery endpoint.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Webhooks"
+                ],
+                "summary": "Create webhook endpoint",
+                "operationId": "createWebhook",
+                "parameters": [
+                    {
+                        "description": "Webhook input",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/docs.WebhookEndpointResponse"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/docs.WebhookCreateEndpointResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/webhooks/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns a single webhook endpoint by ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Webhooks"
+                ],
+                "summary": "Get webhook endpoint",
+                "operationId": "getWebhook",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Webhook UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.WebhookEndpointResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Removes a webhook endpoint and its delivery log.",
+                "tags": [
+                    "Webhooks"
+                ],
+                "summary": "Delete webhook endpoint",
+                "operationId": "deleteWebhook",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Webhook UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successfully deleted"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Applies partial updates to a webhook endpoint.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Webhooks"
+                ],
+                "summary": "Update webhook endpoint",
+                "operationId": "updateWebhook",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Webhook UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update fields",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/docs.WebhookEndpointResponse"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.WebhookEndpointResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/webhooks/{id}/logs": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns delivery logs for a webhook endpoint (newest first, max 200).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Webhooks"
+                ],
+                "summary": "List delivery logs",
+                "operationId": "listWebhookDeliveryLogs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Webhook UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum log entries (default 50, max 200)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/webhooks/{id}/test": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Fires a synchronous test event to the webhook endpoint.",
+                "tags": [
+                    "Webhooks"
+                ],
+                "summary": "Send test delivery",
+                "operationId": "testWebhook",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Webhook UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -6525,6 +6879,76 @@ const docTemplate = `{
                 "version": {
                     "type": "string",
                     "example": "0.7.0"
+                }
+            }
+        },
+        "docs.WebhookCreateEndpointResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "host.online",
+                        "scan.completed"
+                    ]
+                },
+                "id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "secret": {
+                    "type": "string",
+                    "example": "abc123..."
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "example": "https://example.com/webhook"
+                }
+            }
+        },
+        "docs.WebhookEndpointResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "host.online",
+                        "scan.completed"
+                    ]
+                },
+                "id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "example": "https://example.com/webhook"
                 }
             }
         }

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -66,6 +66,255 @@ const docTemplate = `{
                 }
             }
         },
+        "/alerts": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns all configured alert rules.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Alerts"
+                ],
+                "summary": "List all alert rules",
+                "operationId": "listAlertRules",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/docs.AlertRuleResponse"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Creates a new alert rule for a host, group, or tag.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Alerts"
+                ],
+                "summary": "Create an alert rule",
+                "operationId": "createAlertRule",
+                "parameters": [
+                    {
+                        "description": "Alert rule input",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/docs.AlertRuleResponse"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/docs.AlertRuleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/alerts/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns a single alert rule by ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Alerts"
+                ],
+                "summary": "Get an alert rule",
+                "operationId": "getAlertRule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Alert rule UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.AlertRuleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Removes an alert rule.",
+                "tags": [
+                    "Alerts"
+                ],
+                "summary": "Delete an alert rule",
+                "operationId": "deleteAlertRule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Alert rule UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successfully deleted"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Applies partial updates to an alert rule.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Alerts"
+                ],
+                "summary": "Update an alert rule",
+                "operationId": "updateAlertRule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Alert rule UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update fields",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/docs.AlertRuleResponse"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.AlertRuleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/certificates/expiring": {
             "get": {
                 "security": [
@@ -1603,6 +1852,57 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/hosts/{id}/alerts": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns alert rules that target a specific host directly.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Alerts"
+                ],
+                "summary": "List alert rules for a host",
+                "operationId": "listHostAlertRules",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Host UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/docs.AlertRuleResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/docs.ErrorResponse"
                         }
@@ -4904,6 +5204,53 @@ const docTemplate = `{
                     "additionalProperties": true
                 },
                 "timestamp": {
+                    "type": "string"
+                }
+            }
+        },
+        "docs.AlertRuleResponse": {
+            "type": "object",
+            "properties": {
+                "channel_type": {
+                    "type": "string",
+                    "example": "webhook"
+                },
+                "channel_url": {
+                    "type": "string",
+                    "example": "https://example.com/hook"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "group_id": {
+                    "type": "string"
+                },
+                "host_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440001"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "tag": {
+                    "type": "string",
+                    "example": "nas"
+                },
+                "trigger": {
+                    "type": "string",
+                    "enum": [
+                        "online",
+                        "offline",
+                        "both"
+                    ],
+                    "example": "offline"
+                },
+                "updated_at": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -4660,6 +4660,59 @@ const docTemplate = `{
                 }
             }
         },
+        "/search": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Search across hosts (by IP/hostname), networks (by name/CIDR),\nscans (by target), and profiles (by name) in a single request.\nq must be 2–100 characters. Results are grouped by entity type.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Search"
+                ],
+                "summary": "Unified cross-entity search",
+                "operationId": "globalSearch",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query (2–100 characters)",
+                        "name": "q",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max results per type (default 10, max 50)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.SearchResults"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/smart-scan/hosts/{id}/refresh-identity": {
             "post": {
                 "security": [
@@ -7289,6 +7342,51 @@ const docTemplate = `{
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "docs.SearchResult": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "label": {
+                    "type": "string",
+                    "example": "192.168.1.1 (myserver)"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "host",
+                        "network",
+                        "scan",
+                        "profile"
+                    ],
+                    "example": "host"
+                },
+                "url": {
+                    "type": "string",
+                    "example": "/hosts/550e8400-e29b-41d4-a716-446655440000"
+                }
+            }
+        },
+        "docs.SearchResults": {
+            "type": "object",
+            "properties": {
+                "results": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/docs.SearchResult"
+                        }
+                    }
+                },
+                "total": {
+                    "type": "integer",
+                    "example": 4
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -4654,6 +4654,59 @@
                 }
             }
         },
+        "/search": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Search across hosts (by IP/hostname), networks (by name/CIDR),\nscans (by target), and profiles (by name) in a single request.\nq must be 2–100 characters. Results are grouped by entity type.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Search"
+                ],
+                "summary": "Unified cross-entity search",
+                "operationId": "globalSearch",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query (2–100 characters)",
+                        "name": "q",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max results per type (default 10, max 50)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.SearchResults"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/smart-scan/hosts/{id}/refresh-identity": {
             "post": {
                 "security": [
@@ -7283,6 +7336,51 @@
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "docs.SearchResult": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "label": {
+                    "type": "string",
+                    "example": "192.168.1.1 (myserver)"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "host",
+                        "network",
+                        "scan",
+                        "profile"
+                    ],
+                    "example": "host"
+                },
+                "url": {
+                    "type": "string",
+                    "example": "/hosts/550e8400-e29b-41d4-a716-446655440000"
+                }
+            }
+        },
+        "docs.SearchResults": {
+            "type": "object",
+            "properties": {
+                "results": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/docs.SearchResult"
+                        }
+                    }
+                },
+                "total": {
+                    "type": "integer",
+                    "example": 4
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1534,6 +1534,90 @@
                 }
             }
         },
+        "/hosts/export": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Streams all hosts matching the active filters as a file download.\nUses chunked DB reads so large exports do not buffer in memory.",
+                "produces": [
+                    "text/csv",
+                    "application/json"
+                ],
+                "tags": [
+                    "Hosts"
+                ],
+                "summary": "Export hosts as CSV or JSON",
+                "operationId": "exportHosts",
+                "parameters": [
+                    {
+                        "enum": [
+                            "csv",
+                            "json"
+                        ],
+                        "type": "string",
+                        "description": "Output format: csv (default) or json",
+                        "name": "format",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by host status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by OS family",
+                        "name": "os",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by network CIDR",
+                        "name": "network",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by vendor",
+                        "name": "vendor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Full-text search",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort direction: asc or desc",
+                        "name": "sort_order",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "CSV or JSON file download"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/hosts/{hostId}": {
             "get": {
                 "security": [
@@ -3665,6 +3749,78 @@
                         "schema": {
                             "$ref": "#/definitions/docs.ErrorResponse"
                         }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/scans/export": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Streams all scans matching the active filters as a file download.\nUses chunked DB reads so large exports do not buffer in memory.",
+                "produces": [
+                    "text/csv",
+                    "application/json"
+                ],
+                "tags": [
+                    "Scans"
+                ],
+                "summary": "Export scans as CSV or JSON",
+                "operationId": "exportScans",
+                "parameters": [
+                    {
+                        "enum": [
+                            "csv",
+                            "json"
+                        ],
+                        "type": "string",
+                        "description": "Output format: csv (default) or json",
+                        "name": "format",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by scan status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by scan type",
+                        "name": "scan_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by profile ID",
+                        "name": "profile_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort direction: asc or desc",
+                        "name": "sort_order",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "CSV or JSON file download"
                     },
                     "500": {
                         "description": "Internal Server Error",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -60,6 +60,255 @@
                 }
             }
         },
+        "/alerts": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns all configured alert rules.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Alerts"
+                ],
+                "summary": "List all alert rules",
+                "operationId": "listAlertRules",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/docs.AlertRuleResponse"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Creates a new alert rule for a host, group, or tag.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Alerts"
+                ],
+                "summary": "Create an alert rule",
+                "operationId": "createAlertRule",
+                "parameters": [
+                    {
+                        "description": "Alert rule input",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/docs.AlertRuleResponse"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/docs.AlertRuleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/alerts/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns a single alert rule by ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Alerts"
+                ],
+                "summary": "Get an alert rule",
+                "operationId": "getAlertRule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Alert rule UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.AlertRuleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Removes an alert rule.",
+                "tags": [
+                    "Alerts"
+                ],
+                "summary": "Delete an alert rule",
+                "operationId": "deleteAlertRule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Alert rule UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successfully deleted"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Applies partial updates to an alert rule.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Alerts"
+                ],
+                "summary": "Update an alert rule",
+                "operationId": "updateAlertRule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Alert rule UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update fields",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/docs.AlertRuleResponse"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.AlertRuleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/certificates/expiring": {
             "get": {
                 "security": [
@@ -1597,6 +1846,57 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/hosts/{id}/alerts": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns alert rules that target a specific host directly.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Alerts"
+                ],
+                "summary": "List alert rules for a host",
+                "operationId": "listHostAlertRules",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Host UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/docs.AlertRuleResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/docs.ErrorResponse"
                         }
@@ -4898,6 +5198,53 @@
                     "additionalProperties": true
                 },
                 "timestamp": {
+                    "type": "string"
+                }
+            }
+        },
+        "docs.AlertRuleResponse": {
+            "type": "object",
+            "properties": {
+                "channel_type": {
+                    "type": "string",
+                    "example": "webhook"
+                },
+                "channel_url": {
+                    "type": "string",
+                    "example": "https://example.com/hook"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "group_id": {
+                    "type": "string"
+                },
+                "host_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440001"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "tag": {
+                    "type": "string",
+                    "example": "nas"
+                },
+                "trigger": {
+                    "type": "string",
+                    "enum": [
+                        "online",
+                        "offline",
+                        "both"
+                    ],
+                    "example": "offline"
+                },
+                "updated_at": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -3607,6 +3607,74 @@
                 }
             }
         },
+        "/scans/diff": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Compare two scans of the same host and return a structured port diff.\nNew ports are marked \"new\", ports that disappeared are \"closed\",\nports with changed service or state are \"changed\", the rest are \"unchanged\".",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Scans"
+                ],
+                "summary": "Compare two scans",
+                "operationId": "getScanDiff",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Scan A ID (older/baseline)",
+                        "name": "a",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Scan B ID (newer/current)",
+                        "name": "b",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ScanDiffResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/scans/{scanId}": {
             "get": {
                 "security": [
@@ -6757,6 +6825,104 @@
                 "tx_bytes": {
                     "type": "integer",
                     "example": 524288
+                }
+            }
+        },
+        "docs.ScanDiffEntryResponse": {
+            "type": "object",
+            "properties": {
+                "port": {
+                    "type": "integer",
+                    "example": 443
+                },
+                "prev_service_name": {
+                    "type": "string",
+                    "example": "http"
+                },
+                "prev_service_version": {
+                    "type": "string"
+                },
+                "prev_state": {
+                    "type": "string",
+                    "example": "filtered"
+                },
+                "protocol": {
+                    "type": "string",
+                    "example": "tcp"
+                },
+                "service_name": {
+                    "type": "string",
+                    "example": "https"
+                },
+                "service_version": {
+                    "type": "string",
+                    "example": "nginx/1.24.0"
+                },
+                "state": {
+                    "type": "string",
+                    "example": "open"
+                },
+                "status": {
+                    "description": "Status is \"new\" | \"closed\" | \"changed\" | \"unchanged\"",
+                    "type": "string",
+                    "enum": [
+                        "new",
+                        "closed",
+                        "changed",
+                        "unchanged"
+                    ],
+                    "example": "new"
+                }
+            }
+        },
+        "docs.ScanDiffResponse": {
+            "type": "object",
+            "properties": {
+                "changed_count": {
+                    "type": "integer",
+                    "example": 2
+                },
+                "closed_count": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "curr_os_name": {
+                    "type": "string",
+                    "example": "Ubuntu 22.04"
+                },
+                "host_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440002"
+                },
+                "new_count": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "os_changed": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "ports": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/docs.ScanDiffEntryResponse"
+                    }
+                },
+                "prev_os_name": {
+                    "type": "string",
+                    "example": "Ubuntu 20.04"
+                },
+                "scan_a_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "scan_b_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440001"
+                },
+                "unchanged_count": {
+                    "type": "integer",
+                    "example": 47
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -4529,6 +4529,360 @@
                     }
                 }
             }
+        },
+        "/webhooks": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns all registered webhook delivery endpoints.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Webhooks"
+                ],
+                "summary": "List webhook endpoints",
+                "operationId": "listWebhooks",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Registers a new webhook delivery endpoint.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Webhooks"
+                ],
+                "summary": "Create webhook endpoint",
+                "operationId": "createWebhook",
+                "parameters": [
+                    {
+                        "description": "Webhook input",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/docs.WebhookEndpointResponse"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/docs.WebhookCreateEndpointResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/webhooks/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns a single webhook endpoint by ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Webhooks"
+                ],
+                "summary": "Get webhook endpoint",
+                "operationId": "getWebhook",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Webhook UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.WebhookEndpointResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Removes a webhook endpoint and its delivery log.",
+                "tags": [
+                    "Webhooks"
+                ],
+                "summary": "Delete webhook endpoint",
+                "operationId": "deleteWebhook",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Webhook UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successfully deleted"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Applies partial updates to a webhook endpoint.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Webhooks"
+                ],
+                "summary": "Update webhook endpoint",
+                "operationId": "updateWebhook",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Webhook UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update fields",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/docs.WebhookEndpointResponse"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/docs.WebhookEndpointResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/webhooks/{id}/logs": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns delivery logs for a webhook endpoint (newest first, max 200).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Webhooks"
+                ],
+                "summary": "List delivery logs",
+                "operationId": "listWebhookDeliveryLogs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Webhook UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum log entries (default 50, max 200)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/webhooks/{id}/test": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Fires a synchronous test event to the webhook endpoint.",
+                "tags": [
+                    "Webhooks"
+                ],
+                "summary": "Send test delivery",
+                "operationId": "testWebhook",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Webhook UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/docs.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -6519,6 +6873,76 @@
                 "version": {
                     "type": "string",
                     "example": "0.7.0"
+                }
+            }
+        },
+        "docs.WebhookCreateEndpointResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "host.online",
+                        "scan.completed"
+                    ]
+                },
+                "id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "secret": {
+                    "type": "string",
+                    "example": "abc123..."
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "example": "https://example.com/webhook"
+                }
+            }
+        },
+        "docs.WebhookEndpointResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "host.online",
+                        "scan.completed"
+                    ]
+                },
+                "id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "example": "https://example.com/webhook"
                 }
             }
         }

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -5279,6 +5279,16 @@
                     "type": "string",
                     "example": "Primary web server"
                 },
+                "device_id": {
+                    "description": "DeviceID is the stable device this host is attached to, if any.",
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440001"
+                },
+                "device_name": {
+                    "description": "DeviceName is the canonical name of the attached device, populated by JOIN in GetHost.",
+                    "type": "string",
+                    "example": "Andreas's iPhone"
+                },
                 "display_name": {
                     "description": "DisplayName is the winning display name chosen by the identity resolver.\nAlways set; falls back to IPAddress when no source produced a usable name.",
                     "type": "string",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -11,6 +11,40 @@ definitions:
       timestamp:
         type: string
     type: object
+  docs.AlertRuleResponse:
+    properties:
+      channel_type:
+        example: webhook
+        type: string
+      channel_url:
+        example: https://example.com/hook
+        type: string
+      created_at:
+        type: string
+      enabled:
+        example: true
+        type: boolean
+      group_id:
+        type: string
+      host_id:
+        example: 550e8400-e29b-41d4-a716-446655440001
+        type: string
+      id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      tag:
+        example: nas
+        type: string
+      trigger:
+        enum:
+        - online
+        - offline
+        - both
+        example: offline
+        type: string
+      updated_at:
+        type: string
+    type: object
   docs.AttachedHostResponse:
     properties:
       first_seen:
@@ -1547,6 +1581,167 @@ paths:
       summary: Admin status
       tags:
       - Admin
+  /alerts:
+    get:
+      description: Returns all configured alert rules.
+      operationId: listAlertRules
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/docs.AlertRuleResponse'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: List all alert rules
+      tags:
+      - Alerts
+    post:
+      consumes:
+      - application/json
+      description: Creates a new alert rule for a host, group, or tag.
+      operationId: createAlertRule
+      parameters:
+      - description: Alert rule input
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/docs.AlertRuleResponse'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/docs.AlertRuleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Create an alert rule
+      tags:
+      - Alerts
+  /alerts/{id}:
+    delete:
+      description: Removes an alert rule.
+      operationId: deleteAlertRule
+      parameters:
+      - description: Alert rule UUID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: Successfully deleted
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Delete an alert rule
+      tags:
+      - Alerts
+    get:
+      description: Returns a single alert rule by ID.
+      operationId: getAlertRule
+      parameters:
+      - description: Alert rule UUID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/docs.AlertRuleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Get an alert rule
+      tags:
+      - Alerts
+    patch:
+      consumes:
+      - application/json
+      description: Applies partial updates to an alert rule.
+      operationId: updateAlertRule
+      parameters:
+      - description: Alert rule UUID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Update fields
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/docs.AlertRuleResponse'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/docs.AlertRuleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Update an alert rule
+      tags:
+      - Alerts
   /certificates/expiring:
     get:
       description: |-
@@ -2563,6 +2758,39 @@ paths:
       summary: Get host scans
       tags:
       - Hosts
+  /hosts/{id}/alerts:
+    get:
+      description: Returns alert rules that target a specific host directly.
+      operationId: listHostAlertRules
+      parameters:
+      - description: Host UUID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/docs.AlertRuleResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: List alert rules for a host
+      tags:
+      - Alerts
   /hosts/{id}/custom-name:
     patch:
       consumes:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -533,6 +533,15 @@ definitions:
       description:
         example: Primary web server
         type: string
+      device_id:
+        description: DeviceID is the stable device this host is attached to, if any.
+        example: 550e8400-e29b-41d4-a716-446655440001
+        type: string
+      device_name:
+        description: DeviceName is the canonical name of the attached device, populated
+          by JOIN in GetHost.
+        example: Andreas's iPhone
+        type: string
       display_name:
         description: |-
           DisplayName is the winning display name chosen by the identity resolver.

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1437,6 +1437,55 @@ definitions:
         example: 0.7.0
         type: string
     type: object
+  docs.WebhookCreateEndpointResponse:
+    properties:
+      created_at:
+        type: string
+      enabled:
+        example: true
+        type: boolean
+      events:
+        example:
+        - host.online
+        - scan.completed
+        items:
+          type: string
+        type: array
+      id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      secret:
+        example: abc123...
+        type: string
+      updated_at:
+        type: string
+      url:
+        example: https://example.com/webhook
+        type: string
+    type: object
+  docs.WebhookEndpointResponse:
+    properties:
+      created_at:
+        type: string
+      enabled:
+        example: true
+        type: boolean
+      events:
+        example:
+        - host.online
+        - scan.completed
+        items:
+          type: string
+        type: array
+      id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      updated_at:
+        type: string
+      url:
+        example: https://example.com/webhook
+        type: string
+    type: object
 host: localhost:8080
 info:
   contact:
@@ -4429,6 +4478,237 @@ paths:
       summary: Version information
       tags:
       - System
+  /webhooks:
+    get:
+      description: Returns all registered webhook delivery endpoints.
+      operationId: listWebhooks
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: List webhook endpoints
+      tags:
+      - Webhooks
+    post:
+      consumes:
+      - application/json
+      description: Registers a new webhook delivery endpoint.
+      operationId: createWebhook
+      parameters:
+      - description: Webhook input
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/docs.WebhookEndpointResponse'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/docs.WebhookCreateEndpointResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Create webhook endpoint
+      tags:
+      - Webhooks
+  /webhooks/{id}:
+    delete:
+      description: Removes a webhook endpoint and its delivery log.
+      operationId: deleteWebhook
+      parameters:
+      - description: Webhook UUID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: Successfully deleted
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Delete webhook endpoint
+      tags:
+      - Webhooks
+    get:
+      description: Returns a single webhook endpoint by ID.
+      operationId: getWebhook
+      parameters:
+      - description: Webhook UUID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/docs.WebhookEndpointResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Get webhook endpoint
+      tags:
+      - Webhooks
+    patch:
+      consumes:
+      - application/json
+      description: Applies partial updates to a webhook endpoint.
+      operationId: updateWebhook
+      parameters:
+      - description: Webhook UUID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Update fields
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/docs.WebhookEndpointResponse'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/docs.WebhookEndpointResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Update webhook endpoint
+      tags:
+      - Webhooks
+  /webhooks/{id}/logs:
+    get:
+      description: Returns delivery logs for a webhook endpoint (newest first, max
+        200).
+      operationId: listWebhookDeliveryLogs
+      parameters:
+      - description: Webhook UUID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Maximum log entries (default 50, max 200)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: List delivery logs
+      tags:
+      - Webhooks
+  /webhooks/{id}/test:
+    post:
+      description: Fires a synchronous test event to the webhook endpoint.
+      operationId: testWebhook
+      parameters:
+      - description: Webhook UUID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Send test delivery
+      tags:
+      - Webhooks
 security:
 - ApiKeyAuth: []
 securityDefinitions:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -2911,6 +2911,63 @@ paths:
       summary: Set or clear a host's custom display name
       tags:
       - Hosts
+  /hosts/export:
+    get:
+      description: |-
+        Streams all hosts matching the active filters as a file download.
+        Uses chunked DB reads so large exports do not buffer in memory.
+      operationId: exportHosts
+      parameters:
+      - description: 'Output format: csv (default) or json'
+        enum:
+        - csv
+        - json
+        in: query
+        name: format
+        type: string
+      - description: Filter by host status
+        in: query
+        name: status
+        type: string
+      - description: Filter by OS family
+        in: query
+        name: os
+        type: string
+      - description: Filter by network CIDR
+        in: query
+        name: network
+        type: string
+      - description: Filter by vendor
+        in: query
+        name: vendor
+        type: string
+      - description: Full-text search
+        in: query
+        name: search
+        type: string
+      - description: Sort column
+        in: query
+        name: sort_by
+        type: string
+      - description: 'Sort direction: asc or desc'
+        in: query
+        name: sort_order
+        type: string
+      produces:
+      - text/csv
+      - application/json
+      responses:
+        "200":
+          description: CSV or JSON file download
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Export hosts as CSV or JSON
+      tags:
+      - Hosts
   /liveness:
     get:
       description: Returns simple liveness status without dependency checks
@@ -4278,6 +4335,55 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Compare two scans
+      tags:
+      - Scans
+  /scans/export:
+    get:
+      description: |-
+        Streams all scans matching the active filters as a file download.
+        Uses chunked DB reads so large exports do not buffer in memory.
+      operationId: exportScans
+      parameters:
+      - description: 'Output format: csv (default) or json'
+        enum:
+        - csv
+        - json
+        in: query
+        name: format
+        type: string
+      - description: Filter by scan status
+        in: query
+        name: status
+        type: string
+      - description: Filter by scan type
+        in: query
+        name: scan_type
+        type: string
+      - description: Filter by profile ID
+        in: query
+        name: profile_id
+        type: string
+      - description: Sort column
+        in: query
+        name: sort_by
+        type: string
+      - description: 'Sort direction: asc or desc'
+        in: query
+        name: sort_order
+        type: string
+      produces:
+      - text/csv
+      - application/json
+      responses:
+        "200":
+          description: CSV or JSON file download
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Export scans as CSV or JSON
       tags:
       - Scans
   /schedules:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1359,6 +1359,38 @@ definitions:
       updated_at:
         type: string
     type: object
+  docs.SearchResult:
+    properties:
+      id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      label:
+        example: 192.168.1.1 (myserver)
+        type: string
+      type:
+        enum:
+        - host
+        - network
+        - scan
+        - profile
+        example: host
+        type: string
+      url:
+        example: /hosts/550e8400-e29b-41d4-a716-446655440000
+        type: string
+    type: object
+  docs.SearchResults:
+    properties:
+      results:
+        additionalProperties:
+          items:
+            $ref: '#/definitions/docs.SearchResult'
+          type: array
+        type: object
+      total:
+        example: 4
+        type: integer
+    type: object
   docs.StatusResponse:
     properties:
       service:
@@ -4670,6 +4702,43 @@ paths:
       summary: Enable schedule
       tags:
       - Schedules
+  /search:
+    get:
+      description: |-
+        Search across hosts (by IP/hostname), networks (by name/CIDR),
+        scans (by target), and profiles (by name) in a single request.
+        q must be 2–100 characters. Results are grouped by entity type.
+      operationId: globalSearch
+      parameters:
+      - description: Search query (2–100 characters)
+        in: query
+        name: q
+        required: true
+        type: string
+      - description: Max results per type (default 10, max 50)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/docs.SearchResults'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Unified cross-entity search
+      tags:
+      - Search
   /smart-scan/hosts/{id}/refresh-identity:
     post:
       description: Queues an identity_enrichment scan for a host, probing mDNS/SNMP/DNS/TLS

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1139,6 +1139,78 @@ definitions:
         example: 524288
         type: integer
     type: object
+  docs.ScanDiffEntryResponse:
+    properties:
+      port:
+        example: 443
+        type: integer
+      prev_service_name:
+        example: http
+        type: string
+      prev_service_version:
+        type: string
+      prev_state:
+        example: filtered
+        type: string
+      protocol:
+        example: tcp
+        type: string
+      service_name:
+        example: https
+        type: string
+      service_version:
+        example: nginx/1.24.0
+        type: string
+      state:
+        example: open
+        type: string
+      status:
+        description: Status is "new" | "closed" | "changed" | "unchanged"
+        enum:
+        - new
+        - closed
+        - changed
+        - unchanged
+        example: new
+        type: string
+    type: object
+  docs.ScanDiffResponse:
+    properties:
+      changed_count:
+        example: 2
+        type: integer
+      closed_count:
+        example: 1
+        type: integer
+      curr_os_name:
+        example: Ubuntu 22.04
+        type: string
+      host_id:
+        example: 550e8400-e29b-41d4-a716-446655440002
+        type: string
+      new_count:
+        example: 3
+        type: integer
+      os_changed:
+        example: false
+        type: boolean
+      ports:
+        items:
+          $ref: '#/definitions/docs.ScanDiffEntryResponse'
+        type: array
+      prev_os_name:
+        example: Ubuntu 20.04
+        type: string
+      scan_a_id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      scan_b_id:
+        example: 550e8400-e29b-41d4-a716-446655440001
+        type: string
+      unchanged_count:
+        example: 47
+        type: integer
+    type: object
   docs.ScanResponse:
     properties:
       completed_at:
@@ -4158,6 +4230,54 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Stop scan
+      tags:
+      - Scans
+  /scans/diff:
+    get:
+      description: |-
+        Compare two scans of the same host and return a structured port diff.
+        New ports are marked "new", ports that disappeared are "closed",
+        ports with changed service or state are "changed", the rest are "unchanged".
+      operationId: getScanDiff
+      parameters:
+      - description: Scan A ID (older/baseline)
+        format: uuid
+        in: query
+        name: a
+        required: true
+        type: string
+      - description: Scan B ID (newer/current)
+        format: uuid
+        in: query
+        name: b
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/docs.ScanDiffResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/docs.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Compare two scans
       tags:
       - Scans
   /schedules:

--- a/docs/swagger_docs.go
+++ b/docs/swagger_docs.go
@@ -2202,3 +2202,43 @@ func DeleteAlertRule(_ http.ResponseWriter, _ *http.Request) {}
 // @Router       /hosts/{id}/alerts [get]
 // @ID           listHostAlertRules
 func ListHostAlertRules(_ http.ResponseWriter, _ *http.Request) {}
+
+// ExportHosts godoc
+// @Summary      Export hosts as CSV or JSON
+// @Description  Streams all hosts matching the active filters as a file download.
+// @Description  Uses chunked DB reads so large exports do not buffer in memory.
+// @Tags         Hosts
+// @Produce      text/csv,application/json
+// @Param        format      query  string  false  "Output format: csv (default) or json"  Enums(csv,json)
+// @Param        status      query  string  false  "Filter by host status"
+// @Param        os          query  string  false  "Filter by OS family"
+// @Param        network     query  string  false  "Filter by network CIDR"
+// @Param        vendor      query  string  false  "Filter by vendor"
+// @Param        search      query  string  false  "Full-text search"
+// @Param        sort_by     query  string  false  "Sort column"
+// @Param        sort_order  query  string  false  "Sort direction: asc or desc"
+// @Success      200  "CSV or JSON file download"
+// @Failure      500  {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /hosts/export [get]
+// @ID           exportHosts
+func ExportHosts(_ http.ResponseWriter, _ *http.Request) {}
+
+// ExportScans godoc
+// @Summary      Export scans as CSV or JSON
+// @Description  Streams all scans matching the active filters as a file download.
+// @Description  Uses chunked DB reads so large exports do not buffer in memory.
+// @Tags         Scans
+// @Produce      text/csv,application/json
+// @Param        format      query  string  false  "Output format: csv (default) or json"  Enums(csv,json)
+// @Param        status      query  string  false  "Filter by scan status"
+// @Param        scan_type   query  string  false  "Filter by scan type"
+// @Param        profile_id  query  string  false  "Filter by profile ID"
+// @Param        sort_by     query  string  false  "Sort column"
+// @Param        sort_order  query  string  false  "Sort direction: asc or desc"
+// @Success      200  "CSV or JSON file download"
+// @Failure      500  {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /scans/export [get]
+// @ID           exportScans
+func ExportScans(_ http.ResponseWriter, _ *http.Request) {}

--- a/docs/swagger_docs.go
+++ b/docs/swagger_docs.go
@@ -1914,3 +1914,140 @@ func AcceptDeviceSuggestion(_ http.ResponseWriter, _ *http.Request) {}
 // @Router       /devices/suggestions/{id}/dismiss [post]
 // @ID           dismissDeviceSuggestion
 func DismissDeviceSuggestion(_ http.ResponseWriter, _ *http.Request) {}
+
+// ── Webhooks ─────────────────────────────────────────────────────────────────
+
+// WebhookEndpointResponse represents a registered webhook delivery endpoint (secret omitted).
+type WebhookEndpointResponse struct {
+	ID        string    `json:"id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	URL       string    `json:"url" example:"https://example.com/webhook"`
+	Events    []string  `json:"events" example:"host.online,scan.completed"`
+	Enabled   bool      `json:"enabled" example:"true"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// WebhookCreateEndpointResponse is returned only on POST /webhooks (includes secret).
+type WebhookCreateEndpointResponse struct {
+	ID        string    `json:"id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	URL       string    `json:"url" example:"https://example.com/webhook"`
+	Secret    string    `json:"secret" example:"abc123..."`
+	Events    []string  `json:"events" example:"host.online,scan.completed"`
+	Enabled   bool      `json:"enabled" example:"true"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// WebhookDeliveryLogResponse represents a single webhook delivery attempt.
+type WebhookDeliveryLogResponse struct {
+	ID           string     `json:"id" example:"550e8400-e29b-41d4-a716-446655440001"`
+	EndpointID   string     `json:"endpoint_id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	EventType    string     `json:"event_type" example:"host.online"`
+	StatusCode   *int       `json:"status_code" example:"200"`
+	AttemptCount int        `json:"attempt_count" example:"1"`
+	LastError    *string    `json:"last_error"`
+	DeliveredAt  *time.Time `json:"delivered_at"`
+	CreatedAt    time.Time  `json:"created_at"`
+}
+
+// ListWebhooks godoc
+// @Summary      List webhook endpoints
+// @Description  Returns all registered webhook delivery endpoints.
+// @Tags         Webhooks
+// @Produce      json
+// @Success      200 {object}  map[string]any
+// @Failure      500 {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /webhooks [get]
+// @ID           listWebhooks
+func ListWebhooks(_ http.ResponseWriter, _ *http.Request) {}
+
+// CreateWebhook godoc
+// @Summary      Create webhook endpoint
+// @Description  Registers a new webhook delivery endpoint.
+// @Tags         Webhooks
+// @Accept       json
+// @Produce      json
+// @Param        body  body      WebhookEndpointResponse       true  "Webhook input"
+// @Success      201   {object}  WebhookCreateEndpointResponse
+// @Failure      400   {object}  ErrorResponse
+// @Failure      500   {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /webhooks [post]
+// @ID           createWebhook
+func CreateWebhook(_ http.ResponseWriter, _ *http.Request) {}
+
+// GetWebhook godoc
+// @Summary      Get webhook endpoint
+// @Description  Returns a single webhook endpoint by ID.
+// @Tags         Webhooks
+// @Produce      json
+// @Param        id   path      string  true  "Webhook UUID" format(uuid)
+// @Success      200  {object}  WebhookEndpointResponse
+// @Failure      400  {object}  ErrorResponse
+// @Failure      404  {object}  ErrorResponse
+// @Failure      500  {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /webhooks/{id} [get]
+// @ID           getWebhook
+func GetWebhook(_ http.ResponseWriter, _ *http.Request) {}
+
+// UpdateWebhook godoc
+// @Summary      Update webhook endpoint
+// @Description  Applies partial updates to a webhook endpoint.
+// @Tags         Webhooks
+// @Accept       json
+// @Produce      json
+// @Param        id    path      string                   true  "Webhook UUID" format(uuid)
+// @Param        body  body      WebhookEndpointResponse  true  "Update fields"
+// @Success      200   {object}  WebhookEndpointResponse
+// @Failure      400   {object}  ErrorResponse
+// @Failure      404   {object}  ErrorResponse
+// @Failure      500   {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /webhooks/{id} [patch]
+// @ID           updateWebhook
+func UpdateWebhook(_ http.ResponseWriter, _ *http.Request) {}
+
+// DeleteWebhook godoc
+// @Summary      Delete webhook endpoint
+// @Description  Removes a webhook endpoint and its delivery log.
+// @Tags         Webhooks
+// @Param        id  path  string  true  "Webhook UUID" format(uuid)
+// @Success      204 "Successfully deleted"
+// @Failure      400 {object}  ErrorResponse
+// @Failure      404 {object}  ErrorResponse
+// @Failure      500 {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /webhooks/{id} [delete]
+// @ID           deleteWebhook
+func DeleteWebhook(_ http.ResponseWriter, _ *http.Request) {}
+
+// TestWebhook godoc
+// @Summary      Send test delivery
+// @Description  Fires a synchronous test event to the webhook endpoint.
+// @Tags         Webhooks
+// @Param        id  path  string  true  "Webhook UUID" format(uuid)
+// @Success      200 {object}  map[string]any
+// @Failure      400 {object}  ErrorResponse
+// @Failure      404 {object}  ErrorResponse
+// @Failure      500 {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /webhooks/{id}/test [post]
+// @ID           testWebhook
+func TestWebhook(_ http.ResponseWriter, _ *http.Request) {}
+
+// ListWebhookDeliveryLogs godoc
+// @Summary      List delivery logs
+// @Description  Returns delivery logs for a webhook endpoint (newest first, max 200).
+// @Tags         Webhooks
+// @Produce      json
+// @Param        id     path      string  true   "Webhook UUID" format(uuid)
+// @Param        limit  query     int     false  "Maximum log entries (default 50, max 200)"
+// @Success      200    {object}  map[string]any
+// @Failure      400    {object}  ErrorResponse
+// @Failure      500    {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /webhooks/{id}/logs [get]
+// @ID           listWebhookDeliveryLogs
+func ListWebhookDeliveryLogs(_ http.ResponseWriter, _ *http.Request) {}

--- a/docs/swagger_docs.go
+++ b/docs/swagger_docs.go
@@ -2051,3 +2051,106 @@ func TestWebhook(_ http.ResponseWriter, _ *http.Request) {}
 // @Router       /webhooks/{id}/logs [get]
 // @ID           listWebhookDeliveryLogs
 func ListWebhookDeliveryLogs(_ http.ResponseWriter, _ *http.Request) {}
+
+// ── Alert Rules ───────────────────────────────────────────────────────────────
+
+// AlertRuleResponse is returned for alert rule read/write operations.
+type AlertRuleResponse struct {
+	ID          string  `json:"id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	HostID      *string `json:"host_id" example:"550e8400-e29b-41d4-a716-446655440001"`
+	GroupID     *string `json:"group_id"`
+	Tag         *string `json:"tag" example:"nas"`
+	Trigger     string  `json:"trigger" example:"offline" enums:"online,offline,both"`
+	ChannelType string  `json:"channel_type" example:"webhook"`
+	ChannelURL  string  `json:"channel_url" example:"https://example.com/hook"`
+	Enabled     bool    `json:"enabled" example:"true"`
+	CreatedAt   string  `json:"created_at"`
+	UpdatedAt   string  `json:"updated_at"`
+}
+
+// ListAlertRules godoc
+// @Summary      List all alert rules
+// @Description  Returns all configured alert rules.
+// @Tags         Alerts
+// @Produce      json
+// @Success      200  {array}   AlertRuleResponse
+// @Failure      500  {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /alerts [get]
+// @ID           listAlertRules
+func ListAlertRules(_ http.ResponseWriter, _ *http.Request) {}
+
+// CreateAlertRule godoc
+// @Summary      Create an alert rule
+// @Description  Creates a new alert rule for a host, group, or tag.
+// @Tags         Alerts
+// @Accept       json
+// @Produce      json
+// @Param        body  body      AlertRuleResponse  true  "Alert rule input"
+// @Success      201   {object}  AlertRuleResponse
+// @Failure      400   {object}  ErrorResponse
+// @Failure      500   {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /alerts [post]
+// @ID           createAlertRule
+func CreateAlertRule(_ http.ResponseWriter, _ *http.Request) {}
+
+// GetAlertRule godoc
+// @Summary      Get an alert rule
+// @Description  Returns a single alert rule by ID.
+// @Tags         Alerts
+// @Produce      json
+// @Param        id  path      string  true  "Alert rule UUID" format(uuid)
+// @Success      200 {object}  AlertRuleResponse
+// @Failure      400 {object}  ErrorResponse
+// @Failure      404 {object}  ErrorResponse
+// @Failure      500 {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /alerts/{id} [get]
+// @ID           getAlertRule
+func GetAlertRule(_ http.ResponseWriter, _ *http.Request) {}
+
+// UpdateAlertRule godoc
+// @Summary      Update an alert rule
+// @Description  Applies partial updates to an alert rule.
+// @Tags         Alerts
+// @Accept       json
+// @Produce      json
+// @Param        id    path      string             true  "Alert rule UUID" format(uuid)
+// @Param        body  body      AlertRuleResponse  true  "Update fields"
+// @Success      200   {object}  AlertRuleResponse
+// @Failure      400   {object}  ErrorResponse
+// @Failure      404   {object}  ErrorResponse
+// @Failure      500   {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /alerts/{id} [patch]
+// @ID           updateAlertRule
+func UpdateAlertRule(_ http.ResponseWriter, _ *http.Request) {}
+
+// DeleteAlertRule godoc
+// @Summary      Delete an alert rule
+// @Description  Removes an alert rule.
+// @Tags         Alerts
+// @Param        id  path  string  true  "Alert rule UUID" format(uuid)
+// @Success      204 "Successfully deleted"
+// @Failure      400 {object}  ErrorResponse
+// @Failure      404 {object}  ErrorResponse
+// @Failure      500 {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /alerts/{id} [delete]
+// @ID           deleteAlertRule
+func DeleteAlertRule(_ http.ResponseWriter, _ *http.Request) {}
+
+// ListHostAlertRules godoc
+// @Summary      List alert rules for a host
+// @Description  Returns alert rules that target a specific host directly.
+// @Tags         Alerts
+// @Produce      json
+// @Param        id  path      string  true  "Host UUID" format(uuid)
+// @Success      200 {array}   AlertRuleResponse
+// @Failure      400 {object}  ErrorResponse
+// @Failure      500 {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /hosts/{id}/alerts [get]
+// @ID           listHostAlertRules
+func ListHostAlertRules(_ http.ResponseWriter, _ *http.Request) {}

--- a/docs/swagger_docs.go
+++ b/docs/swagger_docs.go
@@ -474,6 +474,35 @@ type LivenessResponse struct {
 	Uptime    string    `json:"uptime" example:"2h30m45s"`
 }
 
+// ScanDiffEntryResponse represents one port's state in a scan diff.
+type ScanDiffEntryResponse struct {
+	Port           int     `json:"port" example:"443"`
+	Protocol       string  `json:"protocol" example:"tcp"`
+	State          string  `json:"state" example:"open"`
+	ServiceName    *string `json:"service_name,omitempty" example:"https"`
+	ServiceVersion *string `json:"service_version,omitempty" example:"nginx/1.24.0"`
+	// Status is "new" | "closed" | "changed" | "unchanged"
+	Status             string  `json:"status" example:"new" enums:"new,closed,changed,unchanged"`
+	PrevState          *string `json:"prev_state,omitempty" example:"filtered"`
+	PrevServiceName    *string `json:"prev_service_name,omitempty" example:"http"`
+	PrevServiceVersion *string `json:"prev_service_version,omitempty"`
+}
+
+// ScanDiffResponse is the result of comparing two scans of the same host.
+type ScanDiffResponse struct {
+	ScanAID        string                  `json:"scan_a_id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	ScanBID        string                  `json:"scan_b_id" example:"550e8400-e29b-41d4-a716-446655440001"`
+	HostID         string                  `json:"host_id" example:"550e8400-e29b-41d4-a716-446655440002"`
+	Ports          []ScanDiffEntryResponse `json:"ports"`
+	OSChanged      bool                    `json:"os_changed" example:"false"`
+	PrevOSName     *string                 `json:"prev_os_name,omitempty" example:"Ubuntu 20.04"`
+	CurrOSName     *string                 `json:"curr_os_name,omitempty" example:"Ubuntu 22.04"`
+	NewCount       int                     `json:"new_count" example:"3"`
+	ClosedCount    int                     `json:"closed_count" example:"1"`
+	ChangedCount   int                     `json:"changed_count" example:"2"`
+	UnchangedCount int                     `json:"unchanged_count" example:"47"`
+}
+
 // UpdateScanRequest represents a request to update an existing scan
 type UpdateScanRequest struct {
 	Name        string            `json:"name" example:"Updated scan name"`
@@ -1117,6 +1146,25 @@ func StopScan(_ http.ResponseWriter, _ *http.Request) {}
 // @Router /scans/{scanId} [put]
 // @ID updateScan
 func UpdateScan(_ http.ResponseWriter, _ *http.Request) {}
+
+// GetScanDiff godoc
+// @Summary Compare two scans
+// @Description Compare two scans of the same host and return a structured port diff.
+// @Description New ports are marked "new", ports that disappeared are "closed",
+// @Description ports with changed service or state are "changed", the rest are "unchanged".
+// @Tags Scans
+// @Produce json
+// @Param a query string true "Scan A ID (older/baseline)" format(uuid)
+// @Param b query string true "Scan B ID (newer/current)" format(uuid)
+// @Success 200 {object} ScanDiffResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Security ApiKeyAuth
+// @Router /scans/diff [get]
+// @ID getScanDiff
+func GetScanDiff(_ http.ResponseWriter, _ *http.Request) {}
 
 // Liveness godoc
 // @Summary Liveness check

--- a/docs/swagger_docs.go
+++ b/docs/swagger_docs.go
@@ -2242,3 +2242,34 @@ func ExportHosts(_ http.ResponseWriter, _ *http.Request) {}
 // @Router       /scans/export [get]
 // @ID           exportScans
 func ExportScans(_ http.ResponseWriter, _ *http.Request) {}
+
+// SearchResult represents a single item returned by the unified search endpoint.
+type SearchResult struct {
+	ID    string `json:"id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Label string `json:"label" example:"192.168.1.1 (myserver)"`
+	URL   string `json:"url" example:"/hosts/550e8400-e29b-41d4-a716-446655440000"`
+	Type  string `json:"type" example:"host" enums:"host,network,scan,profile"`
+}
+
+// SearchResults is the top-level response from the unified search endpoint.
+type SearchResults struct {
+	Results map[string][]SearchResult `json:"results"`
+	Total   int                       `json:"total" example:"4"`
+}
+
+// GlobalSearch godoc
+// @Summary      Unified cross-entity search
+// @Description  Search across hosts (by IP/hostname), networks (by name/CIDR),
+// @Description  scans (by target), and profiles (by name) in a single request.
+// @Description  q must be 2–100 characters. Results are grouped by entity type.
+// @Tags         Search
+// @Produce      json
+// @Param        q      query    string  true   "Search query (2–100 characters)"
+// @Param        limit  query    int     false  "Max results per type (default 10, max 50)"
+// @Success      200    {object} SearchResults
+// @Failure      400    {object} ErrorResponse
+// @Failure      500    {object} ErrorResponse
+// @Security     ApiKeyAuth
+// @Router       /search [get]
+// @ID           globalSearch
+func GlobalSearch(_ http.ResponseWriter, _ *http.Request) {}

--- a/docs/swagger_docs.go
+++ b/docs/swagger_docs.go
@@ -237,6 +237,10 @@ type HostResponse struct {
 	// host (usable or not). Only populated on GET /hosts/{id}; list responses
 	// leave it as an empty array.
 	NameCandidates []NameCandidateResponse `json:"name_candidates"`
+	// DeviceID is the stable device this host is attached to, if any.
+	DeviceID *string `json:"device_id,omitempty" example:"550e8400-e29b-41d4-a716-446655440001"`
+	// DeviceName is the canonical name of the attached device, populated by JOIN in GetHost.
+	DeviceName *string `json:"device_name,omitempty" example:"Andreas's iPhone"`
 }
 
 // NameCandidateResponse is one row of the Identity tab's candidate table —

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7030,22 +7030,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yaml-ast-parser": {
       "version": "0.0.43",
       "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",

--- a/frontend/src/api/hooks/use-alerts.test.ts
+++ b/frontend/src/api/hooks/use-alerts.test.ts
@@ -1,0 +1,213 @@
+import { waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHookWithQuery } from "../../test/utils";
+import {
+  useAlertRules,
+  useHostAlertRules,
+  useCreateAlertRule,
+  useUpdateAlertRule,
+  useDeleteAlertRule,
+  type AlertRule,
+} from "./use-alerts";
+
+vi.mock("../client", () => ({
+  api: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PATCH: vi.fn(),
+    DELETE: vi.fn(),
+  },
+}));
+
+import { api } from "../client";
+const mockGet = vi.mocked(api.GET);
+const mockPost = vi.mocked(api.POST);
+const mockPatch = vi.mocked(api.PATCH);
+const mockDelete = vi.mocked(api.DELETE);
+
+const ok = (data: unknown): Awaited<ReturnType<typeof mockGet>> =>
+  ({ data, error: undefined, response: new Response() }) as Awaited<
+    ReturnType<typeof mockGet>
+  >;
+
+const fail = (message = "error"): Awaited<ReturnType<typeof mockGet>> =>
+  ({ data: undefined, error: { message }, response: new Response() }) as Awaited<
+    ReturnType<typeof mockGet>
+  >;
+
+// ── sample data ───────────────────────────────────────────────────────────────
+
+const sampleRule: AlertRule = {
+  id: "rule-1",
+  host_id: "host-1",
+  group_id: null,
+  tag: null,
+  trigger: "online",
+  channel_type: "webhook",
+  channel_url: "https://example.com/hook",
+  enabled: true,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+// ── useAlertRules ─────────────────────────────────────────────────────────────
+
+describe("useAlertRules", () => {
+  afterEach(() => vi.resetAllMocks());
+
+  it("returns the rule list on success", async () => {
+    mockGet.mockResolvedValue(ok({ alert_rules: [sampleRule] }));
+
+    const { result } = renderHookWithQuery(() => useAlertRules());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect((result.current.data as AlertRule[])[0].trigger).toBe("online");
+  });
+
+  it("returns empty array when list is empty", async () => {
+    mockGet.mockResolvedValue(ok({ alert_rules: [] }));
+
+    const { result } = renderHookWithQuery(() => useAlertRules());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(0);
+  });
+
+  it("surfaces errors", async () => {
+    mockGet.mockResolvedValue(fail());
+
+    const { result } = renderHookWithQuery(() => useAlertRules());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+// ── useHostAlertRules ─────────────────────────────────────────────────────────
+
+describe("useHostAlertRules", () => {
+  afterEach(() => vi.resetAllMocks());
+
+  it("returns rules for a given host on success", async () => {
+    mockGet.mockResolvedValue(ok({ alert_rules: [sampleRule] }));
+
+    const { result } = renderHookWithQuery(() => useHostAlertRules("host-1"));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect((result.current.data as AlertRule[])[0].channel_url).toBe(
+      "https://example.com/hook",
+    );
+  });
+
+  it("is disabled when hostID is empty", () => {
+    const { result } = renderHookWithQuery(() => useHostAlertRules(""));
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("surfaces errors", async () => {
+    mockGet.mockResolvedValue(fail());
+
+    const { result } = renderHookWithQuery(() => useHostAlertRules("host-1"));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+// ── useCreateAlertRule ────────────────────────────────────────────────────────
+
+describe("useCreateAlertRule", () => {
+  afterEach(() => vi.resetAllMocks());
+
+  it("fires POST and returns the new rule on success", async () => {
+    mockPost.mockResolvedValue(ok(sampleRule));
+
+    const { result, actHook } = renderHookWithQuery(() => useCreateAlertRule());
+    let created: AlertRule | undefined;
+    await actHook(async () => {
+      created = await result.current.mutateAsync({
+        host_id: "host-1",
+        trigger: "online",
+        channel_url: "https://example.com/hook",
+      });
+    });
+
+    expect(created?.trigger).toBe("online");
+  });
+
+  it("throws on error", async () => {
+    mockPost.mockResolvedValue(fail("bad trigger"));
+
+    const { result, actHook } = renderHookWithQuery(() => useCreateAlertRule());
+    await expect(
+      actHook(async () => {
+        await result.current.mutateAsync({
+          host_id: "host-1",
+          trigger: "online",
+          channel_url: "https://example.com/hook",
+        });
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+// ── useUpdateAlertRule ────────────────────────────────────────────────────────
+
+describe("useUpdateAlertRule", () => {
+  afterEach(() => vi.resetAllMocks());
+
+  it("fires PATCH and returns updated rule on success", async () => {
+    const updated = { ...sampleRule, enabled: false };
+    mockPatch.mockResolvedValue(ok(updated));
+
+    const { result, actHook } = renderHookWithQuery(() => useUpdateAlertRule());
+    let updatedRule: AlertRule | undefined;
+    await actHook(async () => {
+      updatedRule = await result.current.mutateAsync({
+        id: "rule-1",
+        body: { enabled: false },
+      });
+    });
+
+    expect(updatedRule?.enabled).toBe(false);
+  });
+
+  it("throws on error", async () => {
+    mockPatch.mockResolvedValue(fail("bad trigger"));
+
+    const { result, actHook } = renderHookWithQuery(() => useUpdateAlertRule());
+    await expect(
+      actHook(async () => {
+        await result.current.mutateAsync({
+          id: "rule-1",
+          body: { trigger: "invalid" as "online" },
+        });
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+// ── useDeleteAlertRule ────────────────────────────────────────────────────────
+
+describe("useDeleteAlertRule", () => {
+  afterEach(() => vi.resetAllMocks());
+
+  it("fires DELETE and resolves on success", async () => {
+    mockDelete.mockResolvedValue(ok(undefined));
+
+    const { result, actHook } = renderHookWithQuery(() => useDeleteAlertRule());
+    let resolved = false;
+    await actHook(async () => {
+      await result.current.mutateAsync({ id: "rule-1", hostID: "host-1" });
+      resolved = true;
+    });
+
+    expect(resolved).toBe(true);
+  });
+
+  it("throws on error", async () => {
+    mockDelete.mockResolvedValue(fail("not found"));
+
+    const { result, actHook } = renderHookWithQuery(() => useDeleteAlertRule());
+    await expect(
+      actHook(async () => {
+        await result.current.mutateAsync({ id: "rule-1" });
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/frontend/src/api/hooks/use-alerts.ts
+++ b/frontend/src/api/hooks/use-alerts.ts
@@ -1,0 +1,112 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../client";
+import type { components } from "../types";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type AlertRule = components["schemas"]["docs.AlertRuleResponse"];
+
+// The swagger spec reuses AlertRuleResponse for request bodies; these local
+// aliases document the intended subset until the spec is updated.
+export type CreateAlertRuleBody = Pick<
+  AlertRule,
+  "host_id" | "group_id" | "tag" | "trigger" | "channel_url"
+>;
+export type UpdateAlertRuleBody = Pick<
+  AlertRule,
+  "trigger" | "channel_url" | "enabled"
+>;
+
+// ── Query keys ────────────────────────────────────────────────────────────────
+
+const ALERTS_KEY = ["alerts"] as const;
+const hostAlertsKey = (hostID: string) => ["alerts", "host", hostID] as const;
+
+// ── Hooks ─────────────────────────────────────────────────────────────────────
+
+export function useAlertRules() {
+  return useQuery({
+    queryKey: ALERTS_KEY,
+    queryFn: async () => {
+      const { data, error } = await api.GET("/alerts");
+      if (error) throw error;
+      return data?.alert_rules ?? [];
+    },
+    staleTime: 30_000,
+  });
+}
+
+export function useHostAlertRules(hostID: string) {
+  return useQuery({
+    queryKey: hostAlertsKey(hostID),
+    queryFn: async () => {
+      const { data, error } = await api.GET("/hosts/{id}/alerts", {
+        params: { path: { id: hostID } },
+      });
+      if (error) throw error;
+      return data?.alert_rules ?? [];
+    },
+    enabled: !!hostID,
+    staleTime: 30_000,
+  });
+}
+
+export function useCreateAlertRule() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: CreateAlertRuleBody) => {
+      const { data, error } = await api.POST("/alerts", { body });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: ALERTS_KEY });
+      if (vars.host_id) {
+        queryClient.invalidateQueries({
+          queryKey: hostAlertsKey(vars.host_id),
+        });
+      }
+    },
+  });
+}
+
+export function useUpdateAlertRule() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      body,
+    }: {
+      id: string;
+      body: UpdateAlertRuleBody;
+    }) => {
+      const { data, error } = await api.PATCH("/alerts/{id}", {
+        params: { path: { id } },
+        body,
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ALERTS_KEY });
+    },
+  });
+}
+
+export function useDeleteAlertRule() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id }: { id: string; hostID?: string }) => {
+      const { error } = await api.DELETE("/alerts/{id}", {
+        params: { path: { id } },
+      });
+      if (error) throw error;
+    },
+    onSuccess: (_data, { hostID }) => {
+      queryClient.invalidateQueries({ queryKey: ALERTS_KEY });
+      if (hostID) {
+        queryClient.invalidateQueries({ queryKey: hostAlertsKey(hostID) });
+      }
+    },
+  });
+}

--- a/frontend/src/api/hooks/use-hosts.ts
+++ b/frontend/src/api/hooks/use-hosts.ts
@@ -86,7 +86,7 @@ export function useUpdateHost() {
       body,
     }: {
       hostId: string;
-      body: { hostname?: string; tags?: string[]; notes?: string };
+      body: { hostname?: string; tags?: string[]; notes?: string; description?: string };
     }) => {
       const { data, error, response } = await api.PUT("/hosts/{hostId}", {
         params: { path: { hostId } },

--- a/frontend/src/api/hooks/use-scan-diff.test.ts
+++ b/frontend/src/api/hooks/use-scan-diff.test.ts
@@ -1,0 +1,112 @@
+import { waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHookWithQuery } from "../../test/utils";
+import { useScanDiff } from "./use-scan-diff";
+
+vi.mock("../client", () => ({
+  api: {
+    GET: vi.fn(),
+  },
+}));
+
+import { api } from "../client";
+const mockGet = vi.mocked(api.GET);
+
+const ok = (data: unknown): Awaited<ReturnType<typeof mockGet>> =>
+  ({
+    data,
+    error: undefined,
+    response: new Response(),
+  }) as Awaited<ReturnType<typeof mockGet>>;
+
+const fail = (message = "error"): Awaited<ReturnType<typeof mockGet>> =>
+  ({
+    data: undefined,
+    error: { message },
+    response: new Response(),
+  }) as Awaited<ReturnType<typeof mockGet>>;
+
+const mockDiff = {
+  scan_a_id: "aaaaaaaa-0000-0000-0000-000000000001",
+  scan_b_id: "bbbbbbbb-0000-0000-0000-000000000002",
+  host_id: "cccccccc-0000-0000-0000-000000000003",
+  ports: [
+    {
+      port: 443,
+      protocol: "tcp",
+      state: "open",
+      service_name: "https",
+      status: "new",
+    },
+    {
+      port: 22,
+      protocol: "tcp",
+      state: "open",
+      service_name: "ssh",
+      status: "unchanged",
+    },
+  ],
+  os_changed: false,
+  new_count: 1,
+  closed_count: 0,
+  changed_count: 0,
+  unchanged_count: 1,
+};
+
+const idA = "aaaaaaaa-0000-0000-0000-000000000001";
+const idB = "bbbbbbbb-0000-0000-0000-000000000002";
+
+// ── useScanDiff ───────────────────────────────────────────────────────────────
+
+describe("useScanDiff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("is disabled when scanAId is undefined", () => {
+    const { result } = renderHookWithQuery(() => useScanDiff(undefined, idB));
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("is disabled when scanBId is undefined", () => {
+    const { result } = renderHookWithQuery(() => useScanDiff(idA, undefined));
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("is disabled when both IDs are undefined", () => {
+    const { result } = renderHookWithQuery(() =>
+      useScanDiff(undefined, undefined),
+    );
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("fetches diff when both IDs are provided (loading then success)", async () => {
+    mockGet.mockResolvedValue(ok(mockDiff));
+    const { result } = renderHookWithQuery(() => useScanDiff(idA, idB));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith("/scans/diff", expect.anything());
+    const diff = result.current.data;
+    expect(diff?.scan_a_id).toBe(idA);
+    expect(diff?.scan_b_id).toBe(idB);
+    expect(diff?.new_count).toBe(1);
+    expect(diff?.unchanged_count).toBe(1);
+    expect(diff?.os_changed).toBe(false);
+    expect(diff?.ports).toHaveLength(2);
+    expect(diff?.ports?.[0]?.status).toBe("new");
+    expect(diff?.ports?.[1]?.status).toBe("unchanged");
+  });
+
+  it("surfaces error state when the API call fails", async () => {
+    mockGet.mockResolvedValue(fail("scan not found"));
+    const { result } = renderHookWithQuery(() => useScanDiff(idA, idB));
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+  });
+});

--- a/frontend/src/api/hooks/use-scan-diff.ts
+++ b/frontend/src/api/hooks/use-scan-diff.ts
@@ -1,0 +1,35 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../client";
+import { ApiError } from "../errors";
+import type { components } from "../types";
+
+export type ScanDiffEntry = components["schemas"]["docs.ScanDiffEntryResponse"];
+export type ScanDiff = components["schemas"]["docs.ScanDiffResponse"];
+
+/**
+ * useScanDiff fetches a diff between two scans of the same host.
+ *
+ * @param scanAId - Baseline scan ID (older)
+ * @param scanBId - Current scan ID (newer)
+ *
+ * Enabled only when both IDs are provided. Diffs are stable once computed
+ * (scan results don't change), so staleTime is set to 60 s.
+ */
+export function useScanDiff(
+  scanAId: string | undefined,
+  scanBId: string | undefined,
+) {
+  return useQuery({
+    queryKey: ["scans", "diff", scanAId, scanBId],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET("/scans/diff", {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        params: { query: { a: scanAId!, b: scanBId! } as any },
+      });
+      if (error) throw new ApiError(response.status, error);
+      return data as ScanDiff;
+    },
+    enabled: !!scanAId && !!scanBId,
+    staleTime: 60_000,
+  });
+}

--- a/frontend/src/api/hooks/use-search.test.ts
+++ b/frontend/src/api/hooks/use-search.test.ts
@@ -1,0 +1,106 @@
+import { waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHookWithQuery } from "../../test/utils";
+import { useSearch } from "./use-search";
+
+vi.mock("../client", () => ({
+  api: {
+    GET: vi.fn(),
+  },
+}));
+
+import { api } from "../client";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockGet = vi.mocked((api as any).GET);
+
+const ok = (data: unknown) =>
+  Promise.resolve({ data, error: undefined, response: new Response() });
+
+const fail = (msg = "error") =>
+  Promise.resolve({
+    data: undefined,
+    error: { message: msg },
+    response: new Response(),
+  });
+
+const mockResults = {
+  results: {
+    hosts: [{ id: "h1", label: "192.168.1.1 (myhost)", url: "/hosts/h1", type: "host" }],
+    networks: [],
+    scans: [],
+    profiles: [],
+  },
+  total: 1,
+};
+
+describe("useSearch", () => {
+  beforeEach(() => {
+    mockGet.mockClear();
+  });
+
+  it("is disabled when query is empty", () => {
+    const { result } = renderHookWithQuery(() => useSearch(""));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("is disabled when query is 1 character", () => {
+    const { result } = renderHookWithQuery(() => useSearch("x"));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("fires when query has 2+ characters", async () => {
+    mockGet.mockReturnValue(ok(mockResults));
+
+    const { result } = renderHookWithQuery(() => useSearch("my"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns search results on success", async () => {
+    mockGet.mockReturnValue(ok(mockResults));
+
+    const { result } = renderHookWithQuery(() => useSearch("myhost"));
+
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined();
+    });
+
+    expect(result.current.data?.total).toBe(1);
+    expect(result.current.data?.results.hosts).toHaveLength(1);
+    expect(result.current.data?.results.hosts?.[0].label).toBe(
+      "192.168.1.1 (myhost)",
+    );
+  });
+
+  it("sets isError on API failure", async () => {
+    mockGet.mockReturnValue(fail("search failed"));
+
+    const { result } = renderHookWithQuery(() => useSearch("host"));
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+
+  it("has staleTime 0", async () => {
+    // Fire search twice with the same query — both should call the API.
+    mockGet.mockReturnValue(ok(mockResults));
+
+    const { result, rerender } = renderHookWithQuery(() => useSearch("test"));
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    // Unmount and remount to simulate fresh load — with staleTime 0 it refetches.
+    rerender();
+    // Simply confirm it was called (staleTime=0 means no cache hit held over).
+    expect(mockGet).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/hooks/use-search.ts
+++ b/frontend/src/api/hooks/use-search.ts
@@ -1,0 +1,44 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../client";
+import { ApiError } from "../errors";
+
+export interface SearchResultItem {
+  id: string;
+  label: string;
+  url: string;
+  type: string;
+}
+
+export interface SearchResults {
+  results: {
+    hosts?: SearchResultItem[];
+    networks?: SearchResultItem[];
+    scans?: SearchResultItem[];
+    profiles?: SearchResultItem[];
+  };
+  total: number;
+}
+
+const SEARCH_LIMIT = 10;
+
+/**
+ * Fires GET /api/v1/search?q=<query>&limit=10.
+ * Enabled only when query has at least 2 characters.
+ * staleTime: 0 — search results should always be fresh.
+ */
+export function useSearch(query: string) {
+  const enabled = query.length >= 2;
+
+  return useQuery<SearchResults>({
+    queryKey: ["search", query],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET("/search", {
+        params: { query: { q: query, limit: SEARCH_LIMIT } },
+      });
+      if (error) throw new ApiError(response.status, error);
+      return data as SearchResults;
+    },
+    enabled,
+    staleTime: 0,
+  });
+}

--- a/frontend/src/api/hooks/use-webhooks.test.ts
+++ b/frontend/src/api/hooks/use-webhooks.test.ts
@@ -1,0 +1,281 @@
+import { waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHookWithQuery } from "../../test/utils";
+import {
+  useWebhooks,
+  useWebhook,
+  useCreateWebhook,
+  useUpdateWebhook,
+  useDeleteWebhook,
+  useTestWebhook,
+  useDeliveryLogs,
+  type WebhookEndpoint,
+  type WebhookDeliveryLog,
+} from "./use-webhooks";
+
+vi.mock("../client", () => ({
+  api: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PATCH: vi.fn(),
+    DELETE: vi.fn(),
+  },
+}));
+
+import { api } from "../client";
+const mockGet = vi.mocked(api.GET);
+const mockPost = vi.mocked(api.POST);
+const mockPatch = vi.mocked(api.PATCH);
+const mockDelete = vi.mocked(api.DELETE);
+
+const ok = (data: unknown) =>
+  ({ data, error: undefined, response: new Response() }) as Awaited<ReturnType<typeof mockGet>>;
+
+const fail = (msg = "error") =>
+  ({
+    data: undefined,
+    error: { message: msg },
+    response: new Response(null, { status: 500 }),
+  }) as Awaited<ReturnType<typeof mockGet>>;
+
+const okMut = (data: unknown) =>
+  ({ data, error: undefined, response: new Response() }) as Awaited<ReturnType<typeof mockPost>>;
+
+const failMut = (msg = "error") =>
+  ({
+    data: undefined,
+    error: { message: msg },
+    response: new Response(null, { status: 500 }),
+  }) as Awaited<ReturnType<typeof mockPost>>;
+
+const sampleEndpoint: WebhookEndpoint = {
+  id: "ep-1",
+  url: "https://example.com/hook",
+  secret: "s3cr3t",
+  events: ["host.online"],
+  enabled: true,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+const sampleLog: WebhookDeliveryLog = {
+  id: "log-1",
+  endpoint_id: "ep-1",
+  event_type: "host.online",
+  status_code: 200,
+  attempt_count: 1,
+  last_error: null,
+  delivered_at: "2024-01-01T00:00:01Z",
+  created_at: "2024-01-01T00:00:00Z",
+};
+
+// ── useWebhooks ───────────────────────────────────────────────────────────────
+
+describe("useWebhooks", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns the webhook list on success", async () => {
+    mockGet.mockImplementation(((path: string) => {
+      expect(path).toBe("/webhooks");
+      return ok({ webhooks: [sampleEndpoint] });
+    }) as typeof mockGet);
+
+    const { result } = renderHookWithQuery(() => useWebhooks());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect((result.current.data as WebhookEndpoint[])[0].url).toBe("https://example.com/hook");
+  });
+
+  it("returns empty array on empty response", async () => {
+    mockGet.mockImplementation((() => ok({ webhooks: [] })) as typeof mockGet);
+
+    const { result } = renderHookWithQuery(() => useWebhooks());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(0);
+  });
+
+  it("surfaces errors", async () => {
+    mockGet.mockImplementation((() => fail()) as typeof mockGet);
+    const { result } = renderHookWithQuery(() => useWebhooks());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+// ── useWebhook ────────────────────────────────────────────────────────────────
+
+describe("useWebhook", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns endpoint detail on success", async () => {
+    mockGet.mockImplementation(((path: string) => {
+      expect(path).toBe("/webhooks/{id}");
+      return ok(sampleEndpoint);
+    }) as typeof mockGet);
+
+    const { result } = renderHookWithQuery(() => useWebhook("ep-1"));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect((result.current.data as WebhookEndpoint).url).toBe("https://example.com/hook");
+  });
+
+  it("surfaces errors", async () => {
+    mockGet.mockImplementation((() => fail()) as typeof mockGet);
+    const { result } = renderHookWithQuery(() => useWebhook("ep-1"));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("is disabled when id is empty", () => {
+    const { result } = renderHookWithQuery(() => useWebhook(""));
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+});
+
+// ── useCreateWebhook ──────────────────────────────────────────────────────────
+
+describe("useCreateWebhook", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("calls POST /webhooks with the provided body", async () => {
+    mockPost.mockResolvedValue(okMut(sampleEndpoint));
+
+    const { result, actHook } = renderHookWithQuery(() => useCreateWebhook());
+    await actHook(async () => {
+      await result.current.mutateAsync({ url: "https://example.com/hook", events: ["host.online"] });
+    });
+
+    expect(mockPost).toHaveBeenCalledWith("/webhooks", expect.objectContaining({
+      body: expect.objectContaining({ url: "https://example.com/hook" }),
+    }));
+  });
+
+  it("throws on error", async () => {
+    mockPost.mockResolvedValue(failMut("bad url") as Awaited<ReturnType<typeof mockPost>>);
+
+    const { result, actHook } = renderHookWithQuery(() => useCreateWebhook());
+    await expect(
+      actHook(async () => {
+        await result.current.mutateAsync({ url: "", events: [] });
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+// ── useUpdateWebhook ──────────────────────────────────────────────────────────
+
+describe("useUpdateWebhook", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("calls PATCH /webhooks/{id} with the provided body", async () => {
+    mockPatch.mockResolvedValue(okMut(sampleEndpoint) as Awaited<ReturnType<typeof mockPatch>>);
+
+    const { result, actHook } = renderHookWithQuery(() => useUpdateWebhook());
+    await actHook(async () => {
+      await result.current.mutateAsync({ id: "ep-1", body: { enabled: false } });
+    });
+
+    expect(mockPatch).toHaveBeenCalledWith("/webhooks/{id}", expect.objectContaining({
+      params: { path: { id: "ep-1" } },
+      body: expect.objectContaining({ enabled: false }),
+    }));
+  });
+
+  it("throws on error", async () => {
+    mockPatch.mockResolvedValue(failMut("not found") as Awaited<ReturnType<typeof mockPatch>>);
+
+    const { result, actHook } = renderHookWithQuery(() => useUpdateWebhook());
+    await expect(
+      actHook(async () => {
+        await result.current.mutateAsync({ id: "ep-1", body: { enabled: false } });
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+// ── useDeleteWebhook ──────────────────────────────────────────────────────────
+
+describe("useDeleteWebhook", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("calls DELETE /webhooks/{id}", async () => {
+    mockDelete.mockResolvedValue(okMut(undefined) as Awaited<ReturnType<typeof mockDelete>>);
+
+    const { result, actHook } = renderHookWithQuery(() => useDeleteWebhook());
+    await actHook(async () => {
+      await result.current.mutateAsync("ep-1");
+    });
+
+    expect(mockDelete).toHaveBeenCalledWith("/webhooks/{id}", expect.objectContaining({
+      params: { path: { id: "ep-1" } },
+    }));
+  });
+
+  it("throws on error", async () => {
+    mockDelete.mockResolvedValue(failMut("not found") as Awaited<ReturnType<typeof mockDelete>>);
+
+    const { result, actHook } = renderHookWithQuery(() => useDeleteWebhook());
+    await expect(
+      actHook(async () => {
+        await result.current.mutateAsync("ep-1");
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+// ── useTestWebhook ────────────────────────────────────────────────────────────
+
+describe("useTestWebhook", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("calls POST /webhooks/{id}/test", async () => {
+    mockPost.mockResolvedValue(okMut({ status: "delivered" }));
+
+    const { result, actHook } = renderHookWithQuery(() => useTestWebhook());
+    await actHook(async () => {
+      await result.current.mutateAsync("ep-1");
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/webhooks/{id}/test",
+      expect.objectContaining({ params: { path: { id: "ep-1" } } }),
+    );
+  });
+
+  it("throws on delivery failure", async () => {
+    mockPost.mockResolvedValue(failMut("endpoint returned 500"));
+
+    const { result, actHook } = renderHookWithQuery(() => useTestWebhook());
+    await expect(
+      actHook(async () => {
+        await result.current.mutateAsync("ep-1");
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+// ── useDeliveryLogs ───────────────────────────────────────────────────────────
+
+describe("useDeliveryLogs", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns log list on success", async () => {
+    mockGet.mockImplementation(((path: string) => {
+      expect(path).toBe("/webhooks/{id}/logs");
+      return ok({ logs: [sampleLog] });
+    }) as typeof mockGet);
+
+    const { result } = renderHookWithQuery(() => useDeliveryLogs("ep-1"));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect((result.current.data as WebhookDeliveryLog[])[0].event_type).toBe("host.online");
+  });
+
+  it("surfaces errors", async () => {
+    mockGet.mockImplementation((() => fail()) as typeof mockGet);
+    const { result } = renderHookWithQuery(() => useDeliveryLogs("ep-1"));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("is disabled when id is empty", () => {
+    const { result } = renderHookWithQuery(() => useDeliveryLogs(""));
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+});

--- a/frontend/src/api/hooks/use-webhooks.ts
+++ b/frontend/src/api/hooks/use-webhooks.ts
@@ -1,0 +1,151 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../client";
+import { ApiError } from "../errors";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface WebhookEndpoint {
+  id: string;
+  url: string;
+  secret: string;
+  events: string[];
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WebhookDeliveryLog {
+  id: string;
+  endpoint_id: string;
+  event_type: string;
+  status_code: number | null;
+  attempt_count: number;
+  last_error: string | null;
+  delivered_at: string | null;
+  created_at: string;
+}
+
+export interface CreateWebhookBody {
+  url: string;
+  secret?: string;
+  events: string[];
+}
+
+export interface UpdateWebhookBody {
+  url?: string;
+  secret?: string;
+  events?: string[];
+  enabled?: boolean;
+}
+
+// ── Query keys ────────────────────────────────────────────────────────────────
+
+const WEBHOOKS_KEY = ["webhooks"] as const;
+const webhookKey = (id: string) => ["webhooks", id] as const;
+const logsKey = (id: string) => ["webhooks", id, "logs"] as const;
+
+// ── Hooks ─────────────────────────────────────────────────────────────────────
+
+export function useWebhooks() {
+  return useQuery({
+    queryKey: WEBHOOKS_KEY,
+    queryFn: async () => {
+      const { data, error, response } = await api.GET("/webhooks");
+      if (error) throw new ApiError(response.status, error);
+      const payload = data as { webhooks?: WebhookEndpoint[] } | undefined;
+      return payload?.webhooks ?? [];
+    },
+    staleTime: 30_000,
+  });
+}
+
+export function useWebhook(id: string) {
+  return useQuery({
+    queryKey: webhookKey(id),
+    queryFn: async () => {
+      const { data, error, response } = await api.GET("/webhooks/{id}", {
+        params: { path: { id } },
+      });
+      if (error) throw new ApiError(response.status, error);
+      return data as WebhookEndpoint | undefined;
+    },
+    enabled: !!id,
+    staleTime: 30_000,
+  });
+}
+
+export function useCreateWebhook() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: CreateWebhookBody) => {
+      const { data, error, response } = await api.POST("/webhooks", {
+        body: body as Parameters<typeof api.POST<"/webhooks">>[1]["body"],
+      });
+      if (error) throw new ApiError(response.status, error);
+      return data as WebhookEndpoint | undefined;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: WEBHOOKS_KEY });
+    },
+  });
+}
+
+export function useUpdateWebhook() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, body }: { id: string; body: UpdateWebhookBody }) => {
+      const { data, error, response } = await api.PATCH("/webhooks/{id}", {
+        params: { path: { id } },
+        body: body as Parameters<typeof api.PATCH<"/webhooks/{id}">>[1]["body"],
+      });
+      if (error) throw new ApiError(response.status, error);
+      return data as WebhookEndpoint | undefined;
+    },
+    onSuccess: (_data, { id }) => {
+      queryClient.invalidateQueries({ queryKey: WEBHOOKS_KEY });
+      queryClient.invalidateQueries({ queryKey: webhookKey(id) });
+    },
+  });
+}
+
+export function useDeleteWebhook() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { error, response } = await api.DELETE("/webhooks/{id}", {
+        params: { path: { id } },
+      });
+      if (error) throw new ApiError(response.status, error);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: WEBHOOKS_KEY });
+    },
+  });
+}
+
+export function useTestWebhook() {
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { error, response } = await api.POST("/webhooks/{id}/test", {
+        params: { path: { id } },
+      });
+      if (error) throw new ApiError(response.status, error);
+    },
+  });
+}
+
+export function useDeliveryLogs(id: string) {
+  return useQuery({
+    queryKey: logsKey(id),
+    queryFn: async () => {
+      const { data, error, response } = await api.GET("/webhooks/{id}/logs", {
+        params: { path: { id } },
+      });
+      if (error) throw new ApiError(response.status, error);
+      const payload = data as { logs?: WebhookDeliveryLog[] } | undefined;
+      return payload?.logs ?? [];
+    },
+    enabled: !!id,
+    staleTime: 10_000,
+  });
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1152,6 +1152,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Unified cross-entity search
+         * @description Search across hosts (by IP/hostname), networks (by name/CIDR),
+         *     scans (by target), and profiles (by name) in a single request.
+         *     q must be 2–100 characters. Results are grouped by entity type.
+         */
+        get: operations["globalSearch"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/smart-scan/hosts/{id}/refresh-identity": {
         parameters: {
             query?: never;
@@ -2271,6 +2293,26 @@ export interface components {
              */
             type?: "scan" | "discovery";
             updated_at?: string;
+        };
+        "docs.SearchResult": {
+            /** @example 550e8400-e29b-41d4-a716-446655440000 */
+            id?: string;
+            /** @example 192.168.1.1 (myserver) */
+            label?: string;
+            /**
+             * @example host
+             * @enum {string}
+             */
+            type?: "host" | "network" | "scan" | "profile";
+            /** @example /hosts/550e8400-e29b-41d4-a716-446655440000 */
+            url?: string;
+        };
+        "docs.SearchResults": {
+            results?: {
+                [key: string]: components["schemas"]["docs.SearchResult"][];
+            };
+            /** @example 4 */
+            total?: number;
         };
         "docs.StatusResponse": {
             /** @example scanorama-api */
@@ -6774,6 +6816,49 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    globalSearch: {
+        parameters: {
+            query: {
+                /** @description Search query (2–100 characters) */
+                q: string;
+                /** @description Max results per type (default 10, max 50) */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.SearchResults"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1176,6 +1176,98 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/webhooks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List webhook endpoints
+         * @description Returns all registered webhook delivery endpoints.
+         */
+        get: operations["listWebhooks"];
+        put?: never;
+        /**
+         * Create webhook endpoint
+         * @description Registers a new webhook delivery endpoint.
+         */
+        post: operations["createWebhook"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/webhooks/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get webhook endpoint
+         * @description Returns a single webhook endpoint by ID.
+         */
+        get: operations["getWebhook"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete webhook endpoint
+         * @description Removes a webhook endpoint and its delivery log.
+         */
+        delete: operations["deleteWebhook"];
+        options?: never;
+        head?: never;
+        /**
+         * Update webhook endpoint
+         * @description Applies partial updates to a webhook endpoint.
+         */
+        patch: operations["updateWebhook"];
+        trace?: never;
+    };
+    "/webhooks/{id}/logs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List delivery logs
+         * @description Returns delivery logs for a webhook endpoint (newest first, max 200).
+         */
+        get: operations["listWebhookDeliveryLogs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/webhooks/{id}/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Send test delivery
+         * @description Fires a synchronous test event to the webhook endpoint.
+         */
+        post: operations["testWebhook"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2097,6 +2189,42 @@ export interface components {
             timestamp?: string;
             /** @example 0.7.0 */
             version?: string;
+        };
+        "docs.WebhookCreateEndpointResponse": {
+            created_at?: string;
+            /** @example true */
+            enabled?: boolean;
+            /**
+             * @example [
+             *       "host.online",
+             *       "scan.completed"
+             *     ]
+             */
+            events?: string[];
+            /** @example 550e8400-e29b-41d4-a716-446655440000 */
+            id?: string;
+            /** @example abc123... */
+            secret?: string;
+            updated_at?: string;
+            /** @example https://example.com/webhook */
+            url?: string;
+        };
+        "docs.WebhookEndpointResponse": {
+            created_at?: string;
+            /** @example true */
+            enabled?: boolean;
+            /**
+             * @example [
+             *       "host.online",
+             *       "scan.completed"
+             *     ]
+             */
+            events?: string[];
+            /** @example 550e8400-e29b-41d4-a716-446655440000 */
+            id?: string;
+            updated_at?: string;
+            /** @example https://example.com/webhook */
+            url?: string;
         };
     };
     responses: never;
@@ -6451,6 +6579,331 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    listWebhooks: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    createWebhook: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Webhook input */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.WebhookEndpointResponse"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.WebhookCreateEndpointResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getWebhook: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Webhook UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.WebhookEndpointResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteWebhook: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Webhook UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateWebhook: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Webhook UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Update fields */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.WebhookEndpointResponse"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.WebhookEndpointResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    listWebhookDeliveryLogs: {
+        parameters: {
+            query?: {
+                /** @description Maximum log entries (default 50, max 200) */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Webhook UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    testWebhook: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Webhook UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
                 };
             };
         };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1513,6 +1513,16 @@ export interface components {
             /** @example Primary web server */
             description?: string;
             /**
+             * @description DeviceID is the stable device this host is attached to, if any.
+             * @example 550e8400-e29b-41d4-a716-446655440001
+             */
+            device_id?: string;
+            /**
+             * @description DeviceName is the canonical name of the attached device, populated by JOIN in GetHost.
+             * @example Andreas's iPhone
+             */
+            device_name?: string;
+            /**
              * @description DisplayName is the winning display name chosen by the identity resolver.
              *     Always set; falls back to IPAddress when no source produced a usable name.
              * @example sams-macbook.local

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -385,6 +385,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/hosts/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export hosts as CSV or JSON
+         * @description Streams all hosts matching the active filters as a file download.
+         *     Uses chunked DB reads so large exports do not buffer in memory.
+         */
+        get: operations["exportHosts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/hosts/{hostId}": {
         parameters: {
             query?: never;
@@ -922,6 +943,27 @@ export interface paths {
          *     ports with changed service or state are "changed", the rest are "unchanged".
          */
         get: operations["getScanDiff"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/scans/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export scans as CSV or JSON
+         * @description Streams all scans matching the active filters as a file download.
+         *     Uses chunked DB reads so large exports do not buffer in memory.
+         */
+        get: operations["exportScans"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3855,6 +3897,51 @@ export interface operations {
             };
         };
     };
+    exportHosts: {
+        parameters: {
+            query?: {
+                /** @description Output format: csv (default) or json */
+                format?: "csv" | "json";
+                /** @description Filter by host status */
+                status?: string;
+                /** @description Filter by OS family */
+                os?: string;
+                /** @description Filter by network CIDR */
+                network?: string;
+                /** @description Filter by vendor */
+                vendor?: string;
+                /** @description Full-text search */
+                search?: string;
+                /** @description Sort column */
+                sort_by?: string;
+                /** @description Sort direction: asc or desc */
+                sort_order?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description CSV or JSON file download */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/csv": components["schemas"]["docs.ErrorResponse"];
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
     getHost: {
         parameters: {
             query?: never;
@@ -5842,6 +5929,47 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    exportScans: {
+        parameters: {
+            query?: {
+                /** @description Output format: csv (default) or json */
+                format?: "csv" | "json";
+                /** @description Filter by scan status */
+                status?: string;
+                /** @description Filter by scan type */
+                scan_type?: string;
+                /** @description Filter by profile ID */
+                profile_id?: string;
+                /** @description Sort column */
+                sort_by?: string;
+                /** @description Sort direction: asc or desc */
+                sort_order?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description CSV or JSON file download */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/csv": components["schemas"]["docs.ErrorResponse"];
                     "application/json": components["schemas"]["docs.ErrorResponse"];
                 };
             };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -908,6 +908,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/scans/diff": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Compare two scans
+         * @description Compare two scans of the same host and return a structured port diff.
+         *     New ports are marked "new", ports that disappeared are "closed",
+         *     ports with changed service or state are "changed", the rest are "unchanged".
+         */
+        get: operations["getScanDiff"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/scans/{scanId}": {
         parameters: {
             query?: never;
@@ -2068,6 +2090,52 @@ export interface components {
             status?: "up" | "down" | "testing" | "unknown" | "dormant" | "notPresent" | "lowerLayerDown";
             /** @example 524288 */
             tx_bytes?: number;
+        };
+        "docs.ScanDiffEntryResponse": {
+            /** @example 443 */
+            port?: number;
+            /** @example http */
+            prev_service_name?: string;
+            prev_service_version?: string;
+            /** @example filtered */
+            prev_state?: string;
+            /** @example tcp */
+            protocol?: string;
+            /** @example https */
+            service_name?: string;
+            /** @example nginx/1.24.0 */
+            service_version?: string;
+            /** @example open */
+            state?: string;
+            /**
+             * @description Status is "new" | "closed" | "changed" | "unchanged"
+             * @example new
+             * @enum {string}
+             */
+            status?: "new" | "closed" | "changed" | "unchanged";
+        };
+        "docs.ScanDiffResponse": {
+            /** @example 2 */
+            changed_count?: number;
+            /** @example 1 */
+            closed_count?: number;
+            /** @example Ubuntu 22.04 */
+            curr_os_name?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440002 */
+            host_id?: string;
+            /** @example 3 */
+            new_count?: number;
+            /** @example false */
+            os_changed?: boolean;
+            ports?: components["schemas"]["docs.ScanDiffEntryResponse"][];
+            /** @example Ubuntu 20.04 */
+            prev_os_name?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440000 */
+            scan_a_id?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440001 */
+            scan_b_id?: string;
+            /** @example 47 */
+            unchanged_count?: number;
         };
         "docs.ScanResponse": {
             completed_at?: string;
@@ -5700,6 +5768,67 @@ export interface operations {
             };
             /** @description Unprocessable Entity */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getScanDiff: {
+        parameters: {
+            query: {
+                /** @description Scan A ID (older/baseline) */
+                a: string;
+                /** @description Scan B ID (newer/current) */
+                b: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ScanDiffResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -24,6 +24,58 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/alerts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List all alert rules
+         * @description Returns all configured alert rules.
+         */
+        get: operations["listAlertRules"];
+        put?: never;
+        /**
+         * Create an alert rule
+         * @description Creates a new alert rule for a host, group, or tag.
+         */
+        post: operations["createAlertRule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/alerts/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get an alert rule
+         * @description Returns a single alert rule by ID.
+         */
+        get: operations["getAlertRule"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete an alert rule
+         * @description Removes an alert rule.
+         */
+        delete: operations["deleteAlertRule"];
+        options?: never;
+        head?: never;
+        /**
+         * Update an alert rule
+         * @description Applies partial updates to an alert rule.
+         */
+        patch: operations["updateAlertRule"];
+        trace?: never;
+    };
     "/certificates/expiring": {
         parameters: {
             query?: never;
@@ -393,6 +445,26 @@ export interface paths {
          * @description Get scans associated with a specific host
          */
         get: operations["getHostScans"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/hosts/{id}/alerts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List alert rules for a host
+         * @description Returns alert rules that target a specific host directly.
+         */
+        get: operations["listHostAlertRules"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1279,6 +1351,28 @@ export interface components {
                 [key: string]: unknown;
             };
             timestamp?: string;
+        };
+        "docs.AlertRuleResponse": {
+            /** @example webhook */
+            channel_type?: string;
+            /** @example https://example.com/hook */
+            channel_url?: string;
+            created_at?: string;
+            /** @example true */
+            enabled?: boolean;
+            group_id?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440001 */
+            host_id?: string;
+            /** @example 550e8400-e29b-41d4-a716-446655440000 */
+            id?: string;
+            /** @example nas */
+            tag?: string;
+            /**
+             * @example offline
+             * @enum {string}
+             */
+            trigger?: "online" | "offline" | "both";
+            updated_at?: string;
         };
         "docs.AttachedHostResponse": {
             first_seen?: string;
@@ -2271,6 +2365,231 @@ export interface operations {
             };
             /** @description Forbidden */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    listAlertRules: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.AlertRuleResponse"][];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    createAlertRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Alert rule input */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.AlertRuleResponse"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.AlertRuleResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getAlertRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Alert rule UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.AlertRuleResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteAlertRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Alert rule UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateAlertRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Alert rule UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Update fields */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["docs.AlertRuleResponse"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.AlertRuleResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3762,6 +4081,47 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.ErrorResponse"];
+                };
+            };
+        };
+    };
+    listHostAlertRules: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Host UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["docs.AlertRuleResponse"][];
+                };
+            };
+            /** @description Bad Request */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/components/command-palette.test.tsx
+++ b/frontend/src/components/command-palette.test.tsx
@@ -1,0 +1,227 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { renderWithRouter } from "../test/utils";
+import { CommandPalette } from "./command-palette";
+
+
+// ── Mock hooks ─────────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("../api/hooks/use-search", () => ({
+  useSearch: vi.fn(),
+}));
+
+vi.mock("../hooks/use-recent-pages", () => ({
+  useRecentPages: vi.fn(),
+}));
+
+import { useSearch } from "../api/hooks/use-search";
+import { useRecentPages } from "../hooks/use-recent-pages";
+
+const mockUseSearch = vi.mocked(useSearch);
+const mockUseRecentPages = vi.mocked(useRecentPages);
+
+const mockAddRecentPage = vi.fn();
+
+function setupDefaultMocks() {
+  mockUseSearch.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+  } as ReturnType<typeof useSearch>);
+
+  mockUseRecentPages.mockReturnValue({
+    recentPages: [],
+    addRecentPage: mockAddRecentPage,
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("CommandPalette", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    setupDefaultMocks();
+    mockNavigate.mockClear();
+    onClose.mockClear();
+    mockAddRecentPage.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the search input", async () => {
+    await renderWithRouter(<CommandPalette onClose={onClose} />);
+    expect(screen.getByRole("searchbox")).toBeInTheDocument();
+  });
+
+  it("shows the backdrop overlay", async () => {
+    await renderWithRouter(<CommandPalette onClose={onClose} />);
+    expect(screen.getByTestId("palette-backdrop")).toBeInTheDocument();
+  });
+
+  it("calls onClose when Escape is pressed", async () => {
+    await renderWithRouter(<CommandPalette onClose={onClose} />);
+    const input = screen.getByRole("searchbox");
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the backdrop is clicked", async () => {
+    await renderWithRouter(<CommandPalette onClose={onClose} />);
+    fireEvent.click(screen.getByTestId("palette-backdrop"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows recent pages when query is empty and there are recent pages", async () => {
+    mockUseRecentPages.mockReturnValue({
+      recentPages: [
+        { label: "Hosts", url: "/hosts", type: "recent" },
+        { label: "Scans", url: "/scans", type: "recent" },
+      ],
+      addRecentPage: mockAddRecentPage,
+    });
+
+    await renderWithRouter(<CommandPalette onClose={onClose} />);
+
+    expect(screen.getByText("Recent")).toBeInTheDocument();
+    expect(screen.getByText("Hosts")).toBeInTheDocument();
+    expect(screen.getByText("Scans")).toBeInTheDocument();
+  });
+
+  it("shows search results grouped by type when query has 2+ chars", async () => {
+    // Return results for any query (debounce is bypassed since hook is mocked).
+    mockUseSearch.mockReturnValue({
+      data: {
+        results: {
+          hosts: [
+            { id: "h1", label: "192.168.1.1 (myhost)", url: "/hosts/h1", type: "host" },
+          ],
+          networks: [],
+          scans: [],
+          profiles: [],
+        },
+        total: 1,
+      },
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useSearch>);
+
+    await renderWithRouter(<CommandPalette onClose={onClose} />);
+
+    const input = screen.getByRole("searchbox");
+    // Type 2+ chars so inputValue >= 2 chars — buildSections shows search mode.
+    fireEvent.change(input, { target: { value: "my" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Hosts")).toBeInTheDocument();
+      expect(screen.getByText("192.168.1.1 (myhost)")).toBeInTheDocument();
+    });
+  });
+
+  it("shows 'no results' message when search returns empty", async () => {
+    mockUseSearch.mockReturnValue({
+      data: { results: { hosts: [], networks: [], scans: [], profiles: [] }, total: 0 },
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useSearch>);
+
+    await renderWithRouter(<CommandPalette onClose={onClose} />);
+
+    const input = screen.getByRole("searchbox");
+    fireEvent.change(input, { target: { value: "xyznotfound" } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/No results for/)).toBeInTheDocument();
+    });
+  });
+
+  it("navigates and calls addRecentPage when a result is clicked", async () => {
+    mockUseSearch.mockReturnValue({
+      data: {
+        results: {
+          hosts: [{ id: "h1", label: "192.168.1.1", url: "/hosts/h1", type: "host" }],
+          networks: [],
+          scans: [],
+          profiles: [],
+        },
+        total: 1,
+      },
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useSearch>);
+
+    await renderWithRouter(<CommandPalette onClose={onClose} />);
+
+    const input = screen.getByRole("searchbox");
+    fireEvent.change(input, { target: { value: "ip" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("192.168.1.1")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("192.168.1.1"));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/hosts/h1" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockAddRecentPage).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "/hosts/h1", type: "recent" }),
+    );
+  });
+
+  it("navigates with arrow keys and Enter", async () => {
+    mockUseSearch.mockReturnValue({
+      data: {
+        results: {
+          hosts: [
+            { id: "h1", label: "192.168.1.1", url: "/hosts/h1", type: "host" },
+            { id: "h2", label: "192.168.1.2", url: "/hosts/h2", type: "host" },
+          ],
+          networks: [],
+          scans: [],
+          profiles: [],
+        },
+        total: 2,
+      },
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useSearch>);
+
+    await renderWithRouter(<CommandPalette onClose={onClose} />);
+
+    const input = screen.getByRole("searchbox");
+    fireEvent.change(input, { target: { value: "ip" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("192.168.1.1")).toBeInTheDocument();
+    });
+
+    // Arrow down to first item, then Enter.
+    act(() => {
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+    });
+    act(() => {
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/hosts/h1" });
+  });
+});

--- a/frontend/src/components/command-palette.tsx
+++ b/frontend/src/components/command-palette.tsx
@@ -1,0 +1,365 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+  useMemo,
+  useId,
+} from "react";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  Computer,
+  Globe,
+  ScanLine,
+  Settings,
+  Clock,
+  Search,
+  X,
+} from "lucide-react";
+import { cn } from "../lib/utils";
+import { useSearch, type SearchResultItem } from "../api/hooks/use-search";
+import {
+  useRecentPages,
+  type RecentPage,
+} from "../hooks/use-recent-pages";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface FlatResult {
+  id: string;
+  label: string;
+  url: string;
+  type: string;
+}
+
+interface GroupedSection {
+  title: string;
+  items: FlatResult[];
+}
+
+// ── Icons ──────────────────────────────────────────────────────────────────────
+
+function ResultIcon({ type }: { type: string }) {
+  const cls = "h-4 w-4 shrink-0 text-text-muted";
+  switch (type) {
+    case "host":
+      return <Computer className={cls} />;
+    case "network":
+      return <Globe className={cls} />;
+    case "scan":
+      return <ScanLine className={cls} />;
+    case "profile":
+      return <Settings className={cls} />;
+    case "recent":
+      return <Clock className={cls} />;
+    default:
+      return <Search className={cls} />;
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const GROUP_TITLES: Record<string, string> = {
+  hosts: "Hosts",
+  networks: "Networks",
+  scans: "Scans",
+  profiles: "Profiles",
+  recent: "Recent",
+};
+
+const GROUP_ORDER = ["hosts", "networks", "scans", "profiles"] as const;
+
+function buildSections(
+  query: string,
+  searchResults: Record<string, SearchResultItem[]> | undefined,
+  recentPages: RecentPage[],
+): GroupedSection[] {
+  if (!query || query.length < 2) {
+    if (recentPages.length === 0) return [];
+    // Map url → id so FlatResult keys are stable and unique.
+    return [{ title: "Recent", items: recentPages.map((p) => ({ ...p, id: p.url })) }];
+  }
+
+  const sections: GroupedSection[] = [];
+  for (const key of GROUP_ORDER) {
+    const items = searchResults?.[key];
+    if (items && items.length > 0) {
+      sections.push({ title: GROUP_TITLES[key] ?? key, items });
+    }
+  }
+  return sections;
+}
+
+function flattenSections(sections: GroupedSection[]): FlatResult[] {
+  return sections.flatMap((s) => s.items);
+}
+
+// ── Sub-components ─────────────────────────────────────────────────────────────
+
+interface ResultItemProps {
+  item: FlatResult;
+  isActive: boolean;
+  onSelect: () => void;
+  onHover: () => void;
+  id: string;
+}
+
+function ResultItem({ item, isActive, onSelect, onHover, id }: ResultItemProps) {
+  return (
+    <li id={id} role="option" aria-selected={isActive}>
+      <button
+        type="button"
+        className={cn(
+          "flex items-center gap-3 w-full px-4 py-2.5 text-left rounded-md",
+          "text-sm text-text-primary transition-colors",
+          isActive
+            ? "bg-primary/10 text-primary"
+            : "hover:bg-surface-raised",
+        )}
+        onClick={onSelect}
+        onMouseEnter={onHover}
+      >
+        <ResultIcon type={item.type} />
+        <span className="flex-1 truncate">{item.label}</span>
+      </button>
+    </li>
+  );
+}
+
+// ── Debounce ───────────────────────────────────────────────────────────────────
+
+function useDebounce(value: string, ms: number): string {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+  return debounced;
+}
+
+// ── Main component ─────────────────────────────────────────────────────────────
+
+export interface CommandPaletteProps {
+  onClose: () => void;
+}
+
+const DEBOUNCE_MS = 300;
+
+export function CommandPalette({ onClose }: CommandPaletteProps) {
+  const dialogId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const navigate = useNavigate();
+
+  const [inputValue, setInputValue] = useState("");
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const { recentPages, addRecentPage } = useRecentPages();
+
+  // Debounce the query so the API is called at most once per 300ms.
+  const debouncedQuery = useDebounce(inputValue, DEBOUNCE_MS);
+  const { data: searchData, isLoading } = useSearch(debouncedQuery);
+
+  // Build the flat list used for keyboard navigation.
+  const sections = useMemo(
+    () => buildSections(inputValue, searchData?.results, recentPages),
+    [inputValue, searchData, recentPages],
+  );
+  const flatItems = useMemo(() => flattenSections(sections), [sections]);
+
+  // Focus the input on mount.
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Reset active index when the flat item list changes.
+  useEffect(() => {
+    setActiveIndex(-1);
+  }, [debouncedQuery]);
+
+  // Navigate to the selected item and close the palette.
+  const selectItem = useCallback(
+    (item: FlatResult) => {
+      addRecentPage({ label: item.label, url: item.url, type: "recent" });
+      void navigate({ to: item.url as "/" });
+      onClose();
+    },
+    [addRecentPage, navigate, onClose],
+  );
+
+  // Keyboard handler for the list.
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setActiveIndex((prev) =>
+            prev < flatItems.length - 1 ? prev + 1 : 0,
+          );
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setActiveIndex((prev) =>
+            prev > 0 ? prev - 1 : flatItems.length - 1,
+          );
+          break;
+        case "Enter":
+          e.preventDefault();
+          if (activeIndex >= 0 && flatItems[activeIndex]) {
+            selectItem(flatItems[activeIndex]);
+          }
+          break;
+        case "Escape":
+          e.preventDefault();
+          onClose();
+          break;
+        default:
+          break;
+      }
+    },
+    [flatItems, activeIndex, selectItem, onClose],
+  );
+
+  // Scroll the active item into view.
+  useEffect(() => {
+    if (activeIndex < 0 || !listRef.current) return;
+    const el = listRef.current.querySelector(
+      `[id="${dialogId}-item-${activeIndex}"]`,
+    );
+    if (el && typeof el.scrollIntoView === "function") {
+      el.scrollIntoView({ block: "nearest" });
+    }
+  }, [activeIndex, dialogId]);
+
+  // showEmpty: debounce has settled, API responded, and no results found.
+  // Comparing inputValue === debouncedQuery prevents a flash of "no results"
+  // during the 300ms debounce window before the query fires.
+  const showEmpty =
+    debouncedQuery.length >= 2 &&
+    inputValue === debouncedQuery &&
+    !isLoading &&
+    flatItems.length === 0;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 z-50"
+        onClick={onClose}
+        aria-hidden="true"
+        data-testid="palette-backdrop"
+      />
+
+      {/* Dialog */}
+      <div
+        role="combobox"
+        aria-expanded="true"
+        aria-haspopup="listbox"
+        aria-controls={`${dialogId}-listbox`}
+        aria-activedescendant={
+          activeIndex >= 0 ? `${dialogId}-item-${activeIndex}` : undefined
+        }
+        className={cn(
+          "fixed z-[60] inset-x-0 top-[10%] mx-auto",
+          "w-full max-w-xl",
+          "bg-surface border border-border rounded-lg shadow-2xl",
+          "flex flex-col overflow-hidden",
+        )}
+      >
+        {/* Search input row */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-border">
+          <Search className="h-4 w-4 shrink-0 text-text-muted" />
+          <input
+            ref={inputRef}
+            type="text"
+            role="searchbox"
+            aria-label="Search"
+            aria-autocomplete="list"
+            className={cn(
+              "flex-1 bg-transparent outline-none",
+              "text-sm text-text-primary placeholder:text-text-muted",
+            )}
+            placeholder="Search hosts, networks, scans, profiles…"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+          />
+          {isLoading && (
+            <span className="text-xs text-text-muted animate-pulse">
+              Searching…
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close search"
+            className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Results */}
+        <div className="overflow-y-auto max-h-96">
+          {showEmpty ? (
+            <p className="px-4 py-8 text-sm text-center text-text-muted">
+              No results for &ldquo;{inputValue}&rdquo;
+            </p>
+          ) : (
+            <ul
+              ref={listRef}
+              id={`${dialogId}-listbox`}
+              role="listbox"
+              aria-label="Search results"
+              className="py-2"
+            >
+              {sections.map((section) => (
+                <li key={section.title}>
+                  <div className="px-4 pt-3 pb-1">
+                    <span className="text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+                      {section.title}
+                    </span>
+                  </div>
+                  <ul>
+                    {section.items.map((item) => {
+                      const flatIdx = flatItems.indexOf(item);
+                      return (
+                        <ResultItem
+                          key={`${item.type}-${item.id}`}
+                          id={`${dialogId}-item-${flatIdx}`}
+                          item={item}
+                          isActive={flatIdx === activeIndex}
+                          onSelect={() => selectItem(item)}
+                          onHover={() => setActiveIndex(flatIdx)}
+                        />
+                      );
+                    })}
+                  </ul>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {flatItems.length === 0 && !showEmpty && !isLoading && inputValue.length < 2 && (
+            <p className="px-4 py-8 text-sm text-center text-text-muted">
+              Type to search…
+            </p>
+          )}
+        </div>
+
+        {/* Footer hint */}
+        <div className="px-4 py-2 border-t border-border flex items-center gap-4 text-[11px] text-text-muted">
+          <span>
+            <kbd className="font-mono">↑↓</kbd> navigate
+          </span>
+          <span>
+            <kbd className="font-mono">↵</kbd> open
+          </span>
+          <span>
+            <kbd className="font-mono">Esc</kbd> close
+          </span>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/export-button.test.tsx
+++ b/frontend/src/components/export-button.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ExportButton } from "./export-button";
+
+describe("ExportButton", () => {
+  let originalLocationDescriptor: PropertyDescriptor | undefined;
+  const hrefSetter = vi.fn();
+
+  beforeEach(() => {
+    // Save the original descriptor so we can restore it in afterEach.
+    originalLocationDescriptor = Object.getOwnPropertyDescriptor(window, "location");
+    const originalHref = window.location.href;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        get href() {
+          return originalHref;
+        },
+        set href(url: string) {
+          hrefSetter(url);
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (originalLocationDescriptor) {
+      Object.defineProperty(window, "location", originalLocationDescriptor);
+    }
+    hrefSetter.mockClear();
+  });
+
+  // ── rendering ──────────────────────────────────────────────────────────────
+
+  it("renders the Export label", () => {
+    render(<ExportButton basePath="/api/v1/hosts/export" params={{}} />);
+    expect(screen.getByRole("button", { name: "Export CSV" })).toBeInTheDocument();
+  });
+
+  it("renders a custom label", () => {
+    render(
+      <ExportButton basePath="/api/v1/hosts/export" params={{}} label="Download" />,
+    );
+    expect(screen.getByRole("button", { name: "Download CSV" })).toBeInTheDocument();
+  });
+
+  it("renders the chevron button for the format picker", () => {
+    render(<ExportButton basePath="/api/v1/hosts/export" params={{}} />);
+    expect(
+      screen.getByRole("button", { name: "Export format picker" }),
+    ).toBeInTheDocument();
+  });
+
+  // ── primary click → CSV ────────────────────────────────────────────────────
+
+  it("clicking the primary button sets window.location.href to the CSV export URL", async () => {
+    const user = userEvent.setup();
+    render(
+      <ExportButton
+        basePath="/api/v1/hosts/export"
+        params={{ sort_by: "last_seen", sort_order: "desc", status: "up" }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Export CSV" }));
+
+    expect(hrefSetter).toHaveBeenCalledOnce();
+    const url = hrefSetter.mock.calls[0][0] as string;
+    expect(url).toContain("/api/v1/hosts/export");
+    expect(url).toContain("format=csv");
+    expect(url).toContain("sort_by=last_seen");
+    expect(url).toContain("status=up");
+  });
+
+  // ── dropdown menu ──────────────────────────────────────────────────────────
+
+  it("opens the dropdown when the chevron is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ExportButton basePath="/api/v1/hosts/export" params={{}} />);
+
+    // Menu should not be visible initially.
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Export format picker" }));
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Export CSV" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Export JSON" })).toBeInTheDocument();
+  });
+
+  it("clicking 'Export CSV' from the menu sets href with format=csv", async () => {
+    const user = userEvent.setup();
+    render(
+      <ExportButton basePath="/api/v1/scans/export" params={{ sort_by: "created_at" }} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Export format picker" }));
+    await user.click(screen.getByRole("menuitem", { name: "Export CSV" }));
+
+    expect(hrefSetter).toHaveBeenCalledOnce();
+    const url = hrefSetter.mock.calls[0][0] as string;
+    expect(url).toContain("format=csv");
+    expect(url).toContain("/api/v1/scans/export");
+  });
+
+  it("clicking 'Export JSON' from the menu sets href with format=json", async () => {
+    const user = userEvent.setup();
+    render(
+      <ExportButton basePath="/api/v1/hosts/export" params={{ sort_by: "ip" }} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Export format picker" }));
+    await user.click(screen.getByRole("menuitem", { name: "Export JSON" }));
+
+    expect(hrefSetter).toHaveBeenCalledOnce();
+    const url = hrefSetter.mock.calls[0][0] as string;
+    expect(url).toContain("format=json");
+  });
+
+  it("closes the menu after selecting a format", async () => {
+    const user = userEvent.setup();
+    render(<ExportButton basePath="/api/v1/hosts/export" params={{}} />);
+
+    await user.click(screen.getByRole("button", { name: "Export format picker" }));
+    await user.click(screen.getByRole("menuitem", { name: "Export JSON" }));
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  // ── params filtering ───────────────────────────────────────────────────────
+
+  it("omits undefined params from the URL", async () => {
+    const user = userEvent.setup();
+    render(
+      <ExportButton
+        basePath="/api/v1/hosts/export"
+        params={{ sort_by: "last_seen", status: undefined }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Export CSV" }));
+
+    const url = hrefSetter.mock.calls[0][0] as string;
+    expect(url).not.toContain("status");
+    expect(url).toContain("sort_by=last_seen");
+  });
+});

--- a/frontend/src/components/export-button.tsx
+++ b/frontend/src/components/export-button.tsx
@@ -1,0 +1,132 @@
+import { useState, useRef, useEffect } from "react";
+import { Download, ChevronDown } from "lucide-react";
+import { cn } from "../lib/utils";
+
+export interface ExportButtonProps {
+  /** API path for the export endpoint, e.g. "/api/v1/hosts/export". */
+  basePath: string;
+  /** Current filter/sort params to append to the download URL. */
+  params: Record<string, string | number | undefined>;
+  /** Button label (default: "Export"). */
+  label?: string;
+}
+
+type ExportFormat = "csv" | "json";
+
+/** Builds the full download URL from a base path and a param map. */
+function buildExportURL(
+  basePath: string,
+  params: Record<string, string | number | undefined>,
+  format: ExportFormat,
+): string {
+  const qs = new URLSearchParams();
+  qs.set("format", format);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== "" && value !== null) {
+      qs.set(key, String(value));
+    }
+  }
+  return `${basePath}?${qs.toString()}`;
+}
+
+/**
+ * ExportButton renders a split-button that downloads the table data as CSV or
+ * JSON. Clicking the primary area downloads CSV; the chevron opens a small menu
+ * so the user can choose JSON instead.
+ *
+ * The download is triggered by navigating window.location.href so the browser
+ * handles the file-save dialog natively — no fetch + Blob needed.
+ */
+export function ExportButton({
+  basePath,
+  params,
+  label = "Export",
+}: ExportButtonProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close the dropdown when the user clicks outside.
+  useEffect(() => {
+    if (!open) return;
+    function handleOutside(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleOutside);
+    return () => document.removeEventListener("mousedown", handleOutside);
+  }, [open]);
+
+  function triggerDownload(format: ExportFormat) {
+    const url = buildExportURL(basePath, params, format);
+    window.location.href = url;
+    setOpen(false);
+  }
+
+  const baseBtn = cn(
+    "inline-flex items-center justify-center rounded transition-colors",
+    "border border-border text-text-secondary",
+    "hover:text-text-primary hover:bg-surface-raised",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50",
+    "px-3 py-1.5 text-xs gap-1.5",
+    "disabled:cursor-not-allowed",
+  );
+
+  return (
+    <div ref={containerRef} className="relative inline-flex">
+      {/* Primary: Export CSV */}
+      <button
+        type="button"
+        onClick={() => triggerDownload("csv")}
+        className={cn(baseBtn, "rounded-r-none border-r-0")}
+        aria-label={`${label} CSV`}
+      >
+        <Download className="h-3.5 w-3.5 shrink-0" />
+        {label}
+      </button>
+
+      {/* Chevron: opens format picker */}
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className={cn(baseBtn, "rounded-l-none px-1.5")}
+        aria-label="Export format picker"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <ChevronDown className="h-3 w-3 shrink-0" />
+      </button>
+
+      {/* Dropdown menu */}
+      {open && (
+        <div
+          role="menu"
+          className={cn(
+            "absolute right-0 top-full mt-1 z-30",
+            "w-36 bg-surface border border-border rounded-md shadow-lg py-1",
+          )}
+        >
+          <button
+            role="menuitem"
+            type="button"
+            onClick={() => triggerDownload("csv")}
+            className="w-full text-left px-3 py-1.5 text-xs hover:bg-surface-raised"
+          >
+            Export CSV
+          </button>
+          <button
+            role="menuitem"
+            type="button"
+            onClick={() => triggerDownload("json")}
+            className="w-full text-left px-3 py-1.5 text-xs hover:bg-surface-raised"
+          >
+            Export JSON
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/inline-edit-text.test.tsx
+++ b/frontend/src/components/inline-edit-text.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { InlineEditText } from "./inline-edit-text";
+
+describe("InlineEditText", () => {
+  // ── Display mode ─────────────────────────────────────────────
+
+  it("renders the display value when not editing", () => {
+    render(<InlineEditText value="router.local" onSave={vi.fn()} />);
+    expect(screen.getByText("router.local")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("renders placeholder text when value is empty", () => {
+    render(<InlineEditText value="" placeholder="No notes." onSave={vi.fn()} />);
+    expect(screen.getByText("No notes.")).toBeInTheDocument();
+  });
+
+  it("renders default placeholder '—' when value is empty and no placeholder given", () => {
+    render(<InlineEditText value="" onSave={vi.fn()} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("shows an edit button on hover", () => {
+    render(<InlineEditText value="test" onSave={vi.fn()} />);
+    // The clickable text area is the single accessible Edit button; the pencil is aria-hidden
+    expect(screen.getByRole("button", { name: /^edit$/i })).toBeInTheDocument();
+  });
+
+  // ── Enter edit mode ─────────────────────────────────────────
+
+  it("enters edit mode when the display text is clicked", async () => {
+    render(<InlineEditText value="router.local" onSave={vi.fn()} />);
+    // Click the first "Edit" button (the display text button)
+    await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("pre-fills the input with the current value when entering edit mode", async () => {
+    render(<InlineEditText value="router.local" onSave={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    expect(screen.getByRole("textbox")).toHaveValue("router.local");
+  });
+
+  // ── Single-line save ──────────────────────────────────────
+
+  it("calls onSave with the trimmed input value when Enter is pressed", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<InlineEditText value="old" onSave={onSave} />);
+    await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    const input = screen.getByRole("textbox");
+    await userEvent.clear(input);
+    await userEvent.type(input, "  new-hostname  ");
+    await userEvent.keyboard("{Enter}");
+    expect(onSave).toHaveBeenCalledWith("new-hostname");
+  });
+
+  it("calls onSave when the Save (check) button is clicked", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<InlineEditText value="old" onSave={onSave} />);
+    await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    await userEvent.clear(screen.getByRole("textbox"));
+    await userEvent.type(screen.getByRole("textbox"), "saved");
+    await userEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    expect(onSave).toHaveBeenCalledWith("saved");
+  });
+
+  it("exits edit mode after a successful save", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<InlineEditText value="old" onSave={onSave} />);
+    await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    await userEvent.keyboard("{Enter}");
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  // ── Cancel ────────────────────────────────────────────────
+
+  it("cancels without calling onSave when Escape is pressed", async () => {
+    const onSave = vi.fn();
+    render(<InlineEditText value="old" onSave={onSave} />);
+    await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    await userEvent.type(screen.getByRole("textbox"), " modified");
+    await userEvent.keyboard("{Escape}");
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("cancels without calling onSave when the Cancel button is clicked", async () => {
+    const onSave = vi.fn();
+    render(<InlineEditText value="old" onSave={onSave} />);
+    await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  // ── Error handling ─────────────────────────────────────────
+
+  it("stays in edit mode and shows error message when onSave rejects", async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error("Network error"));
+    render(<InlineEditText value="old" onSave={onSave} />);
+    await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    await userEvent.keyboard("{Enter}");
+    // Should remain in edit mode
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByText("Network error")).toBeInTheDocument();
+  });
+
+  // ── Multiline mode ─────────────────────────────────────────
+
+  it("renders a textarea in multiline mode", async () => {
+    render(<InlineEditText value="notes" onSave={vi.fn()} multiline />);
+    await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    // Textarea has rows attribute
+    expect(screen.getByRole("textbox").tagName).toBe("TEXTAREA");
+  });
+
+  it("saves on Ctrl+Enter in multiline mode", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<InlineEditText value="initial" onSave={onSave} multiline />);
+    await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    const textarea = screen.getByRole("textbox");
+    await userEvent.clear(textarea);
+    await userEvent.type(textarea, "updated notes");
+    await userEvent.keyboard("{Control>}{Enter}{/Control}");
+    expect(onSave).toHaveBeenCalledWith("updated notes");
+  });
+
+  it("does not save on plain Enter in multiline mode", async () => {
+    const onSave = vi.fn();
+    render(<InlineEditText value="initial" onSave={onSave} multiline />);
+    await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    await userEvent.keyboard("{Enter}");
+    expect(onSave).not.toHaveBeenCalled();
+    // Still in edit mode
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("cancels on Escape in multiline mode", async () => {
+    const onSave = vi.fn();
+    render(<InlineEditText value="initial" onSave={onSave} multiline />);
+    await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    await userEvent.keyboard("{Escape}");
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  // ── Blur behaviour ─────────────────────────────────────────
+
+  it("blur cancels editing when not saving and no error", async () => {
+    render(<InlineEditText value="original" onSave={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    // Fire a synthetic blur event — should cancel editing
+    fireEvent.blur(screen.getByRole("textbox"));
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("stays in edit mode on blur when a save error is shown", async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error("Network error"));
+    render(<InlineEditText value="old" onSave={onSave} />);
+    await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    await userEvent.keyboard("{Enter}");
+    // Error is shown — blur should NOT cancel editing
+    expect(screen.getByText("Network error")).toBeInTheDocument();
+    fireEvent.blur(screen.getByRole("textbox"));
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  // ── Disabled state ──────────────────────────────────────────
+
+  it("does not enter edit mode when disabled", async () => {
+    render(<InlineEditText value="locked" onSave={vi.fn()} disabled />);
+    // Only the display button is in the DOM when disabled (no pencil button rendered)
+    const btn = screen.getByRole("button", { name: /^edit$/i });
+    await userEvent.click(btn);
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/inline-edit-text.tsx
+++ b/frontend/src/components/inline-edit-text.tsx
@@ -1,0 +1,187 @@
+import { useState, useRef, useEffect } from "react";
+import { Pencil, Check, X } from "lucide-react";
+import { cn } from "../lib/utils";
+
+export interface InlineEditTextProps {
+  value: string;
+  placeholder?: string;
+  multiline?: boolean;
+  onSave: (newValue: string) => Promise<void>;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * InlineEditText renders a display value that can be clicked to enter an
+ * inline edit mode. Pressing Enter (or Ctrl+Enter in multiline mode) saves;
+ * Escape cancels. On save error the component stays in edit mode and reports
+ * the error via a small message below the input.
+ */
+export function InlineEditText({
+  value,
+  placeholder = "—",
+  multiline = false,
+  onSave,
+  disabled = false,
+  className,
+}: InlineEditTextProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState(value);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+
+  // Sync external value changes when not editing.
+  useEffect(() => {
+    if (!isEditing) {
+      setInputValue(value);
+    }
+  }, [value, isEditing]);
+
+  function startEditing() {
+    if (disabled) return;
+    setInputValue(value);
+    setSaveError(null);
+    setIsEditing(true);
+  }
+
+  function cancelEditing() {
+    setIsEditing(false);
+    setInputValue(value);
+    setSaveError(null);
+  }
+
+  async function commitSave() {
+    const trimmed = inputValue.trim();
+    setSaveError(null);
+    setIsSaving(true);
+    try {
+      await onSave(trimmed);
+      setIsEditing(false);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Save failed.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      cancelEditing();
+      return;
+    }
+    if (!multiline && e.key === "Enter") {
+      e.preventDefault();
+      void commitSave();
+      return;
+    }
+    if (multiline && e.key === "Enter" && e.ctrlKey) {
+      e.preventDefault();
+      void commitSave();
+    }
+  }
+
+  const sharedInputClass =
+    "flex-1 px-2 py-0.5 text-xs rounded border border-border bg-surface text-text-primary focus:outline-none focus:ring-1 focus:ring-border min-w-0";
+
+  if (isEditing) {
+    return (
+      <div className={cn("space-y-1", className)}>
+        <div className="flex items-start gap-1.5">
+          {multiline ? (
+            <textarea
+              ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              onBlur={() => {
+                if (!isSaving && !saveError) setIsEditing(false);
+              }}
+              autoFocus
+              aria-label="Edit notes"
+              rows={3}
+              className={cn(sharedInputClass, "resize-y")}
+            />
+          ) : (
+            <input
+              ref={inputRef as React.RefObject<HTMLInputElement>}
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              onBlur={() => {
+                if (!isSaving && !saveError) setIsEditing(false);
+              }}
+              autoFocus
+              aria-label="Edit value"
+              className={sharedInputClass}
+            />
+          )}
+          <button
+            type="button"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => void commitSave()}
+            disabled={isSaving}
+            aria-label="Save"
+            className="p-0.5 rounded text-success hover:bg-surface-raised shrink-0"
+          >
+            <Check className="h-3 w-3" />
+          </button>
+          <button
+            type="button"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={cancelEditing}
+            aria-label="Cancel"
+            className="p-0.5 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised shrink-0"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+        {saveError && (
+          <p className="text-[11px] text-danger">{saveError}</p>
+        )}
+        {multiline && (
+          <p className="text-[11px] text-text-muted">
+            Ctrl+Enter to save · Esc to cancel
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  const isEmpty = !value;
+  return (
+    <div className={cn("flex items-center gap-1.5 group min-w-0", className)}>
+      <button
+        type="button"
+        onClick={startEditing}
+        disabled={disabled}
+        aria-label="Edit"
+        className={cn(
+          "text-left break-all min-w-0 flex-1",
+          "text-xs",
+          isEmpty
+            ? "text-text-muted italic"
+            : "text-text-secondary",
+          !disabled && "hover:text-text-primary cursor-text",
+          disabled && "cursor-default",
+        )}
+      >
+        {isEmpty ? placeholder : value}
+      </button>
+      {!disabled && (
+        <button
+          type="button"
+          onClick={startEditing}
+          aria-hidden="true"
+          tabIndex={-1}
+          className="p-0.5 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+        >
+          <Pencil className="h-2.5 w-2.5" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/keyboard-shortcut-help.test.tsx
+++ b/frontend/src/components/keyboard-shortcut-help.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { KeyboardShortcutHelp } from "./keyboard-shortcut-help";
+
+describe("KeyboardShortcutHelp", () => {
+  it("renders the dialog with its title", () => {
+    render(<KeyboardShortcutHelp onClose={vi.fn()} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(
+      screen.getByText("Keyboard shortcuts"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all navigation bindings", () => {
+    render(<KeyboardShortcutHelp onClose={vi.fn()} />);
+
+    expect(screen.getByText("Go to Hosts")).toBeInTheDocument();
+    expect(screen.getByText("Go to Scans")).toBeInTheDocument();
+    expect(screen.getByText("Go to Networks")).toBeInTheDocument();
+    expect(screen.getByText("Go to Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Go to Admin")).toBeInTheDocument();
+  });
+
+  it("renders all action bindings", () => {
+    render(<KeyboardShortcutHelp onClose={vi.fn()} />);
+
+    expect(screen.getByText("New scan")).toBeInTheDocument();
+    expect(screen.getByText("Toggle this help")).toBeInTheDocument();
+    expect(screen.getByText("Close overlay")).toBeInTheDocument();
+  });
+
+  it("renders section headings", () => {
+    render(<KeyboardShortcutHelp onClose={vi.fn()} />);
+
+    expect(screen.getByText("Navigation")).toBeInTheDocument();
+    expect(screen.getByText("Actions")).toBeInTheDocument();
+  });
+
+  it("calls onClose when the close button is clicked", () => {
+    const onClose = vi.fn();
+    render(<KeyboardShortcutHelp onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /close dialog/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the backdrop is clicked", () => {
+    const onClose = vi.fn();
+    render(<KeyboardShortcutHelp onClose={onClose} />);
+
+    // The backdrop is the div with aria-hidden="true" and bg-black/50
+    const backdrop = document.querySelector("[aria-hidden='true']") as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose on Escape key", () => {
+    const onClose = vi.fn();
+    render(<KeyboardShortcutHelp onClose={onClose} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("displays key badges for g h binding", () => {
+    render(<KeyboardShortcutHelp onClose={vi.fn()} />);
+
+    // Multiple 'g' badges appear (one per g-prefixed binding)
+    const gBadges = screen.getAllByText("g");
+    expect(gBadges.length).toBeGreaterThanOrEqual(1);
+
+    // 'h' appears as key badge for the "Go to Hosts" binding
+    expect(screen.getByText("h")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/keyboard-shortcut-help.tsx
+++ b/frontend/src/components/keyboard-shortcut-help.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useId } from "react";
+import { X } from "lucide-react";
+import { cn } from "../lib/utils";
+
+interface Binding {
+  keys: string[];
+  description: string;
+}
+
+const NAV_BINDINGS: Binding[] = [
+  { keys: ["g", "h"], description: "Go to Hosts" },
+  { keys: ["g", "s"], description: "Go to Scans" },
+  { keys: ["g", "n"], description: "Go to Networks" },
+  { keys: ["g", "d"], description: "Go to Dashboard" },
+  { keys: ["g", "a"], description: "Go to Admin" },
+];
+
+const ACTION_BINDINGS: Binding[] = [
+  { keys: ["n"], description: "New scan" },
+  { keys: ["?"], description: "Toggle this help" },
+  { keys: ["Esc"], description: "Close overlay" },
+];
+
+function KeyBadge({ label }: { label: string }) {
+  return (
+    <kbd
+      className={cn(
+        "inline-flex items-center justify-center",
+        "min-w-[1.5rem] px-1.5 h-6",
+        "rounded border border-border bg-surface-raised",
+        "font-mono text-[11px] text-text-primary",
+        "shadow-sm",
+      )}
+    >
+      {label}
+    </kbd>
+  );
+}
+
+function BindingRow({ binding }: { binding: Binding }) {
+  return (
+    <li className="flex items-center gap-3">
+      <span className="flex items-center gap-1 shrink-0">
+        {binding.keys.map((k, i) => (
+          <KeyBadge key={i} label={k} />
+        ))}
+      </span>
+      <span className="text-xs text-text-secondary">{binding.description}</span>
+    </li>
+  );
+}
+
+function BindingSection({
+  title,
+  bindings,
+}: {
+  title: string;
+  bindings: Binding[];
+}) {
+  return (
+    <div className="space-y-2.5">
+      <h3 className="text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+        {title}
+      </h3>
+      <ul className="space-y-2">
+        {bindings.map((b, i) => (
+          <BindingRow key={i} binding={b} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export interface KeyboardShortcutHelpProps {
+  onClose: () => void;
+}
+
+export function KeyboardShortcutHelp({ onClose }: KeyboardShortcutHelpProps) {
+  const id = useId();
+
+  // Dismiss on Escape is handled by the global shortcut hook, but we also
+  // handle it here so the overlay is self-contained when rendered standalone.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Dialog */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${id}-title`}
+        className={cn(
+          "fixed z-50 inset-0 m-auto",
+          "w-full max-w-sm h-fit",
+          "bg-surface border border-border rounded-lg shadow-xl",
+          "flex flex-col",
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+          <h2
+            id={`${id}-title`}
+            className="text-sm font-semibold text-text-primary"
+          >
+            Keyboard shortcuts
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close dialog"
+            className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body — two columns */}
+        <div className="px-5 py-4 grid grid-cols-2 gap-6">
+          <BindingSection title="Navigation" bindings={NAV_BINDINGS} />
+          <BindingSection title="Actions" bindings={ACTION_BINDINGS} />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/layout/root-layout.tsx
+++ b/frontend/src/components/layout/root-layout.tsx
@@ -1,9 +1,10 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Outlet, useRouterState, useNavigate } from "@tanstack/react-router";
 import { Sidebar } from "./sidebar";
 import { Topbar } from "./topbar";
 import { ToastProvider, useToast } from "../toast-provider";
 import { KeyboardShortcutHelp } from "../keyboard-shortcut-help";
+import { CommandPalette } from "../command-palette";
 import { useKeyboardShortcuts } from "../../hooks/use-keyboard-shortcuts";
 import { useWs } from "../../lib/use-ws";
 import type { WsMessage } from "../../lib/ws";
@@ -63,15 +64,27 @@ function DiscoveryNotifications() {
   return null;
 }
 
-// ── Global keyboard shortcuts ──────────────────────────────────────────────────
+// ── Global keyboard shortcuts + command palette ────────────────────────────────
 // Must live inside <ToastProvider> (same as DiscoveryNotifications).
 
 function GlobalShortcuts() {
   const { showHelp, setShowHelp } = useKeyboardShortcuts();
+  const [showPalette, setShowPalette] = useState(false);
 
-  return showHelp ? (
-    <KeyboardShortcutHelp onClose={() => setShowHelp(false)} />
-  ) : null;
+  useEffect(() => {
+    function onSearchRequested() {
+      setShowPalette((prev) => !prev);
+    }
+    document.addEventListener("search-requested", onSearchRequested);
+    return () => document.removeEventListener("search-requested", onSearchRequested);
+  }, []);
+
+  return (
+    <>
+      {showHelp && <KeyboardShortcutHelp onClose={() => setShowHelp(false)} />}
+      {showPalette && <CommandPalette onClose={() => setShowPalette(false)} />}
+    </>
+  );
 }
 
 // ── Root layout ────────────────────────────────────────────────────────────────

--- a/frontend/src/components/layout/root-layout.tsx
+++ b/frontend/src/components/layout/root-layout.tsx
@@ -3,6 +3,8 @@ import { Outlet, useRouterState, useNavigate } from "@tanstack/react-router";
 import { Sidebar } from "./sidebar";
 import { Topbar } from "./topbar";
 import { ToastProvider, useToast } from "../toast-provider";
+import { KeyboardShortcutHelp } from "../keyboard-shortcut-help";
+import { useKeyboardShortcuts } from "../../hooks/use-keyboard-shortcuts";
 import { useWs } from "../../lib/use-ws";
 import type { WsMessage } from "../../lib/ws";
 
@@ -61,6 +63,17 @@ function DiscoveryNotifications() {
   return null;
 }
 
+// ── Global keyboard shortcuts ──────────────────────────────────────────────────
+// Must live inside <ToastProvider> (same as DiscoveryNotifications).
+
+function GlobalShortcuts() {
+  const { showHelp, setShowHelp } = useKeyboardShortcuts();
+
+  return showHelp ? (
+    <KeyboardShortcutHelp onClose={() => setShowHelp(false)} />
+  ) : null;
+}
+
 // ── Root layout ────────────────────────────────────────────────────────────────
 
 export function RootLayout() {
@@ -70,6 +83,7 @@ export function RootLayout() {
   return (
     <ToastProvider>
       <DiscoveryNotifications />
+      <GlobalShortcuts />
       <div className="flex h-screen overflow-hidden">
         <Sidebar />
         <div className="flex flex-col flex-1 min-w-0">

--- a/frontend/src/components/layout/root-layout.tsx
+++ b/frontend/src/components/layout/root-layout.tsx
@@ -5,6 +5,7 @@ import { Topbar } from "./topbar";
 import { ToastProvider, useToast } from "../toast-provider";
 import { KeyboardShortcutHelp } from "../keyboard-shortcut-help";
 import { CommandPalette } from "../command-palette";
+import { OnboardingWizard } from "../onboarding-wizard";
 import { useKeyboardShortcuts } from "../../hooks/use-keyboard-shortcuts";
 import { useWs } from "../../lib/use-ws";
 import type { WsMessage } from "../../lib/ws";
@@ -97,6 +98,7 @@ export function RootLayout() {
     <ToastProvider>
       <DiscoveryNotifications />
       <GlobalShortcuts />
+      <OnboardingWizard />
       <div className="flex h-screen overflow-hidden">
         <Sidebar />
         <div className="flex flex-col flex-1 min-w-0">

--- a/frontend/src/components/layout/topbar.test.tsx
+++ b/frontend/src/components/layout/topbar.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Topbar } from "./topbar";
+
+// ── Mock hooks used by Topbar ─────────────────────────────────────────────────
+
+vi.mock("../../api/hooks/use-system", () => ({
+  useHealth: vi.fn(),
+}));
+
+vi.mock("../../lib/use-ws", () => ({
+  useWsStatus: vi.fn(),
+}));
+
+vi.mock("../../hooks/use-theme", () => ({
+  useTheme: vi.fn(),
+}));
+
+import { useHealth } from "../../api/hooks/use-system";
+import { useWsStatus } from "../../lib/use-ws";
+import { useTheme } from "../../hooks/use-theme";
+
+const mockUseHealth = vi.mocked(useHealth);
+const mockUseWsStatus = vi.mocked(useWsStatus);
+const mockUseTheme = vi.mocked(useTheme);
+
+function setupDefaultMocks() {
+  mockUseHealth.mockReturnValue({
+    data: { status: "healthy" },
+    isLoading: false,
+    error: null,
+  } as ReturnType<typeof useHealth>);
+  mockUseWsStatus.mockReturnValue("connected");
+  mockUseTheme.mockReturnValue({
+    theme: "dark",
+    toggleTheme: vi.fn(),
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("Topbar", () => {
+  beforeEach(() => {
+    setupDefaultMocks();
+  });
+
+  it("renders the title", () => {
+    render(<Topbar title="Dashboard" />);
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+  });
+
+  it("shows 'Live' when WS is connected", () => {
+    mockUseWsStatus.mockReturnValue("connected");
+    render(<Topbar title="Test" />);
+    expect(screen.getByText("Live")).toBeInTheDocument();
+  });
+
+  it("shows 'Healthy' when API is healthy", () => {
+    render(<Topbar title="Test" />);
+    expect(screen.getByText("Healthy")).toBeInTheDocument();
+  });
+
+  it("shows 'Unhealthy' when API is not healthy", () => {
+    mockUseHealth.mockReturnValue({
+      data: { status: "degraded" },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useHealth>);
+    render(<Topbar title="Test" />);
+    expect(screen.getByText("Unhealthy")).toBeInTheDocument();
+  });
+
+  // ── ThemeToggle integration ────────────────────────────────────────────────
+
+  it("renders Sun icon and correct aria-label when theme is dark", () => {
+    mockUseTheme.mockReturnValue({ theme: "dark", toggleTheme: vi.fn() });
+    render(<Topbar title="Test" />);
+    const btn = screen.getByRole("button", { name: "Switch to light mode" });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it("renders Moon icon and correct aria-label when theme is light", () => {
+    mockUseTheme.mockReturnValue({ theme: "light", toggleTheme: vi.fn() });
+    render(<Topbar title="Test" />);
+    const btn = screen.getByRole("button", { name: "Switch to dark mode" });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it("calls toggleTheme when the theme toggle button is clicked", async () => {
+    const user = userEvent.setup();
+    const toggleTheme = vi.fn();
+    mockUseTheme.mockReturnValue({ theme: "dark", toggleTheme });
+    render(<Topbar title="Test" />);
+    const btn = screen.getByRole("button", { name: "Switch to light mode" });
+    await user.click(btn);
+    expect(toggleTheme).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/layout/topbar.tsx
+++ b/frontend/src/components/layout/topbar.tsx
@@ -3,6 +3,7 @@ import { Activity } from "lucide-react";
 import { useHealth } from "../../api/hooks/use-system";
 import { useWsStatus } from "../../lib/use-ws";
 import type { WsStatus } from "../../lib/ws";
+import { ThemeToggle } from "../theme-toggle";
 
 interface TopbarProps {
   title: string;
@@ -81,6 +82,12 @@ export function Topbar({ title }: TopbarProps) {
             {isHealthy ? "Healthy" : "Unhealthy"}
           </span>
         </div>
+
+        {/* Separator */}
+        <span className="w-px h-3 bg-border" />
+
+        {/* Theme toggle */}
+        <ThemeToggle />
       </div>
     </header>
   );

--- a/frontend/src/components/onboarding-wizard.test.tsx
+++ b/frontend/src/components/onboarding-wizard.test.tsx
@@ -1,0 +1,382 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderWithRouter } from "../test/utils";
+import { OnboardingWizard } from "./onboarding-wizard";
+
+// ── localStorage mock ──────────────────────────────────────────────────────────
+// Node 26 has an experimental (broken) global localStorage that conflicts with
+// jsdom's. We stub it with a working in-memory implementation.
+
+function makeStorageMock(): Storage {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      Object.keys(store).forEach((k) => delete store[k]);
+    },
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  };
+}
+
+// ── Mock hooks ─────────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("../api/hooks/use-networks", () => ({
+  useNetworks: vi.fn(),
+  useCreateNetwork: vi.fn(),
+}));
+
+vi.mock("../api/hooks/use-discovery", () => ({
+  useRerunDiscovery: vi.fn(),
+  useDiscoveryJobs: vi.fn(),
+}));
+
+import { useNetworks, useCreateNetwork } from "../api/hooks/use-networks";
+import { useRerunDiscovery, useDiscoveryJobs } from "../api/hooks/use-discovery";
+
+const mockUseNetworks = vi.mocked(useNetworks);
+const mockUseCreateNetwork = vi.mocked(useCreateNetwork);
+const mockUseRerunDiscovery = vi.mocked(useRerunDiscovery);
+const mockUseDiscoveryJobs = vi.mocked(useDiscoveryJobs);
+
+const SKIP_KEY = "scanorama_onboarding_skipped";
+
+// ── Default mock setup ─────────────────────────────────────────────────────────
+
+function setupDefaultMocks() {
+  mockUseNetworks.mockReturnValue({
+    data: { data: [], total: 0 },
+    isLoading: false,
+  } as unknown as ReturnType<typeof useNetworks>);
+
+  mockUseCreateNetwork.mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({ id: "net-1" }),
+    isPending: false,
+  } as unknown as ReturnType<typeof useCreateNetwork>);
+
+  mockUseRerunDiscovery.mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({ id: "job-1" }),
+    isPending: false,
+  } as unknown as ReturnType<typeof useRerunDiscovery>);
+
+  mockUseDiscoveryJobs.mockReturnValue({
+    data: { data: [], total: 0 },
+    isLoading: false,
+  } as unknown as ReturnType<typeof useDiscoveryJobs>);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("OnboardingWizard", () => {
+  let storageMock: Storage;
+
+  beforeEach(() => {
+    storageMock = makeStorageMock();
+    vi.stubGlobal("localStorage", storageMock);
+    vi.clearAllMocks();
+    mockNavigate.mockClear();
+    setupDefaultMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // 1. Does not render wizard when networks.total > 0
+  it("does not render wizard when networks already exist", async () => {
+    mockUseNetworks.mockReturnValue({
+      data: { data: [{ id: "net-existing" }], total: 1 },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useNetworks>);
+
+    await renderWithRouter(<OnboardingWizard />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  // 2. Does not render wizard when localStorage skip flag is set
+  it("does not render wizard when the skip flag is set in localStorage", async () => {
+    localStorage.setItem(SKIP_KEY, "true");
+
+    await renderWithRouter(<OnboardingWizard />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  // 3. Renders wizard when networks total is 0
+  it("renders the wizard when no networks exist", async () => {
+    await renderWithRouter(<OnboardingWizard />);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  // 4. Shows "Step 1 of 3" progress text
+  it("shows 'Step 1 of 3' progress indicator on first render", async () => {
+    await renderWithRouter(<OnboardingWizard />);
+
+    expect(screen.getByText("Step 1 of 3")).toBeInTheDocument();
+  });
+
+  // 5. "Skip setup" button dismisses wizard and sets localStorage
+  it("dismisses the wizard and sets localStorage when Skip setup is clicked", async () => {
+    const user = userEvent.setup();
+
+    await renderWithRouter(<OnboardingWizard />);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Skip setup" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(localStorage.getItem(SKIP_KEY)).toBe("true");
+  });
+
+  // 6. Submitting Step 1 form advances to Step 2
+  it("advances to Step 2 after successfully creating a network", async () => {
+    const user = userEvent.setup();
+
+    await renderWithRouter(<OnboardingWizard />);
+
+    // Fill in required fields
+    await user.type(screen.getByPlaceholderText("Office LAN"), "My Network");
+    await user.type(
+      screen.getByPlaceholderText("192.168.1.0/24"),
+      "10.0.0.0/8",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add network" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Step 2 of 3")).toBeInTheDocument();
+    });
+  });
+
+  // 6b. Submitting with empty name shows validation error
+  it("shows a validation error when name is empty", async () => {
+    const user = userEvent.setup();
+
+    await renderWithRouter(<OnboardingWizard />);
+
+    await user.click(screen.getByRole("button", { name: "Add network" }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Network name is required.",
+    );
+  });
+
+  // 7. Step 2 shows discovery running state
+  it("shows discovery running state after starting a scan", async () => {
+    const user = userEvent.setup();
+
+    // Job is still in the running list → scan not yet complete
+    mockUseDiscoveryJobs.mockReturnValue({
+      data: { data: [{ id: "job-1", status: "running" }], total: 1 },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDiscoveryJobs>);
+
+    await renderWithRouter(<OnboardingWizard />);
+
+    // Get to step 2
+    await user.type(screen.getByPlaceholderText("Office LAN"), "My Network");
+    await user.type(
+      screen.getByPlaceholderText("192.168.1.0/24"),
+      "10.0.0.0/8",
+    );
+    await user.click(screen.getByRole("button", { name: "Add network" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Step 2 of 3")).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Start discovery scan" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Discovery scan running…")).toBeInTheDocument();
+    });
+  });
+
+  // 8. Step 2 → Step 3 transition when job completes
+  //
+  // Tests the completed state directly: when the discovery job has status
+  // "completed", the wizard shows "Discovery scan complete." and a "View results"
+  // button.
+  it("shows 'Discovery scan complete' and View results button when job finishes", async () => {
+    const user = userEvent.setup();
+
+    // Job is in the list with status "completed" → scan complete immediately.
+    mockUseDiscoveryJobs.mockReturnValue({
+      data: { data: [{ id: "job-1", status: "completed", hosts_found: 5 }], total: 1 },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDiscoveryJobs>);
+
+    await renderWithRouter(<OnboardingWizard />);
+
+    // Navigate to step 2
+    await user.type(screen.getByPlaceholderText("Office LAN"), "My Network");
+    await user.type(
+      screen.getByPlaceholderText("192.168.1.0/24"),
+      "10.0.0.0/8",
+    );
+    await user.click(screen.getByRole("button", { name: "Add network" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Step 2 of 3")).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Start discovery scan" }),
+    );
+
+    // Once jobId is set and our job reports "completed", the wizard shows
+    // "Discovery scan complete." and a "View results" button.
+    await waitFor(() => {
+      expect(screen.getByText("Discovery scan complete.")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("button", { name: "View results" }),
+    ).toBeInTheDocument();
+  });
+
+  // 9. Step 3 shows hosts count and navigates to /hosts
+  it("shows new hosts count and navigates to /hosts when Go to Hosts is clicked", async () => {
+    const user = userEvent.setup();
+
+    // Job reports "completed" with 7 hosts found.
+    mockUseDiscoveryJobs.mockReturnValue({
+      data: { data: [{ id: "job-1", status: "completed", hosts_found: 7 }], total: 1 },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDiscoveryJobs>);
+
+    await renderWithRouter(<OnboardingWizard />);
+
+    // Step 1
+    await user.type(screen.getByPlaceholderText("Office LAN"), "My Network");
+    await user.type(
+      screen.getByPlaceholderText("192.168.1.0/24"),
+      "10.0.0.0/8",
+    );
+    await user.click(screen.getByRole("button", { name: "Add network" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Step 2 of 3")).toBeInTheDocument();
+    });
+
+    // Step 2: trigger scan, job immediately complete
+    await user.click(
+      screen.getByRole("button", { name: "Start discovery scan" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Discovery scan complete.")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "View results" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Step 3 of 3")).toBeInTheDocument();
+    });
+
+    // Step 3: verify hosts found count is displayed.
+    expect(screen.getByText("7")).toBeInTheDocument();
+
+    // Clicking "Go to Hosts" navigates via TanStack Router, not a bare href.
+    await user.click(screen.getByRole("button", { name: "Go to Hosts" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/hosts" });
+  });
+
+  // 10a. Jobs query failing while scanning shows API error and Retry button
+  it("shows an error when the discovery jobs query fails while scanning", async () => {
+    const user = userEvent.setup();
+
+    // First render: jobs query succeeds (no error)
+    setupDefaultMocks();
+
+    await renderWithRouter(<OnboardingWizard />);
+
+    // Navigate to step 2
+    await user.type(screen.getByPlaceholderText("Office LAN"), "My Network");
+    await user.type(screen.getByPlaceholderText("192.168.1.0/24"), "10.0.0.0/8");
+    await user.click(screen.getByRole("button", { name: "Add network" }));
+    await waitFor(() => expect(screen.getByText("Step 2 of 3")).toBeInTheDocument());
+
+    // Now simulate the jobs query failing after the job is started
+    mockUseDiscoveryJobs.mockReturnValue({
+      data: undefined,
+      error: new Error("Network error"),
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDiscoveryJobs>);
+
+    await user.click(screen.getByRole("button", { name: "Start discovery scan" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Failed to check scan status");
+    });
+  });
+
+  // 10. Failed discovery scan shows error and retry button
+  it("shows error message and Retry button when discovery scan fails", async () => {
+    const user = userEvent.setup();
+
+    // Job reports "failed".
+    mockUseDiscoveryJobs.mockReturnValue({
+      data: { data: [{ id: "job-1", status: "failed", hosts_found: 0 }], total: 1 },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDiscoveryJobs>);
+
+    await renderWithRouter(<OnboardingWizard />);
+
+    // Navigate to step 2
+    await user.type(screen.getByPlaceholderText("Office LAN"), "My Network");
+    await user.type(
+      screen.getByPlaceholderText("192.168.1.0/24"),
+      "10.0.0.0/8",
+    );
+    await user.click(screen.getByRole("button", { name: "Add network" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Step 2 of 3")).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Start discovery scan" }),
+    );
+
+    // When the job status is "failed", show an error alert and a Retry button.
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Discovery scan failed.",
+      );
+    });
+
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+
+    // Clicking Retry resets back to the "Start discovery scan" state.
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Start discovery scan" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/onboarding-wizard.tsx
+++ b/frontend/src/components/onboarding-wizard.tsx
@@ -1,0 +1,526 @@
+import { useState, useId } from "react";
+import { Loader2, CheckCircle2 } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+import { Button } from "./button";
+import { useNetworks, useCreateNetwork } from "../api/hooks/use-networks";
+import {
+  useRerunDiscovery,
+  useDiscoveryJobs,
+} from "../api/hooks/use-discovery";
+import { cn } from "../lib/utils";
+
+const SKIP_KEY = "scanorama_onboarding_skipped";
+const TOTAL_STEPS = 3;
+
+const DISCOVERY_METHODS = [
+  { value: "ping", label: "Ping (ICMP echo)" },
+  { value: "tcp", label: "TCP" },
+  { value: "arp", label: "ARP broadcast" },
+] as const;
+
+type DiscoveryMethod = (typeof DISCOVERY_METHODS)[number]["value"];
+
+// ── Step 1: Add a network ─────────────────────────────────────────────────────
+
+interface Step1Props {
+  onCreated: (networkId: string) => void;
+  onSkip: () => void;
+}
+
+function Step1({ onCreated, onSkip }: Step1Props) {
+  const id = useId();
+  const [name, setName] = useState("");
+  const [cidr, setCidr] = useState("");
+  const [description, setDescription] = useState("");
+  const [discoveryMethod, setDiscoveryMethod] =
+    useState<DiscoveryMethod>("ping");
+  const [scanEnabled, setScanEnabled] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const { mutateAsync: createNetwork, isPending } = useCreateNetwork();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const trimmedName = name.trim();
+    const trimmedCidr = cidr.trim();
+
+    if (!trimmedName) {
+      setError("Network name is required.");
+      return;
+    }
+
+    if (!trimmedCidr) {
+      setError("CIDR block is required (e.g. 192.168.1.0/24).");
+      return;
+    }
+
+    if (!/^[\da-fA-F:./]+\/\d+$/.test(trimmedCidr)) {
+      setError(
+        "CIDR block must be in valid notation (e.g. 192.168.1.0/24 or 10.0.0.0/8).",
+      );
+      return;
+    }
+
+    try {
+      const created = await createNetwork({
+        name: trimmedName,
+        cidr: trimmedCidr,
+        description: description.trim() || undefined,
+        discovery_method: discoveryMethod,
+        scan_enabled: scanEnabled,
+        is_active: true,
+      });
+      if (created?.id) {
+        onCreated(created.id);
+      }
+    } catch (err) {
+      const apiErr = err as { message?: string; error?: string };
+      const message =
+        apiErr.message ?? apiErr.error ?? "Failed to create network.";
+      setError(message);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="px-5 py-4 space-y-5">
+      <div className="space-y-1.5">
+        <label
+          htmlFor={`${id}-name`}
+          className="block text-xs font-medium text-text-primary"
+        >
+          Name
+        </label>
+        <input
+          id={`${id}-name`}
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Office LAN"
+          autoFocus
+          className={cn(
+            "w-full px-3 py-1.5 text-xs rounded border border-border",
+            "bg-surface text-text-primary placeholder:text-text-muted",
+            "focus:outline-none focus:ring-1 focus:ring-border",
+          )}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <label
+          htmlFor={`${id}-cidr`}
+          className="block text-xs font-medium text-text-primary"
+        >
+          CIDR block
+        </label>
+        <input
+          id={`${id}-cidr`}
+          type="text"
+          value={cidr}
+          onChange={(e) => setCidr(e.target.value)}
+          placeholder="192.168.1.0/24"
+          className={cn(
+            "w-full px-3 py-1.5 text-xs rounded border border-border font-mono",
+            "bg-surface text-text-primary placeholder:text-text-muted",
+            "focus:outline-none focus:ring-1 focus:ring-border",
+          )}
+        />
+        <p className="text-xs text-text-muted">
+          IPv4 or IPv6 CIDR notation (e.g. 10.0.0.0/8).
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <label
+          htmlFor={`${id}-description`}
+          className="block text-xs font-medium text-text-primary"
+        >
+          Description{" "}
+          <span className="text-text-muted font-normal">(optional)</span>
+        </label>
+        <input
+          id={`${id}-description`}
+          type="text"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Main office network"
+          className={cn(
+            "w-full px-3 py-1.5 text-xs rounded border border-border",
+            "bg-surface text-text-primary placeholder:text-text-muted",
+            "focus:outline-none focus:ring-1 focus:ring-border",
+          )}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <label
+          htmlFor={`${id}-discovery`}
+          className="block text-xs font-medium text-text-primary"
+        >
+          Discovery method
+        </label>
+        <select
+          id={`${id}-discovery`}
+          value={discoveryMethod}
+          onChange={(e) =>
+            setDiscoveryMethod(e.target.value as DiscoveryMethod)
+          }
+          aria-label="Select discovery method"
+          className={cn(
+            "w-full px-3 py-1.5 text-xs rounded border border-border",
+            "bg-surface text-text-primary",
+            "focus:outline-none focus:ring-1 focus:ring-border",
+          )}
+        >
+          {DISCOVERY_METHODS.map((m) => (
+            <option key={m.value} value={m.value}>
+              {m.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          id={`${id}-scan-enabled`}
+          type="checkbox"
+          checked={scanEnabled}
+          onChange={(e) => setScanEnabled(e.target.checked)}
+          className="h-3.5 w-3.5 rounded border-border accent-accent"
+        />
+        <label
+          htmlFor={`${id}-scan-enabled`}
+          className="text-xs text-text-primary"
+        >
+          Enable scanning for this network
+        </label>
+      </div>
+
+      {error && (
+        <p role="alert" className="text-xs text-danger">
+          {error}
+        </p>
+      )}
+
+      <div className="flex justify-between gap-2 pt-1">
+        <Button variant="ghost" type="button" onClick={onSkip}>
+          Skip setup
+        </Button>
+        <Button type="submit" loading={isPending}>
+          {isPending ? (
+            <>
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Creating…
+            </>
+          ) : (
+            "Add network"
+          )}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+// ── Step 2: Run a discovery scan ──────────────────────────────────────────────
+
+interface Step2Props {
+  networkId: string;
+  onComplete: (jobId: string, newHostsCount: number) => void;
+  onSkip: () => void;
+}
+
+function Step2({ networkId, onComplete, onSkip }: Step2Props) {
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [startError, setStartError] = useState<string | null>(null);
+
+  const { mutateAsync: rerunDiscovery, isPending } = useRerunDiscovery();
+
+  // Fetch all jobs (no status filter) so we can detect completed and failed.
+  const { data: jobsData, error: jobsError } = useDiscoveryJobs();
+
+  const allJobs = jobsData?.data ?? [];
+  const ourJob = jobId !== null ? allJobs.find((j) => j.id === jobId) : undefined;
+
+  // When jobId is set but the job isn't in the list yet, treat as still pending.
+  const jobStatus = ourJob?.status ?? (jobId !== null ? "pending" : null);
+  const jobsFailed = jobId !== null && !!jobsError;
+  const scanComplete = jobStatus === "completed";
+  const scanFailed = jobStatus === "failed";
+  const scanRunning = jobId !== null && !scanComplete && !scanFailed && !jobsFailed;
+
+  async function handleStart() {
+    setStartError(null);
+    try {
+      const created = await rerunDiscovery({ networks: [networkId] });
+      if (created?.id) {
+        setJobId(created.id);
+      }
+    } catch (err) {
+      const apiErr = err as { message?: string; error?: string };
+      setStartError(apiErr.message ?? apiErr.error ?? "Failed to start discovery.");
+    }
+  }
+
+  function handleRetry() {
+    setJobId(null);
+  }
+
+  function handleNext() {
+    if (jobId && ourJob) {
+      onComplete(jobId, ourJob.hosts_found ?? 0);
+    }
+  }
+
+  return (
+    <div className="px-5 py-4 space-y-5">
+      <p className="text-sm text-text-primary">
+        Run a discovery scan to find all devices on your network.
+      </p>
+
+      {!jobId && (
+        <div className="space-y-3">
+          <p className="text-xs text-text-muted">
+            This will probe the CIDR range you just added and list all
+            responding hosts.
+          </p>
+          {startError && (
+            <p role="alert" className="text-xs text-danger">
+              {startError}
+            </p>
+          )}
+          <div className="flex justify-between gap-2 pt-1">
+            <Button variant="ghost" type="button" onClick={onSkip}>
+              Skip setup
+            </Button>
+            <Button onClick={() => void handleStart()} loading={isPending}>
+              {isPending ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Starting…
+                </>
+              ) : (
+                "Start discovery scan"
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {scanRunning && (
+        <div className="space-y-3">
+          <div
+            className="flex items-center gap-2 text-xs text-text-muted"
+            aria-live="polite"
+          >
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>Discovery scan running…</span>
+          </div>
+          <div className="flex justify-between gap-2 pt-1">
+            <Button variant="ghost" type="button" onClick={onSkip}>
+              Skip setup
+            </Button>
+            <Button variant="secondary" disabled>
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {scanFailed && (
+        <div className="space-y-3">
+          <p role="alert" className="text-xs text-danger">
+            Discovery scan failed.
+          </p>
+          <div className="flex justify-between gap-2 pt-1">
+            <Button variant="ghost" type="button" onClick={onSkip}>
+              Skip setup
+            </Button>
+            <Button onClick={handleRetry}>Retry</Button>
+          </div>
+        </div>
+      )}
+
+      {jobsFailed && (
+        <div className="space-y-3">
+          <p role="alert" className="text-xs text-danger">
+            Failed to check scan status. Please try again.
+          </p>
+          <div className="flex justify-between gap-2 pt-1">
+            <Button variant="ghost" type="button" onClick={onSkip}>
+              Skip setup
+            </Button>
+            <Button variant="secondary" onClick={() => setJobId(null)}>
+              Retry
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {scanComplete && (
+        <div className="space-y-3">
+          <div
+            className="flex items-center gap-2 text-xs text-text-primary"
+            aria-live="polite"
+          >
+            <CheckCircle2 className="h-4 w-4 text-success" />
+            <span>Discovery scan complete.</span>
+          </div>
+          <div className="flex justify-end gap-2 pt-1">
+            <Button onClick={handleNext}>View results</Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Step 3: Review results ────────────────────────────────────────────────────
+
+interface Step3Props {
+  newHostsCount: number;
+  onDone: () => void;
+}
+
+function Step3({ newHostsCount, onDone }: Step3Props) {
+  return (
+    <div className="px-5 py-4 space-y-5">
+      <p className="text-sm text-text-primary">
+        Your network has been scanned. Here is what was found:
+      </p>
+
+      <div className="rounded border border-border bg-surface-raised px-4 py-3">
+        <p className="text-xs text-text-muted">Hosts discovered</p>
+        <p className="text-2xl font-semibold text-text-primary mt-0.5">
+          {newHostsCount}
+        </p>
+      </div>
+
+      <p className="text-xs text-text-muted">
+        View all discovered hosts to see details, open ports, and more.
+      </p>
+
+      <div className="flex justify-end gap-2 pt-1">
+        <Button onClick={onDone}>Go to Hosts</Button>
+      </div>
+    </div>
+  );
+}
+
+// ── Progress indicator ─────────────────────────────────────────────────────────
+
+interface ProgressProps {
+  step: number;
+  total: number;
+}
+
+function ProgressIndicator({ step, total }: ProgressProps) {
+  return (
+    <div className="flex items-center gap-2 px-5 py-3 border-b border-border">
+      <span className="text-xs text-text-muted">
+        Step {step} of {total}
+      </span>
+      <div className="flex gap-1.5 ml-1">
+        {Array.from({ length: total }, (_, i) => (
+          <div
+            key={i}
+            className={cn(
+              "h-1.5 w-1.5 rounded-full transition-colors",
+              i + 1 <= step ? "bg-accent" : "bg-border",
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Wizard shell ──────────────────────────────────────────────────────────────
+
+export function OnboardingWizard() {
+  const { data: networksData, isLoading } = useNetworks();
+  const navigate = useNavigate();
+
+  const [dismissed, setDismissed] = useState(
+    () => localStorage.getItem(SKIP_KEY) === "true",
+  );
+  const [step, setStep] = useState(1);
+  const [createdNetworkId, setCreatedNetworkId] = useState<string | null>(null);
+  const [completedJobId, setCompletedJobId] = useState<string | null>(null);
+  const [newHostsCount, setNewHostsCount] = useState(0);
+
+  function handleSkip() {
+    localStorage.setItem(SKIP_KEY, "true");
+    setDismissed(true);
+  }
+
+  function handleNetworkCreated(networkId: string) {
+    setCreatedNetworkId(networkId);
+    setStep(2);
+  }
+
+  function handleScanComplete(jobId: string, hostCount: number) {
+    setCompletedJobId(jobId);
+    setNewHostsCount(hostCount);
+    setStep(3);
+  }
+
+  function handleDone() {
+    localStorage.setItem(SKIP_KEY, "true");
+    setDismissed(true);
+    void navigate({ to: "/hosts" });
+  }
+
+  // Don't render while loading, when dismissed, or when networks already exist.
+  if (isLoading || dismissed) return null;
+  const total = networksData?.total ?? 0;
+  if (total > 0) return null;
+
+  const titles: Record<number, string> = {
+    1: "Add your first network",
+    2: "Run a discovery scan",
+    3: "Review results",
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 z-40" aria-hidden="true" />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="First-run setup wizard"
+        className={cn(
+          "fixed z-50 inset-0 m-auto",
+          "w-full max-w-md h-fit",
+          "bg-surface border border-border rounded-lg shadow-xl",
+          "flex flex-col",
+        )}
+      >
+        <ProgressIndicator step={step} total={TOTAL_STEPS} />
+
+        <div className="px-5 py-4 border-b border-border">
+          <h2 className="text-sm font-semibold text-text-primary">
+            {titles[step]}
+          </h2>
+        </div>
+
+        {step === 1 && (
+          <Step1 onCreated={handleNetworkCreated} onSkip={handleSkip} />
+        )}
+        {step === 2 && createdNetworkId && (
+          <Step2
+            networkId={createdNetworkId}
+            onComplete={handleScanComplete}
+            onSkip={handleSkip}
+          />
+        )}
+        {step === 3 && completedJobId && (
+          <Step3
+            newHostsCount={newHostsCount}
+            onDone={handleDone}
+          />
+        )}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/theme-toggle.tsx
+++ b/frontend/src/components/theme-toggle.tsx
@@ -1,0 +1,22 @@
+import { Sun, Moon } from "lucide-react";
+import { useTheme } from "../hooks/use-theme";
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={
+        theme === "dark" ? "Switch to light mode" : "Switch to dark mode"
+      }
+      className="p-1.5 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors"
+    >
+      {theme === "dark" ? (
+        <Sun className="h-4 w-4" />
+      ) : (
+        <Moon className="h-4 w-4" />
+      )}
+    </button>
+  );
+}

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -50,6 +50,18 @@ body {
     font-family: var(--font-mono);
 }
 
+/* ── Theme transition ────────────────────────────────────────────────────────── */
+/* Smooth 150ms fade when switching between dark and light themes.               */
+*, *::before, *::after {
+    transition: background-color 150ms ease, color 150ms ease,
+                border-color 150ms ease;
+}
+
+/* Suppress transitions for elements where animation would be jarring.           */
+[data-no-transition], [data-no-transition] * {
+    transition: none !important;
+}
+
 /* ── Light theme ─────────────────────────────────────────────────────────────── */
 /* Applied by setting data-theme="light" on <html>.                               */
 /* All semantic tokens are overridden here; components need no changes.           */

--- a/frontend/src/hooks/use-keyboard-shortcuts.test.ts
+++ b/frontend/src/hooks/use-keyboard-shortcuts.test.ts
@@ -245,7 +245,7 @@ describe("useKeyboardShortcuts", () => {
     document.removeEventListener("new-scan-requested", listener);
   });
 
-  it("ignores modifier-key combos", () => {
+  it("ignores modifier-key combos (other than Cmd/Ctrl+K)", () => {
     renderHook(() => useKeyboardShortcuts());
 
     act(() => {
@@ -253,5 +253,36 @@ describe("useKeyboardShortcuts", () => {
     });
 
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("dispatches search-requested on Cmd+K (metaKey)", () => {
+    const listener = vi.fn();
+    document.addEventListener("search-requested", listener);
+
+    renderHook(() => useKeyboardShortcuts());
+
+    act(() => {
+      fireKey("k", { metaKey: true });
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    document.removeEventListener("search-requested", listener);
+  });
+
+  it("dispatches search-requested on Ctrl+K", () => {
+    const listener = vi.fn();
+    document.addEventListener("search-requested", listener);
+
+    renderHook(() => useKeyboardShortcuts());
+
+    act(() => {
+      fireKey("k", { ctrlKey: true });
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    document.removeEventListener("search-requested", listener);
   });
 });

--- a/frontend/src/hooks/use-keyboard-shortcuts.test.ts
+++ b/frontend/src/hooks/use-keyboard-shortcuts.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useKeyboardShortcuts, G_TIMEOUT_MS } from "./use-keyboard-shortcuts";
+
+// ── Mock TanStack Router ───────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+let mockPathname = "/";
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mockNavigate,
+  useRouterState: ({ select }: { select: (s: { location: { pathname: string } }) => string }) =>
+    select({ location: { pathname: mockPathname } }),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function fireKey(key: string, options: Partial<KeyboardEventInit> = {}) {
+  const event = new KeyboardEvent("keydown", { key, bubbles: true, ...options });
+  document.dispatchEvent(event);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("useKeyboardShortcuts", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockPathname = "/";
+    // Ensure no element is focused inside an input
+    (document.activeElement as HTMLElement | null)?.blur?.();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("navigates to /hosts on g h", () => {
+    renderHook(() => useKeyboardShortcuts());
+
+    act(() => {
+      fireKey("g");
+      fireKey("h");
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/hosts" });
+  });
+
+  it("navigates to /scans on g s", () => {
+    renderHook(() => useKeyboardShortcuts());
+
+    act(() => {
+      fireKey("g");
+      fireKey("s");
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/scans" });
+  });
+
+  it("navigates to /networks on g n", () => {
+    renderHook(() => useKeyboardShortcuts());
+
+    act(() => {
+      fireKey("g");
+      fireKey("n");
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/networks" });
+  });
+
+  it("navigates to / on g d", () => {
+    renderHook(() => useKeyboardShortcuts());
+
+    act(() => {
+      fireKey("g");
+      fireKey("d");
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/" });
+  });
+
+  it("navigates to /admin on g a", () => {
+    renderHook(() => useKeyboardShortcuts());
+
+    act(() => {
+      fireKey("g");
+      fireKey("a");
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/admin" });
+  });
+
+  it("does not navigate when g is pressed without a follow-up key", () => {
+    vi.useFakeTimers();
+    renderHook(() => useKeyboardShortcuts());
+
+    act(() => {
+      fireKey("g");
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(G_TIMEOUT_MS + 100);
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("cancels pending g on timeout so subsequent g h works fresh", () => {
+    vi.useFakeTimers();
+    renderHook(() => useKeyboardShortcuts());
+
+    act(() => {
+      fireKey("g");
+    });
+    // Let the timeout expire
+    act(() => {
+      vi.advanceTimersByTime(G_TIMEOUT_MS + 100);
+    });
+    // Now press g h — should navigate
+    act(() => {
+      fireKey("g");
+      fireKey("h");
+    });
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/hosts" });
+    vi.useRealTimers();
+  });
+
+  it("ignores unrecognised second key after g and does not navigate", () => {
+    renderHook(() => useKeyboardShortcuts());
+
+    act(() => {
+      fireKey("g");
+      fireKey("z"); // not a valid binding
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("toggles showHelp on ?", () => {
+    const { result } = renderHook(() => useKeyboardShortcuts());
+
+    expect(result.current.showHelp).toBe(false);
+
+    act(() => {
+      fireKey("?");
+    });
+
+    expect(result.current.showHelp).toBe(true);
+
+    act(() => {
+      fireKey("?");
+    });
+
+    expect(result.current.showHelp).toBe(false);
+  });
+
+  it("closes help overlay on Escape when it is open", () => {
+    const { result } = renderHook(() => useKeyboardShortcuts());
+
+    act(() => {
+      fireKey("?");
+    });
+    expect(result.current.showHelp).toBe(true);
+
+    act(() => {
+      fireKey("Escape");
+    });
+    expect(result.current.showHelp).toBe(false);
+  });
+
+  it("does not fire shortcuts when focus is inside an input", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    renderHook(() => useKeyboardShortcuts());
+
+    act(() => {
+      fireKey("g");
+      fireKey("h");
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+
+  it("does not fire shortcuts when focus is inside a textarea", () => {
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+
+    const { result } = renderHook(() => useKeyboardShortcuts());
+
+    // Initially showHelp should be false
+    expect(result.current.showHelp).toBe(false);
+
+    // Focus textarea and press ?
+    textarea.focus();
+    act(() => {
+      fireKey("?");
+    });
+
+    // showHelp should remain false since focus was in textarea
+    expect(result.current.showHelp).toBe(false);
+
+    // Unfocus textarea and press ? again
+    textarea.blur();
+    act(() => {
+      fireKey("?");
+    });
+
+    // Now showHelp should toggle to true, proving suppression was the reason it stayed false
+    expect(result.current.showHelp).toBe(true);
+
+    document.body.removeChild(textarea);
+  });
+
+  it("navigates to /scans on n when not on /scans", () => {
+    mockPathname = "/hosts";
+    renderHook(() => useKeyboardShortcuts());
+
+    act(() => {
+      fireKey("n");
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/scans" });
+  });
+
+  it("dispatches new-scan-requested event on n when already on /scans", () => {
+    mockPathname = "/scans";
+    const listener = vi.fn();
+    document.addEventListener("new-scan-requested", listener);
+
+    renderHook(() => useKeyboardShortcuts());
+
+    act(() => {
+      fireKey("n");
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    document.removeEventListener("new-scan-requested", listener);
+  });
+
+  it("ignores modifier-key combos", () => {
+    renderHook(() => useKeyboardShortcuts());
+
+    act(() => {
+      fireKey("h", { ctrlKey: true });
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/use-keyboard-shortcuts.ts
+++ b/frontend/src/hooks/use-keyboard-shortcuts.ts
@@ -48,7 +48,14 @@ export function useKeyboardShortcuts(): UseKeyboardShortcutsResult {
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      // Ignore modifier-key combos (Ctrl, Alt, Meta) — let the browser handle them.
+      // Cmd+K (macOS) or Ctrl+K (Windows/Linux) opens the command palette.
+      if ((e.metaKey || e.ctrlKey) && e.key === "k" && !e.altKey) {
+        e.preventDefault();
+        document.dispatchEvent(new CustomEvent("search-requested"));
+        return;
+      }
+
+      // Ignore other modifier-key combos (Ctrl, Alt, Meta) — let the browser handle them.
       if (e.ctrlKey || e.altKey || e.metaKey) return;
 
       // Suppress shortcuts when typing in an input field.

--- a/frontend/src/hooks/use-keyboard-shortcuts.ts
+++ b/frontend/src/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,135 @@
+import { useEffect, useCallback, useRef, useState } from "react";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
+
+/** Duration in ms to wait for a second key after `g` before cancelling. */
+export const G_TIMEOUT_MS = 1000;
+
+/** Returns true when focus is inside an interactive text input element. */
+function isInTextInput(): boolean {
+  const tag = document.activeElement?.tagName?.toLowerCase();
+  return tag === "input" || tag === "textarea" || tag === "select";
+}
+
+export interface UseKeyboardShortcutsResult {
+  showHelp: boolean;
+  setShowHelp: (v: boolean) => void;
+}
+
+/**
+ * Sets up the global keyboard shortcut listener.
+ *
+ * Bindings:
+ *   g h  → /hosts
+ *   g s  → /scans
+ *   g n  → /networks
+ *   g d  → / (dashboard)
+ *   g a  → /admin
+ *   n    → navigate to /scans or emit new-scan-requested if already there
+ *   ?    → toggle help overlay
+ *
+ * Shortcuts are suppressed while focus is inside an <input>, <textarea>,
+ * or <select>. The `g` prefix has a 1-second timeout — if no second key
+ * arrives within 1s the pending `g` is cancelled.
+ */
+export function useKeyboardShortcuts(): UseKeyboardShortcutsResult {
+  const navigate = useNavigate();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const [showHelp, setShowHelp] = useState(false);
+  const pendingG = useRef(false);
+  const gTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelPendingG = useCallback(() => {
+    if (gTimer.current !== null) {
+      clearTimeout(gTimer.current);
+      gTimer.current = null;
+    }
+    pendingG.current = false;
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      // Ignore modifier-key combos (Ctrl, Alt, Meta) — let the browser handle them.
+      if (e.ctrlKey || e.altKey || e.metaKey) return;
+
+      // Suppress shortcuts when typing in an input field.
+      if (isInTextInput()) {
+        cancelPendingG();
+        return;
+      }
+
+      const key = e.key;
+
+      // ── Handle pending `g` prefix ──────────────────────────────────────────
+      if (pendingG.current) {
+        cancelPendingG();
+
+        switch (key) {
+          case "h":
+            e.preventDefault();
+            void navigate({ to: "/hosts" });
+            return;
+          case "s":
+            e.preventDefault();
+            void navigate({ to: "/scans" });
+            return;
+          case "n":
+            e.preventDefault();
+            void navigate({ to: "/networks" });
+            return;
+          case "d":
+            e.preventDefault();
+            void navigate({ to: "/" });
+            return;
+          case "a":
+            e.preventDefault();
+            void navigate({ to: "/admin" });
+            return;
+          default:
+            // Unrecognised second key — just drop the pending `g`.
+            return;
+        }
+      }
+
+      // ── Top-level bindings ─────────────────────────────────────────────────
+      switch (key) {
+        case "g":
+          e.preventDefault();
+          pendingG.current = true;
+          gTimer.current = setTimeout(cancelPendingG, G_TIMEOUT_MS);
+          return;
+
+        case "n":
+          e.preventDefault();
+          if (pathname === "/scans") {
+            document.dispatchEvent(new CustomEvent("new-scan-requested"));
+          } else {
+            void navigate({ to: "/scans" });
+          }
+          return;
+
+        case "?":
+          e.preventDefault();
+          setShowHelp((prev) => !prev);
+          return;
+
+        case "Escape":
+          if (showHelp) {
+            e.preventDefault();
+            setShowHelp(false);
+          }
+          return;
+      }
+    },
+    [navigate, pathname, showHelp, cancelPendingG],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      cancelPendingG();
+    };
+  }, [handleKeyDown, cancelPendingG]);
+
+  return { showHelp, setShowHelp };
+}

--- a/frontend/src/hooks/use-recent-pages.test.ts
+++ b/frontend/src/hooks/use-recent-pages.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useRecentPages, type RecentPage } from "./use-recent-pages";
+
+// ── localStorage mock ──────────────────────────────────────────────────────────
+// Node 26 has an experimental (broken) global localStorage that conflicts with
+// jsdom's. We stub it with a working in-memory implementation.
+
+function makeStorageMock(): Storage {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      Object.keys(store).forEach((k) => delete store[k]);
+    },
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  };
+}
+
+let storageMock: Storage;
+
+const STORAGE_KEY = "scanorama_recent_pages";
+
+function makeRecent(label: string, url: string): RecentPage {
+  return { label, url, type: "recent" };
+}
+
+describe("useRecentPages", () => {
+  beforeEach(() => {
+    storageMock = makeStorageMock();
+    vi.stubGlobal("localStorage", storageMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns an empty list when localStorage is empty", () => {
+    const { result } = renderHook(() => useRecentPages());
+    expect(result.current.recentPages).toEqual([]);
+  });
+
+  it("adds a page and returns it", () => {
+    const { result } = renderHook(() => useRecentPages());
+
+    act(() => {
+      result.current.addRecentPage(makeRecent("Hosts", "/hosts"));
+    });
+
+    expect(result.current.recentPages).toHaveLength(1);
+    expect(result.current.recentPages[0].url).toBe("/hosts");
+    expect(result.current.recentPages[0].label).toBe("Hosts");
+    expect(result.current.recentPages[0].type).toBe("recent");
+  });
+
+  it("persists to localStorage", () => {
+    const { result } = renderHook(() => useRecentPages());
+
+    act(() => {
+      result.current.addRecentPage(makeRecent("Hosts", "/hosts"));
+    });
+
+    const stored = JSON.parse(
+      storageMock.getItem(STORAGE_KEY) ?? "[]",
+    ) as RecentPage[];
+    expect(stored).toHaveLength(1);
+    expect(stored[0].url).toBe("/hosts");
+  });
+
+  it("deduplicates entries by URL (keeps the latest visit first)", () => {
+    const { result } = renderHook(() => useRecentPages());
+
+    act(() => {
+      result.current.addRecentPage(makeRecent("Hosts", "/hosts"));
+    });
+    act(() => {
+      result.current.addRecentPage(makeRecent("Scans", "/scans"));
+    });
+    act(() => {
+      result.current.addRecentPage(makeRecent("Hosts", "/hosts"));
+    });
+
+    expect(result.current.recentPages).toHaveLength(2);
+    expect(result.current.recentPages[0].url).toBe("/hosts");
+    expect(result.current.recentPages[1].url).toBe("/scans");
+  });
+
+  it("limits to 5 entries (newest first)", () => {
+    const { result } = renderHook(() => useRecentPages());
+
+    act(() => {
+      for (let i = 1; i <= 7; i++) {
+        result.current.addRecentPage(makeRecent(`Page ${i}`, `/page/${i}`));
+      }
+    });
+
+    expect(result.current.recentPages).toHaveLength(5);
+    // Newest is last-added (page 7).
+    expect(result.current.recentPages[0].url).toBe("/page/7");
+    // Oldest retained is page 3 (pages 1 and 2 were evicted).
+    expect(result.current.recentPages[4].url).toBe("/page/3");
+  });
+
+  it("loads existing entries from localStorage on mount", () => {
+    const existing: RecentPage[] = [
+      makeRecent("Networks", "/networks"),
+      makeRecent("Admin", "/admin"),
+    ];
+    storageMock.setItem(STORAGE_KEY, JSON.stringify(existing));
+
+    const { result } = renderHook(() => useRecentPages());
+
+    expect(result.current.recentPages).toHaveLength(2);
+    expect(result.current.recentPages[0].url).toBe("/networks");
+  });
+});

--- a/frontend/src/hooks/use-recent-pages.ts
+++ b/frontend/src/hooks/use-recent-pages.ts
@@ -1,0 +1,48 @@
+import { useState, useCallback } from "react";
+
+const STORAGE_KEY = "scanorama_recent_pages";
+const MAX_RECENT = 5;
+
+export interface RecentPage {
+  label: string;
+  url: string;
+  type: "recent";
+}
+
+function readFromStorage(): RecentPage[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as RecentPage[];
+  } catch {
+    return [];
+  }
+}
+
+function writeToStorage(pages: RecentPage[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(pages));
+  } catch {
+    // localStorage may be unavailable in some environments — silently ignore.
+  }
+}
+
+/**
+ * Stores and retrieves recent page visits from localStorage.
+ * Key: "scanorama_recent_pages", max 5 entries, newest first.
+ */
+export function useRecentPages() {
+  const [recentPages, setRecentPages] = useState<RecentPage[]>(readFromStorage);
+
+  const addRecentPage = useCallback((page: RecentPage) => {
+    setRecentPages((prev) => {
+      // Deduplicate by URL — remove existing entry if present.
+      const filtered = prev.filter((p) => p.url !== page.url);
+      const updated = [page, ...filtered].slice(0, MAX_RECENT);
+      writeToStorage(updated);
+      return updated;
+    });
+  }, []);
+
+  return { recentPages, addRecentPage };
+}

--- a/frontend/src/hooks/use-theme.test.ts
+++ b/frontend/src/hooks/use-theme.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTheme } from "./use-theme";
+
+// ── localStorage mock ──────────────────────────────────────────────────────────
+// Node 26 has an experimental (broken) global localStorage that conflicts with
+// jsdom's. We stub it with a working in-memory implementation.
+
+function makeStorageMock(): Storage {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { Object.keys(store).forEach((k) => delete store[k]); },
+    get length() { return Object.keys(store).length; },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  };
+}
+
+let storageMock: Storage;
+
+// ── matchMedia helper ──────────────────────────────────────────────────────────
+
+function makeMatchMedia(prefersLight: boolean) {
+  return vi.fn((query: string) => ({
+    matches: prefersLight && query === "(prefers-color-scheme: light)",
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  }));
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("useTheme", () => {
+  beforeEach(() => {
+    storageMock = makeStorageMock();
+    vi.stubGlobal("localStorage", storageMock);
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("defaults to dark when no localStorage and no system preference for light", () => {
+    vi.stubGlobal("matchMedia", makeMatchMedia(false));
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBeNull();
+  });
+
+  it("reads 'light' from localStorage and applies data-theme='light'", () => {
+    vi.stubGlobal("matchMedia", makeMatchMedia(false));
+    storageMock.setItem("theme", "light");
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+
+  it("reads 'dark' from localStorage and removes data-theme", () => {
+    vi.stubGlobal("matchMedia", makeMatchMedia(true));
+    // system prefers light but explicit localStorage wins
+    storageMock.setItem("theme", "dark");
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBeNull();
+  });
+
+  it("falls back to system preference (light) when localStorage is empty", () => {
+    vi.stubGlobal("matchMedia", makeMatchMedia(true));
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+
+  it("toggleTheme flips from dark to light, applies data-theme='light', persists to localStorage", () => {
+    vi.stubGlobal("matchMedia", makeMatchMedia(false));
+
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("dark");
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+
+    expect(result.current.theme).toBe("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(storageMock.getItem("theme")).toBe("light");
+  });
+
+  it("toggleTheme flips from light to dark, removes data-theme, persists to localStorage", () => {
+    vi.stubGlobal("matchMedia", makeMatchMedia(false));
+    storageMock.setItem("theme", "light");
+
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("light");
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+
+    expect(result.current.theme).toBe("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBeNull();
+    expect(storageMock.getItem("theme")).toBe("dark");
+  });
+});

--- a/frontend/src/hooks/use-theme.ts
+++ b/frontend/src/hooks/use-theme.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect } from "react";
+
+export type Theme = "dark" | "light";
+
+const STORAGE_KEY = "theme";
+const LIGHT_QUERY = "(prefers-color-scheme: light)";
+const DATA_ATTR = "light";
+
+function applyTheme(theme: Theme): void {
+  if (theme === "light") {
+    document.documentElement.setAttribute("data-theme", DATA_ATTR);
+  } else {
+    document.documentElement.removeAttribute("data-theme");
+  }
+}
+
+function getInitialTheme(): Theme {
+  const stored = globalThis.localStorage?.getItem(STORAGE_KEY);
+  if (stored === "light" || stored === "dark") return stored;
+  return window.matchMedia(LIGHT_QUERY).matches ? "light" : "dark";
+}
+
+export interface UseThemeResult {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+export function useTheme(): UseThemeResult {
+  const [theme, setTheme] = useState<Theme>(() => getInitialTheme());
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  function toggleTheme(): void {
+    const next: Theme = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    globalThis.localStorage?.setItem(STORAGE_KEY, next);
+  }
+
+  return { theme, toggleTheme };
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -18,6 +18,7 @@ import { AdminPage } from "./routes/admin";
 import { GroupsPage } from "./routes/groups";
 import { PortsPage } from "./routes/ports";
 import { DeviceDetailPage } from "./routes/devices";
+import { ScanDiffPage } from "./routes/scan-diff";
 
 const rootRoute = createRootRoute({
   component: RootLayout,
@@ -33,6 +34,18 @@ const scansRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/scans",
   component: ScansPage,
+});
+
+const scanDiffSearchSchema = z.object({
+  a: z.string().optional(),
+  b: z.string().optional(),
+});
+
+const scanDiffRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/scans/diff",
+  component: ScanDiffPage,
+  validateSearch: scanDiffSearchSchema,
 });
 
 const hostsSearchSchema = z.object({
@@ -111,6 +124,7 @@ const deviceDetailRoute = createRoute({
 const routeTree = rootRoute.addChildren([
   dashboardRoute,
   scansRoute,
+  scanDiffRoute,
   hostsRoute,
   networksRoute,
   exclusionsRoute,

--- a/frontend/src/routes/admin.test.tsx
+++ b/frontend/src/routes/admin.test.tsx
@@ -34,6 +34,15 @@ vi.mock("../api/hooks/use-dashboard", () => ({
   useUpdateSetting: vi.fn(),
 }));
 
+vi.mock("../api/hooks/use-webhooks", () => ({
+  useWebhooks: vi.fn(),
+  useCreateWebhook: vi.fn(),
+  useUpdateWebhook: vi.fn(),
+  useDeleteWebhook: vi.fn(),
+  useTestWebhook: vi.fn(),
+  useDeliveryLogs: vi.fn(),
+}));
+
 import {
   useAdminStatus,
   useWorkers,
@@ -41,12 +50,26 @@ import {
   useLogs,
 } from "../api/hooks/use-system";
 import { useSettings, useUpdateSetting } from "../api/hooks/use-dashboard";
+import {
+  useWebhooks,
+  useCreateWebhook,
+  useUpdateWebhook,
+  useDeleteWebhook,
+  useTestWebhook,
+  useDeliveryLogs,
+} from "../api/hooks/use-webhooks";
 const mockUseAdminStatus = vi.mocked(useAdminStatus);
 const mockUseWorkers = vi.mocked(useWorkers);
 const mockUseVersion = vi.mocked(useVersion);
 const mockUseLogs = vi.mocked(useLogs);
 const mockUseSettings = vi.mocked(useSettings);
 const mockUseUpdateSetting = vi.mocked(useUpdateSetting);
+const mockUseWebhooks = vi.mocked(useWebhooks);
+const mockUseCreateWebhook = vi.mocked(useCreateWebhook);
+const mockUseUpdateWebhook = vi.mocked(useUpdateWebhook);
+const mockUseDeleteWebhook = vi.mocked(useDeleteWebhook);
+const mockUseTestWebhook = vi.mocked(useTestWebhook);
+const mockUseDeliveryLogs = vi.mocked(useDeliveryLogs);
 
 beforeEach(() => {
   // Default: not loading, no data — SystemStatusCard renders real UI (including "System Status" heading)
@@ -74,6 +97,12 @@ beforeEach(() => {
     mutateAsync: vi.fn(),
     isPending: false,
   } as any);
+  mockUseWebhooks.mockReturnValue({ data: [], isLoading: false, isError: false } as any);
+  mockUseCreateWebhook.mockReturnValue({ mutateAsync: vi.fn(), isPending: false } as any);
+  mockUseUpdateWebhook.mockReturnValue({ mutateAsync: vi.fn(), isPending: false } as any);
+  mockUseDeleteWebhook.mockReturnValue({ mutateAsync: vi.fn(), isPending: false } as any);
+  mockUseTestWebhook.mockReturnValue({ mutateAsync: vi.fn(), isPending: false } as any);
+  mockUseDeliveryLogs.mockReturnValue({ data: [], isLoading: false } as any);
 });
 
 describe("AdminPage", () => {
@@ -131,5 +160,16 @@ describe("AdminPage", () => {
     } as any);
     render(<AdminPage />);
     expect(screen.getByText(/no workers running/i)).toBeInTheDocument();
+  });
+
+  it("shows error state when webhooks fail to load", () => {
+    mockUseWebhooks.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("fetch failed"),
+    } as any);
+    render(<AdminPage />);
+    expect(screen.getByText(/failed to load webhooks/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/routes/admin.tsx
+++ b/frontend/src/routes/admin.tsx
@@ -11,6 +11,14 @@ import {
   AlertCircle,
   Save,
   AlertTriangle,
+  Link2,
+  Plus,
+  Trash2,
+  FlaskConical,
+  ChevronDown,
+  ChevronRight,
+  CheckCircle,
+  XCircle,
 } from "lucide-react";
 import {
   useAdminStatus,
@@ -23,6 +31,16 @@ import { cn, formatRelativeTime } from "../lib/utils";
 import { LogViewer } from "../components/log-viewer";
 import { Button } from "../components/button";
 import { useToast } from "../components/toast-provider";
+import {
+  useWebhooks,
+  useCreateWebhook,
+  useUpdateWebhook,
+  useDeleteWebhook,
+  useTestWebhook,
+  useDeliveryLogs,
+  type WebhookEndpoint,
+  type WebhookDeliveryLog,
+} from "../api/hooks/use-webhooks";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -562,6 +580,431 @@ function SettingsCard() {
   );
 }
 
+// ── Section 5 — Webhooks ──────────────────────────────────────────────────────
+
+const WEBHOOK_EVENTS = [
+  { value: "host.online", label: "Host Online" },
+  { value: "host.offline", label: "Host Offline" },
+  { value: "scan.started", label: "Scan Started" },
+  { value: "scan.completed", label: "Scan Completed" },
+  { value: "discovery.completed", label: "Discovery Completed" },
+] as const;
+
+function statusCodeClass(code: number | null): string {
+  if (code === null) return "text-text-muted";
+  if (code >= 200 && code < 300) return "text-success";
+  return "text-danger";
+}
+
+function DeliveryLogsPanel({ endpointId }: { endpointId: string }) {
+  const { data: logs = [], isLoading, isError } = useDeliveryLogs(endpointId);
+
+  if (isError) {
+    return (
+      <div className="px-4 py-3">
+        <p className="text-xs text-danger">Failed to load delivery logs.</p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="p-3 space-y-2">
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-4 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  if (logs.length === 0) {
+    return (
+      <div className="px-4 py-3 text-xs text-text-muted">
+        No delivery logs yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="border-b border-border/40">
+            {["Event", "Status", "Attempts", "Delivered", "Error"].map((h) => (
+              <th
+                key={h}
+                className="text-left px-4 py-2 text-[10px] uppercase tracking-wide text-text-muted font-medium whitespace-nowrap"
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {(logs as WebhookDeliveryLog[]).map((log) => (
+            <tr key={log.id} className="border-b border-border/20 last:border-0">
+              <td className="px-4 py-2 font-mono text-text-secondary whitespace-nowrap">
+                {log.event_type}
+              </td>
+              <td className={cn("px-4 py-2 font-mono whitespace-nowrap", statusCodeClass(log.status_code))}>
+                {log.status_code ?? "—"}
+              </td>
+              <td className="px-4 py-2 text-text-muted">{log.attempt_count}</td>
+              <td className="px-4 py-2 text-text-muted whitespace-nowrap">
+                {log.delivered_at ? formatRelativeTime(log.delivered_at) : "—"}
+              </td>
+              <td className="px-4 py-2 text-text-muted truncate max-w-xs">
+                {log.last_error ?? "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function WebhookRow({
+  endpoint,
+  expanded,
+  onToggleExpand,
+}: {
+  endpoint: WebhookEndpoint;
+  expanded: boolean;
+  onToggleExpand: () => void;
+}) {
+  const { toast } = useToast();
+  const { mutateAsync: updateWebhook, isPending: updatePending } = useUpdateWebhook();
+  const { mutateAsync: deleteWebhook, isPending: deletePending } = useDeleteWebhook();
+  const { mutateAsync: testWebhook, isPending: testPending } = useTestWebhook();
+
+  async function handleToggleEnabled() {
+    try {
+      await updateWebhook({ id: endpoint.id, body: { enabled: !endpoint.enabled } });
+    } catch {
+      toast.error("Failed to update webhook.");
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm(`Delete webhook for ${endpoint.url}?`)) return;
+    try {
+      await deleteWebhook(endpoint.id);
+      toast.success("Webhook deleted.");
+    } catch {
+      toast.error("Failed to delete webhook.");
+    }
+  }
+
+  async function handleTest() {
+    try {
+      await testWebhook(endpoint.id);
+      toast.success("Test delivery sent successfully.");
+    } catch {
+      toast.error("Test delivery failed. Check delivery logs for details.");
+    }
+  }
+
+  return (
+    <>
+      <tr
+        className="border-b border-border last:border-0 hover:bg-surface-raised/30 transition-colors"
+      >
+        <td className="px-4 py-3">
+          <button
+            type="button"
+            onClick={onToggleExpand}
+            className="flex items-center gap-1 text-text-primary hover:text-text-primary"
+          >
+            {expanded ? (
+              <ChevronDown className="h-3 w-3 text-text-muted shrink-0" />
+            ) : (
+              <ChevronRight className="h-3 w-3 text-text-muted shrink-0" />
+            )}
+            <span className="font-mono text-xs truncate max-w-xs">{endpoint.url}</span>
+          </button>
+        </td>
+        <td className="px-4 py-3">
+          <div className="flex flex-wrap gap-1">
+            {endpoint.events.map((e) => (
+              <span
+                key={e}
+                className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent/10 text-accent"
+              >
+                {e}
+              </span>
+            ))}
+          </div>
+        </td>
+        <td className="px-4 py-3">
+          {endpoint.enabled ? (
+            <span className="inline-flex items-center gap-1 text-success text-xs">
+              <CheckCircle className="h-3 w-3" />
+              Enabled
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1 text-text-muted text-xs">
+              <XCircle className="h-3 w-3" />
+              Disabled
+            </span>
+          )}
+        </td>
+        <td className="px-4 py-3 text-xs text-text-muted whitespace-nowrap">
+          {formatRelativeTime(endpoint.created_at)}
+        </td>
+        <td className="px-4 py-3">
+          <div className="flex items-center gap-1">
+            <Button
+              onClick={() => void handleToggleEnabled()}
+              loading={updatePending}
+              className="text-[10px] h-6 px-2"
+            >
+              {endpoint.enabled ? "Disable" : "Enable"}
+            </Button>
+            <Button
+              onClick={() => void handleTest()}
+              loading={testPending}
+              icon={<FlaskConical className="h-3 w-3" />}
+              className="text-[10px] h-6 px-2"
+            >
+              Test
+            </Button>
+            <Button
+              onClick={() => void handleDelete()}
+              loading={deletePending}
+              icon={<Trash2 className="h-3 w-3" />}
+              className="text-[10px] h-6 px-2 text-danger hover:bg-danger/10"
+            >
+              Delete
+            </Button>
+          </div>
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="bg-surface-raised/20 border-b border-border">
+          <td colSpan={5} className="px-0 py-0">
+            <div className="border-t border-border/40">
+              <div className="px-4 py-2 text-[10px] uppercase tracking-wide text-text-muted font-medium">
+                Delivery Logs (last 50)
+              </div>
+              <DeliveryLogsPanel endpointId={endpoint.id} />
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function AddWebhookForm({ onClose }: { onClose: () => void }) {
+  const { toast } = useToast();
+  const [url, setUrl] = useState("");
+  const [secret, setSecret] = useState("");
+  const [selectedEvents, setSelectedEvents] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const { mutateAsync: createWebhook, isPending } = useCreateWebhook();
+
+  function toggleEvent(value: string) {
+    setSelectedEvents((prev) =>
+      prev.includes(value) ? prev.filter((e) => e !== value) : [...prev, value],
+    );
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!url.trim()) {
+      setError("URL is required.");
+      return;
+    }
+    if (selectedEvents.length === 0) {
+      setError("Select at least one event type.");
+      return;
+    }
+    try {
+      await createWebhook({ url: url.trim(), secret: secret.trim() || undefined, events: selectedEvents });
+      toast.success("Webhook created.");
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create webhook.");
+    }
+  }
+
+  return (
+    <div className="border-t border-border bg-surface-raised/20 px-4 py-4">
+      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-3">
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-[10px] uppercase tracking-wide text-text-muted mb-1">
+              URL <span className="text-danger">*</span>
+            </label>
+            <input
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://example.com/webhook"
+              className={cn(
+                "w-full px-2 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+          </div>
+          <div>
+            <label className="block text-[10px] uppercase tracking-wide text-text-muted mb-1">
+              Secret (optional, auto-generated if empty)
+            </label>
+            <input
+              type="text"
+              value={secret}
+              onChange={(e) => setSecret(e.target.value)}
+              placeholder="Leave blank to auto-generate"
+              className={cn(
+                "w-full px-2 py-1.5 text-xs rounded border border-border",
+                "bg-surface text-text-primary placeholder:text-text-muted",
+                "focus:outline-none focus:ring-1 focus:ring-border",
+              )}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-[10px] uppercase tracking-wide text-text-muted mb-1.5">
+            Events <span className="text-danger">*</span>
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {WEBHOOK_EVENTS.map(({ value, label }) => (
+              <label key={value} className="flex items-center gap-1.5 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={selectedEvents.includes(value)}
+                  onChange={() => toggleEvent(value)}
+                  className="h-3 w-3 rounded border-border"
+                />
+                <span className="text-xs text-text-secondary">{label}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {error && (
+          <p className="text-xs text-danger flex items-center gap-1">
+            <AlertCircle className="h-3 w-3 shrink-0" />
+            {error}
+          </p>
+        )}
+
+        <div className="flex items-center gap-2">
+          <Button type="submit" loading={isPending} icon={<Plus className="h-3 w-3" />}>
+            Create Webhook
+          </Button>
+          <Button type="button" onClick={onClose} className="text-text-muted">
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function WebhooksCard() {
+  const { data: webhooks = [], isLoading, error } = useWebhooks();
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  function toggleExpand(id: string) {
+    setExpandedId((prev) => (prev === id ? null : id));
+  }
+
+  return (
+    <div className="bg-surface rounded-lg border border-border overflow-hidden">
+      <div className="px-4 py-3 border-b border-border flex items-center gap-2">
+        <Link2 className="h-4 w-4 text-text-muted" />
+        <span className="text-xs font-medium text-text-primary">Webhooks</span>
+        {!isLoading && (webhooks as WebhookEndpoint[]).length > 0 && (
+          <span className="ml-auto text-[10px] text-text-muted">
+            {(webhooks as WebhookEndpoint[]).length} endpoint
+            {(webhooks as WebhookEndpoint[]).length !== 1 ? "s" : ""}
+          </span>
+        )}
+        {!showAddForm && (
+          <Button
+            onClick={() => setShowAddForm(true)}
+            icon={<Plus className="h-3 w-3" />}
+            className={cn("text-[10px] h-6 px-2", !isLoading && (webhooks as WebhookEndpoint[]).length > 0 ? "" : "ml-auto")}
+          >
+            Add Webhook
+          </Button>
+        )}
+      </div>
+
+      {showAddForm && <AddWebhookForm onClose={() => setShowAddForm(false)} />}
+
+      {error ? (
+        <div className="flex items-center gap-2 text-danger text-xs px-4 py-3">
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+          <span>Failed to load webhooks.</span>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-border">
+                {["URL", "Events", "Status", "Created", "Actions"].map((col) => (
+                  <th
+                    key={col}
+                    className="text-left px-4 py-2 text-[10px] uppercase tracking-wide text-text-muted font-medium whitespace-nowrap"
+                  >
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading &&
+                [1, 2].map((i) => (
+                  <tr key={i} className="border-b border-border last:border-0">
+                    {[1, 2, 3, 4, 5].map((j) => (
+                      <td key={j} className="px-4 py-3">
+                        <Skeleton className="h-3 w-24" />
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+
+              {!isLoading &&
+                (webhooks as WebhookEndpoint[]).map((ep) => (
+                  <WebhookRow
+                    key={ep.id}
+                    endpoint={ep}
+                    expanded={expandedId === ep.id}
+                    onToggleExpand={() => toggleExpand(ep.id)}
+                  />
+                ))}
+
+              {!isLoading && (webhooks as WebhookEndpoint[]).length === 0 && !showAddForm && (
+                <tr>
+                  <td colSpan={5} className="px-4 py-8 text-center text-text-muted">
+                    No webhook endpoints configured. Click{" "}
+                    <button
+                      type="button"
+                      className="underline text-accent"
+                      onClick={() => setShowAddForm(true)}
+                    >
+                      Add Webhook
+                    </button>{" "}
+                    to get started.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ── Page ───────────────────────────────────────────────────────────────────────
 
 export function AdminPage() {
@@ -596,6 +1039,9 @@ export function AdminPage() {
           <LogViewer />
         </div>
       </div>
+
+      {/* Section 5 — Webhooks */}
+      <WebhooksCard />
     </div>
   );
 }

--- a/frontend/src/routes/discovery.test.tsx
+++ b/frontend/src/routes/discovery.test.tsx
@@ -11,8 +11,21 @@ vi.mock("../api/hooks/use-discovery", () => ({
   useDiscoveryCompare: vi.fn(),
 }));
 
+vi.mock("../api/hooks/use-devices", () => ({
+  useAcceptSuggestion: vi.fn(() => ({ mutateAsync: vi.fn().mockResolvedValue(undefined), isPending: false })),
+  useDismissSuggestion: vi.fn(() => ({ mutateAsync: vi.fn().mockResolvedValue(undefined), isPending: false })),
+}));
+
 vi.mock("@tanstack/react-router", () => ({
   useSearch: vi.fn().mockReturnValue({}),
+}));
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock("../components/toast-provider", () => ({
+  useToast: () => ({
+    toast: { success: mockToastSuccess, error: mockToastError },
+  }),
 }));
 
 vi.mock("../components/create-discovery-modal", () => ({
@@ -32,6 +45,14 @@ import {
   useDiscoveryDiff,
   useDiscoveryCompare,
 } from "../api/hooks/use-discovery";
+
+import {
+  useAcceptSuggestion,
+  useDismissSuggestion,
+} from "../api/hooks/use-devices";
+
+const mockUseAcceptSuggestion = vi.mocked(useAcceptSuggestion);
+const mockUseDismissSuggestion = vi.mocked(useDismissSuggestion);
 
 const mockUseDiscoveryJobs = vi.mocked(useDiscoveryJobs);
 const mockUseStartDiscovery = vi.mocked(useStartDiscovery);
@@ -121,6 +142,14 @@ beforeEach(() => {
     isLoading: false,
     error: null,
   } as unknown as ReturnType<typeof useDiscoveryCompare>);
+  mockUseAcceptSuggestion.mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+    isPending: false,
+  } as unknown as ReturnType<typeof useAcceptSuggestion>);
+  mockUseDismissSuggestion.mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+    isPending: false,
+  } as unknown as ReturnType<typeof useDismissSuggestion>);
 });
 
 describe("DiscoveryPage", () => {
@@ -642,5 +671,206 @@ describe("DiscoveryPage", () => {
     expect(
       screen.queryByTestId("create-discovery-modal"),
     ).not.toBeInTheDocument();
+  });
+
+  // ── Suggestion cards ──────────────────────────────────────────
+
+  async function openChangesTabWithDiff(suggestions = []) {
+    const diffData = {
+      job_id: "job-1",
+      new_hosts: [],
+      gone_hosts: [],
+      changed_hosts: [],
+      unchanged_count: 5,
+      suggestions,
+    };
+    mockUseDiscoveryDiff.mockReturnValue({
+      data: diffData,
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useDiscoveryDiff>);
+    render(<DiscoveryPage />);
+    const rows = screen.getAllByRole("row");
+    // job-1 is completed
+    await userEvent.click(rows[1]);
+    const dialog = screen.getByRole("dialog", {
+      name: /discovery job details/i,
+    });
+    const changesTab = within(dialog).getByRole("button", { name: /changes/i });
+    await userEvent.click(changesTab);
+    return dialog;
+  }
+
+  it("does not render suggestion cards when suggestions array is empty", async () => {
+    const dialog = await openChangesTabWithDiff([]);
+    expect(
+      within(dialog).queryByTestId("suggestions-section"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders suggestion cards for active (non-dismissed) suggestions", async () => {
+    const suggestions = [
+      {
+        id: "s1",
+        host_id: "h1",
+        device_id: "d1",
+        confidence_score: 85,
+        confidence_reason: "MAC address matches known device",
+        dismissed: false,
+        created_at: new Date().toISOString(),
+      },
+      {
+        id: "s2",
+        host_id: "h2",
+        device_id: "d2",
+        confidence_score: 45,
+        confidence_reason: "IP in known subnet",
+        dismissed: false,
+        created_at: new Date().toISOString(),
+      },
+    ];
+    const dialog = await openChangesTabWithDiff(suggestions);
+    expect(within(dialog).getByTestId("suggestions-section")).toBeInTheDocument();
+    const cards = within(dialog).getAllByTestId("suggestion-card");
+    expect(cards).toHaveLength(2);
+    expect(within(dialog).getByText("MAC address matches known device")).toBeInTheDocument();
+    expect(within(dialog).getByText("IP in known subnet")).toBeInTheDocument();
+  });
+
+  it("filters out dismissed suggestions", async () => {
+    const suggestions = [
+      {
+        id: "s1",
+        host_id: "h1",
+        device_id: "d1",
+        confidence_score: 80,
+        confidence_reason: "High confidence",
+        dismissed: false,
+        created_at: new Date().toISOString(),
+      },
+      {
+        id: "s2",
+        host_id: "h2",
+        device_id: "d2",
+        confidence_score: 60,
+        confidence_reason: "Should be hidden",
+        dismissed: true,
+        created_at: new Date().toISOString(),
+      },
+    ];
+    const dialog = await openChangesTabWithDiff(suggestions);
+    const cards = within(dialog).getAllByTestId("suggestion-card");
+    expect(cards).toHaveLength(1);
+    expect(within(dialog).queryByText("Should be hidden")).not.toBeInTheDocument();
+  });
+
+  it("shows confidence score badge on suggestion card", async () => {
+    const suggestions = [
+      {
+        id: "s1",
+        host_id: "h1",
+        device_id: "d1",
+        confidence_score: 75,
+        confidence_reason: "Good match",
+        dismissed: false,
+        created_at: new Date().toISOString(),
+      },
+    ];
+    const dialog = await openChangesTabWithDiff(suggestions);
+    expect(within(dialog).getByText("75%")).toBeInTheDocument();
+  });
+
+  it("calls acceptSuggestion when Accept button is clicked", async () => {
+    const acceptMutateAsync = vi.fn().mockResolvedValue(undefined);
+    mockUseAcceptSuggestion.mockReturnValue({
+      mutateAsync: acceptMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useAcceptSuggestion>);
+
+    const suggestions = [
+      {
+        id: "s1",
+        host_id: "h1",
+        device_id: "d1",
+        confidence_score: 80,
+        confidence_reason: "Good",
+        dismissed: false,
+        created_at: new Date().toISOString(),
+      },
+    ];
+    const dialog = await openChangesTabWithDiff(suggestions);
+    const card = within(dialog).getByTestId("suggestion-card");
+    await userEvent.click(within(card).getByRole("button", { name: /accept/i }));
+    expect(acceptMutateAsync).toHaveBeenCalledWith("s1");
+  });
+
+  it("calls dismissSuggestion when Dismiss button is clicked", async () => {
+    const dismissMutateAsync = vi.fn().mockResolvedValue(undefined);
+    mockUseDismissSuggestion.mockReturnValue({
+      mutateAsync: dismissMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDismissSuggestion>);
+
+    const suggestions = [
+      {
+        id: "s1",
+        host_id: "h1",
+        device_id: "d1",
+        confidence_score: 80,
+        confidence_reason: "Good",
+        dismissed: false,
+        created_at: new Date().toISOString(),
+      },
+    ];
+    const dialog = await openChangesTabWithDiff(suggestions);
+    const card = within(dialog).getByTestId("suggestion-card");
+    await userEvent.click(within(card).getByRole("button", { name: /dismiss/i }));
+    expect(dismissMutateAsync).toHaveBeenCalledWith("s1");
+  });
+
+  it("shows error toast when accept fails", async () => {
+    mockUseAcceptSuggestion.mockReturnValue({
+      mutateAsync: vi.fn().mockRejectedValue(new Error("Server error")),
+      isPending: false,
+    } as unknown as ReturnType<typeof useAcceptSuggestion>);
+
+    const suggestions = [
+      {
+        id: "s1",
+        host_id: "h1",
+        device_id: "d1",
+        confidence_score: 80,
+        confidence_reason: "Good",
+        dismissed: false,
+        created_at: new Date().toISOString(),
+      },
+    ];
+    const dialog = await openChangesTabWithDiff(suggestions);
+    const card = within(dialog).getByTestId("suggestion-card");
+    await userEvent.click(within(card).getByRole("button", { name: /accept/i }));
+    expect(mockToastError).toHaveBeenCalledWith("Failed to accept suggestion.");
+  });
+
+  it("shows error toast when dismiss fails", async () => {
+    mockUseDismissSuggestion.mockReturnValue({
+      mutateAsync: vi.fn().mockRejectedValue(new Error("Server error")),
+      isPending: false,
+    } as unknown as ReturnType<typeof useDismissSuggestion>);
+
+    const suggestions = [
+      {
+        id: "s1",
+        host_id: "h1",
+        device_id: "d1",
+        confidence_score: 80,
+        confidence_reason: "Good",
+        dismissed: false,
+        created_at: new Date().toISOString(),
+      },
+    ];
+    const dialog = await openChangesTabWithDiff(suggestions);
+    const card = within(dialog).getByTestId("suggestion-card");
+    await userEvent.click(within(card).getByRole("button", { name: /dismiss/i }));
+    expect(mockToastError).toHaveBeenCalledWith("Failed to dismiss suggestion.");
   });
 });

--- a/frontend/src/routes/discovery.tsx
+++ b/frontend/src/routes/discovery.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { X, Plus, ArrowRight, GitCompare } from "lucide-react";
 import { useSearch } from "@tanstack/react-router";
+import { useToast } from "../components/toast-provider";
 import { Button } from "../components/button";
 import {
   useDiscoveryJobs,
@@ -13,7 +14,12 @@ import type {
   DiscoveryDiff,
   DiscoveryDiffHost,
   DiscoveryCompareDiff,
+  DeviceSuggestion,
 } from "../api/hooks/use-discovery";
+import {
+  useAcceptSuggestion,
+  useDismissSuggestion,
+} from "../api/hooks/use-devices";
 import { StatusBadge, Skeleton, PaginationBar } from "../components";
 import { CreateDiscoveryModal } from "../components/create-discovery-modal";
 import { formatRelativeTime } from "../lib/utils";
@@ -136,6 +142,74 @@ function DiffSection({
   );
 }
 
+// ── Suggestion cards ──────────────────────────────────────────────────────────
+
+function confidenceBadgeClass(score: number): string {
+  if (score >= 70) return "bg-success/10 text-success border border-success/20";
+  if (score >= 40) return "bg-warning/10 text-warning border border-warning/20";
+  return "bg-danger/10 text-danger border border-danger/20";
+}
+
+function SuggestionCard({ suggestion }: { suggestion: DeviceSuggestion }) {
+  const { toast } = useToast();
+  const { mutateAsync: accept, isPending: isAccepting } = useAcceptSuggestion();
+  const { mutateAsync: dismiss, isPending: isDismissing } = useDismissSuggestion();
+
+  async function handleAccept() {
+    try {
+      await accept(suggestion.id);
+    } catch {
+      toast.error("Failed to accept suggestion.");
+    }
+  }
+
+  async function handleDismiss() {
+    try {
+      await dismiss(suggestion.id);
+    } catch {
+      toast.error("Failed to dismiss suggestion.");
+    }
+  }
+
+  return (
+    <div
+      className="bg-surface rounded border border-border p-3 text-xs space-y-2"
+      data-testid="suggestion-card"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span
+          className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${confidenceBadgeClass(suggestion.confidence_score)}`}
+        >
+          {suggestion.confidence_score}%
+        </span>
+        <div className="flex gap-1.5">
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => void handleAccept()}
+            loading={isAccepting}
+            disabled={isDismissing}
+          >
+            Accept
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => void handleDismiss()}
+            loading={isDismissing}
+            disabled={isAccepting}
+          >
+            Dismiss
+          </Button>
+        </div>
+      </div>
+      {suggestion.confidence_reason && (
+        <p className="text-text-muted">{suggestion.confidence_reason}</p>
+      )}
+    </div>
+  );
+}
+
 interface ChangesTabProps {
   diff?: DiscoveryDiff;
   isLoading: boolean;
@@ -200,6 +274,22 @@ function ChangesTab({ diff, isLoading, isError }: ChangesTabProps) {
           {diff.unchanged_count} hosts unchanged
         </p>
       </section>
+
+      {(() => {
+        const activeSuggestions = (diff.suggestions ?? []).filter((s) => !s.dismissed);
+        return activeSuggestions.length > 0 ? (
+          <section data-testid="suggestions-section">
+            <h4 className="text-xs font-medium text-warning mb-2">
+              Device Suggestions ({activeSuggestions.length})
+            </h4>
+            <div className="space-y-2">
+              {activeSuggestions.map((s) => (
+                <SuggestionCard key={s.id} suggestion={s} />
+              ))}
+            </div>
+          </section>
+        ) : null;
+      })()}
     </div>
   );
 }

--- a/frontend/src/routes/hosts.test.tsx
+++ b/frontend/src/routes/hosts.test.tsx
@@ -118,6 +118,12 @@ vi.mock("../hooks/use-table-key-nav", () => ({
   }),
 }));
 
+vi.mock("../api/hooks/use-alerts", () => ({
+  useHostAlertRules: vi.fn(() => ({ data: [], isLoading: false, isError: false })),
+  useCreateAlertRule: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  useDeleteAlertRule: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+}));
+
 vi.mock("../components", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../components")>();
   return {

--- a/frontend/src/routes/hosts.test.tsx
+++ b/frontend/src/routes/hosts.test.tsx
@@ -1021,19 +1021,25 @@ describe("HostsPage", () => {
 
     // ── Inline hostname editing ───────────────────────────────────
 
-    it("shows a pencil button to edit the hostname", async () => {
+    function getHostnameRow(panel: HTMLElement) {
+      // Find the "Hostname" label span, then scope to its parent div row
+      const label = within(panel).getByText("Hostname");
+      return label.closest("div") as HTMLElement;
+    }
+
+    it("shows an edit button for the hostname field", async () => {
       const panel = await openPanel();
       expect(
-        within(panel).getByRole("button", { name: /edit hostname/i }),
+        within(getHostnameRow(panel)).getByRole("button", { name: /^edit$/i }),
       ).toBeInTheDocument();
     });
 
-    it("opens the hostname input when the pencil is clicked", async () => {
+    it("opens the hostname input when the edit button is clicked", async () => {
       const panel = await openPanel();
       await userEvent.click(
-        within(panel).getByRole("button", { name: /edit hostname/i }),
+        within(getHostnameRow(panel)).getByRole("button", { name: /^edit$/i }),
       );
-      expect(within(panel).getByRole("textbox", { name: /edit hostname/i })).toBeInTheDocument();
+      expect(within(getHostnameRow(panel)).getByRole("textbox")).toBeInTheDocument();
     });
 
     it("calls updateHost with the new hostname when saved", async () => {
@@ -1041,15 +1047,14 @@ describe("HostsPage", () => {
       mockUseUpdateHost.mockReturnValue(makeMutationResult({ mutateAsync }));
 
       const panel = await openPanel();
+      const hostnameRow = getHostnameRow(panel);
       await userEvent.click(
-        within(panel).getByRole("button", { name: /edit hostname/i }),
+        within(hostnameRow).getByRole("button", { name: /^edit$/i }),
       );
-      const input = within(panel).getByRole("textbox", { name: /edit hostname/i });
+      const input = within(hostnameRow).getByRole("textbox");
       await userEvent.clear(input);
       await userEvent.type(input, "new-hostname");
-      await userEvent.click(
-        within(panel).getByRole("button", { name: /save hostname/i }),
-      );
+      await userEvent.keyboard("{Enter}");
 
       expect(mutateAsync).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1063,15 +1068,16 @@ describe("HostsPage", () => {
       mockUseUpdateHost.mockReturnValue(makeMutationResult({ mutateAsync }));
 
       const panel = await openPanel();
+      const hostnameRow = getHostnameRow(panel);
       await userEvent.click(
-        within(panel).getByRole("button", { name: /edit hostname/i }),
+        within(hostnameRow).getByRole("button", { name: /^edit$/i }),
       );
       await userEvent.click(
-        within(panel).getByRole("button", { name: /cancel/i }),
+        within(panel).getByRole("button", { name: /^cancel$/i }),
       );
 
       expect(mutateAsync).not.toHaveBeenCalled();
-      expect(within(panel).queryByRole("textbox", { name: /edit hostname/i })).not.toBeInTheDocument();
+      expect(within(hostnameRow).queryByRole("textbox")).not.toBeInTheDocument();
     });
 
     // ── Delete flow ───────────────────────────────────────────────
@@ -1307,6 +1313,122 @@ describe("HostsPage", () => {
 
       expect(mockToastError).toHaveBeenCalledWith("Network error");
     });
+
+    // ── Notes section ─────────────────────────────────────────────
+
+    it("shows the Notes section in the detail panel", async () => {
+      const panel = await openPanel();
+      expect(within(panel).getByTestId("notes-section")).toBeInTheDocument();
+    });
+
+    it("shows 'No notes.' placeholder when description is absent", async () => {
+      const panel = await openPanel();
+      expect(within(panel).getByText("No notes.")).toBeInTheDocument();
+    });
+
+    it("shows description text when host has a description", async () => {
+      mockUseHost.mockReturnValue(
+        makeUseHostResult({
+          data: {
+            ...mockFullHost,
+            description: "This is a test server.",
+          } as typeof mockFullHost,
+        }),
+      );
+      const panel = await openPanel();
+      expect(within(panel).getByText("This is a test server.")).toBeInTheDocument();
+    });
+
+    it("enters edit mode for notes when the edit button is clicked", async () => {
+      mockUseHost.mockReturnValue(
+        makeUseHostResult({
+          data: {
+            ...mockFullHost,
+            description: "Initial notes.",
+          } as typeof mockFullHost,
+        }),
+      );
+      const panel = await openPanel();
+      const notesSection = within(panel).getByTestId("notes-section");
+      const editBtns = within(notesSection).getAllByRole("button", { name: /edit/i });
+      await userEvent.click(editBtns[0]);
+      expect(within(notesSection).getByRole("textbox")).toBeInTheDocument();
+    });
+
+    it("saves notes via updateHost when Ctrl+Enter is pressed", async () => {
+      const mutateAsync = vi.fn().mockResolvedValue({});
+      mockUseUpdateHost.mockReturnValue(makeMutationResult({ mutateAsync }));
+      mockUseHost.mockReturnValue(
+        makeUseHostResult({
+          data: {
+            ...mockFullHost,
+            description: "Old notes.",
+          } as typeof mockFullHost,
+        }),
+      );
+
+      const panel = await openPanel();
+      const notesSection = within(panel).getByTestId("notes-section");
+      const editBtns = within(notesSection).getAllByRole("button", { name: /edit/i });
+      await userEvent.click(editBtns[0]);
+      const textarea = within(notesSection).getByRole("textbox");
+      await userEvent.clear(textarea);
+      await userEvent.type(textarea, "New notes.");
+      await userEvent.keyboard("{Control>}{Enter}{/Control}");
+
+      expect(mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({ description: "New notes." }),
+        }),
+      );
+    });
+  });
+
+  // ── Hostname cell inline editing (table row) ─────────────────
+
+  it("shows hostname value in the hostname cell", () => {
+    render(<HostsPage />);
+    expect(screen.getByText("router.local")).toBeInTheDocument();
+  });
+
+  it("entering edit mode on hostname cell does not open the detail panel", async () => {
+    render(<HostsPage />);
+    const rows = screen.getAllByRole("row");
+    // The hostname cell is index 2 in the data row
+    const cells = within(rows[1]).getAllByRole("cell");
+    const hostnameCell = cells[2];
+    // Click the edit button inside the hostname cell
+    const editBtns = within(hostnameCell).getAllByRole("button", { name: /edit/i });
+    await userEvent.click(editBtns[0]);
+    // The input should be visible inside the cell
+    expect(within(hostnameCell).getByRole("textbox")).toBeInTheDocument();
+    // The detail panel should NOT have opened
+    expect(
+      screen.queryByRole("dialog", { name: /host details/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls updateHostInline when hostname is edited and Enter is pressed", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({});
+    mockUseUpdateHost.mockReturnValue(makeMutationResult({ mutateAsync }));
+
+    render(<HostsPage />);
+    const rows = screen.getAllByRole("row");
+    const cells = within(rows[1]).getAllByRole("cell");
+    const hostnameCell = cells[2];
+    const editBtns = within(hostnameCell).getAllByRole("button", { name: /edit/i });
+    await userEvent.click(editBtns[0]);
+    const input = within(hostnameCell).getByRole("textbox");
+    await userEvent.clear(input);
+    await userEvent.type(input, "new-hostname");
+    await userEvent.keyboard("{Enter}");
+
+    expect(mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostId: "host-1",
+        body: expect.objectContaining({ hostname: "new-hostname" }),
+      }),
+    );
   });
 
   // ── Scan selected (bulk scan) ─────────────────────────────────

--- a/frontend/src/routes/hosts.test.tsx
+++ b/frontend/src/routes/hosts.test.tsx
@@ -31,6 +31,10 @@ vi.mock("../api/hooks/use-host-networks", () => ({
   })),
 }));
 
+vi.mock("../api/hooks/use-devices", () => ({
+  useDetachHost: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+}));
+
 vi.mock("../api/hooks/use-tags", () => ({
   useTags: vi.fn(() => ({ data: [] })),
   useUpdateHostTags: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
@@ -78,6 +82,9 @@ import {
   useDeleteHost,
   useBulkDeleteHosts,
 } from "../api/hooks/use-hosts";
+
+import { useDetachHost } from "../api/hooks/use-devices";
+const mockUseDetachHost = vi.mocked(useDetachHost);
 
 import {
   useSmartScanStage,
@@ -142,6 +149,26 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
     ...actual,
     useSearch: vi.fn().mockReturnValue({}),
     useNavigate: vi.fn().mockReturnValue(vi.fn()),
+    Link: ({
+      to,
+      params,
+      children,
+      className,
+    }: {
+      to: string;
+      params?: Record<string, string>;
+      children: unknown;
+      className?: string;
+    }) => {
+      const resolved = params
+        ? to.replace(/\$(\w+)/g, (_, k) => params[k] ?? "")
+        : to;
+      return (
+        <a href={`#${resolved}`} className={className}>
+          {children}
+        </a>
+      );
+    },
   };
 });
 
@@ -389,6 +416,10 @@ beforeEach(async () => {
   mockUseUpdateHost.mockReturnValue(makeMutationResult());
   mockUseDeleteHost.mockReturnValue(makeDeleteMutationResult());
   mockUseBulkDeleteHosts.mockReturnValue(makeBulkDeleteMutationResult());
+  mockUseDetachHost.mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+    isPending: false,
+  } as unknown as ReturnType<typeof useDetachHost>);
 
   const { useHostNetworks } = await import("../api/hooks/use-host-networks");
   vi.mocked(useHostNetworks).mockReturnValue({
@@ -1175,6 +1206,106 @@ describe("HostsPage", () => {
         screen.getByRole("button", { name: /run smart scan/i }),
       );
       expect(mockTrigger).toHaveBeenCalledWith("host-1");
+    });
+
+    // ── Device card ────────────────────────────────────────────────
+
+    it("shows 'No device assigned.' when host has no device_id", async () => {
+      // mockFullHost has no device_id by default
+      const panel = await openPanel();
+      expect(within(panel).getByText("No device assigned.")).toBeInTheDocument();
+    });
+
+    it("shows device name as a link when host has device_id", async () => {
+      mockUseHost.mockReturnValue(
+        makeUseHostResult({
+          data: {
+            ...mockFullHost,
+            device_id: "device-uuid-1",
+            device_name: "Office Router",
+          } as typeof mockFullHost,
+        }),
+      );
+
+      const panel = await openPanel();
+      const deviceSection = within(panel).getByTestId("device-section");
+      const link = within(deviceSection).getByRole("link", { name: "Office Router" });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "#/devices/device-uuid-1");
+    });
+
+    it("shows a Detach button when host has device_id", async () => {
+      mockUseHost.mockReturnValue(
+        makeUseHostResult({
+          data: {
+            ...mockFullHost,
+            device_id: "device-uuid-1",
+            device_name: "Office Router",
+          } as typeof mockFullHost,
+        }),
+      );
+
+      const panel = await openPanel();
+      const deviceSection = within(panel).getByTestId("device-section");
+      expect(
+        within(deviceSection).getByRole("button", { name: /detach/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("calls detachHost and shows success toast when Detach is clicked", async () => {
+      const detachMutateAsync = vi.fn().mockResolvedValue(undefined);
+      mockUseDetachHost.mockReturnValue({
+        mutateAsync: detachMutateAsync,
+        isPending: false,
+      } as unknown as ReturnType<typeof useDetachHost>);
+      mockUseHost.mockReturnValue(
+        makeUseHostResult({
+          data: {
+            ...mockFullHost,
+            device_id: "device-uuid-1",
+            device_name: "Office Router",
+          } as typeof mockFullHost,
+        }),
+      );
+
+      const panel = await openPanel();
+      const deviceSection = within(panel).getByTestId("device-section");
+      await userEvent.click(
+        within(deviceSection).getByRole("button", { name: /detach/i }),
+      );
+
+      expect(detachMutateAsync).toHaveBeenCalledWith({
+        deviceId: "device-uuid-1",
+        hostId: "host-1",
+      });
+      expect(mockToastSuccess).toHaveBeenCalledWith("Host detached from device.");
+    });
+
+    it("shows error toast when detach fails", async () => {
+      const detachMutateAsync = vi
+        .fn()
+        .mockRejectedValue(new Error("Network error"));
+      mockUseDetachHost.mockReturnValue({
+        mutateAsync: detachMutateAsync,
+        isPending: false,
+      } as unknown as ReturnType<typeof useDetachHost>);
+      mockUseHost.mockReturnValue(
+        makeUseHostResult({
+          data: {
+            ...mockFullHost,
+            device_id: "device-uuid-1",
+            device_name: "Office Router",
+          } as typeof mockFullHost,
+        }),
+      );
+
+      const panel = await openPanel();
+      const deviceSection = within(panel).getByTestId("device-section");
+      await userEvent.click(
+        within(deviceSection).getByRole("button", { name: /detach/i }),
+      );
+
+      expect(mockToastError).toHaveBeenCalledWith("Network error");
     });
   });
 

--- a/frontend/src/routes/hosts.tsx
+++ b/frontend/src/routes/hosts.tsx
@@ -44,6 +44,7 @@ import { cn } from "../lib/utils";
 import type { components } from "../api/types";
 import { ColumnToggle } from "../components/column-toggle";
 import type { ColumnDef } from "../components/column-toggle";
+import { ExportButton } from "../components/export-button";
 import { useTableKeyNav } from "../hooks/use-table-key-nav";
 import { FilterBuilder } from "../components/filter-builder";
 import { TagInput } from "../components/tag-input";
@@ -2087,6 +2088,20 @@ export function HostsPage() {
             >
               New scan
             </Button>
+            <ExportButton
+              basePath="/api/v1/hosts/export"
+              params={{
+                sort_by: sortBy,
+                sort_order: sortOrder,
+                ...(statusFilter !== "all" ? { status: statusFilter } : {}),
+                ...(debouncedSearch ? { search: debouncedSearch } : {}),
+                ...(osFilter ? { os: osFilter } : {}),
+                ...(vendorFilter ? { vendor: vendorFilter } : {}),
+                ...(activeFilter
+                  ? { filter: JSON.stringify(activeFilter) }
+                  : {}),
+              }}
+            />
             <ColumnToggle
               columns={HOST_COLUMNS}
               visibility={colVis}

--- a/frontend/src/routes/hosts.tsx
+++ b/frontend/src/routes/hosts.tsx
@@ -7,8 +7,6 @@ import {
   ScanLine,
   X,
   Monitor,
-  Pencil,
-  Check,
   Trash2,
   Activity,
   Play,
@@ -59,6 +57,7 @@ import {
   type TriggerHostResponse,
 } from "../api/hooks/use-smart-scan";
 import { HostSmartScanPreviewModal } from "../components/smart-scan-preview-modal";
+import { InlineEditText } from "../components/inline-edit-text";
 
 type HostResponse = components["schemas"]["docs.HostResponse"];
 
@@ -292,11 +291,6 @@ function HostDetailPanel({
     });
   }
 
-  // Hostname editing
-  const [isEditingHostname, setIsEditingHostname] = useState(false);
-  const [hostnameInput, setHostnameInput] = useState("");
-  const [hostnameError, setHostnameError] = useState<string | null>(null);
-
   // Tags
   const [localTags, setLocalTags] = useState<string[] | null>(null);
   const { mutateAsync: updateTags } = useUpdateHostTags();
@@ -371,24 +365,6 @@ function HostDetailPanel({
     } catch (err) {
       toast.error(
         err instanceof Error ? err.message : "Failed to queue Smart Scan.",
-      );
-    }
-  }
-
-  async function handleSaveHostname() {
-    setHostnameError(null);
-    const trimmed = hostnameInput.trim();
-    try {
-      await updateHost({
-        hostId: h.id ?? "",
-        body: { hostname: trimmed || undefined },
-      });
-      setIsEditingHostname(false);
-      toast.success("Hostname updated");
-    } catch (err) {
-      setHostnameError(err instanceof Error ? err.message : "Update failed.");
-      toast.error(
-        err instanceof Error ? err.message : "Failed to update hostname.",
       );
     }
   }
@@ -588,67 +564,18 @@ function HostDetailPanel({
                   value={<span className="font-mono">{h.ip_address}</span>}
                 />
 
-                {/* Inline hostname editing */}
                 <div className="flex gap-2 text-xs">
-                  <span className="text-text-muted w-28 shrink-0">
-                    Hostname
-                  </span>
-                  {isEditingHostname ? (
-                    <div className="flex items-center gap-1.5 flex-1 min-w-0">
-                      <input
-                        type="text"
-                        value={hostnameInput}
-                        onChange={(e) => setHostnameInput(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") void handleSaveHostname();
-                          if (e.key === "Escape") setIsEditingHostname(false);
-                        }}
-                        autoFocus
-                        aria-label="Edit hostname"
-                        className="flex-1 px-2 py-0.5 text-xs rounded border border-border bg-surface text-text-primary focus:outline-none focus:ring-1 focus:ring-border min-w-0"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => void handleSaveHostname()}
-                        disabled={isUpdatingHost}
-                        aria-label="Save hostname"
-                        className="p-0.5 rounded text-success hover:bg-surface-raised"
-                      >
-                        <Check className="h-3 w-3" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setIsEditingHostname(false)}
-                        aria-label="Cancel"
-                        className="p-0.5 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised"
-                      >
-                        <X className="h-3 w-3" />
-                      </button>
-                    </div>
-                  ) : (
-                    <div className="flex items-center gap-1.5 min-w-0">
-                      <span className="text-text-secondary break-all">
-                        {h.hostname ?? "—"}
-                      </span>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setIsEditingHostname(true);
-                          setHostnameInput(h.hostname ?? "");
-                        }}
-                        aria-label="Edit hostname"
-                        className="p-0.5 rounded text-text-muted hover:text-text-primary hover:bg-surface-raised shrink-0"
-                      >
-                        <Pencil className="h-2.5 w-2.5" />
-                      </button>
-                    </div>
-                  )}
+                  <span className="text-text-muted w-28 shrink-0">Hostname</span>
+                  <InlineEditText
+                    value={h.hostname ?? ""}
+                    placeholder="—"
+                    onSave={async (value) => {
+                      await updateHost({ hostId: h.id ?? "", body: { hostname: value || null } });
+                      toast.success("Hostname updated.");
+                    }}
+                    disabled={isUpdatingHost}
+                  />
                 </div>
-                {hostnameError && (
-                  <p className="text-[11px] text-danger ml-30">
-                    {hostnameError}
-                  </p>
-                )}
 
                 <MetaRow
                   label="MAC Address"
@@ -699,6 +626,29 @@ function HostDetailPanel({
                   </div>
                 )}
               </div>
+            )}
+          </section>
+
+          {/* Notes */}
+          <section data-testid="notes-section">
+            <h3 className="text-xs font-medium text-text-primary mb-3">
+              Notes
+            </h3>
+            {isLoading ? (
+              <Skeleton className="h-10 w-full rounded" />
+            ) : (
+              <InlineEditText
+                value={h.description ?? ""}
+                placeholder="No notes."
+                multiline
+                onSave={async (val) => {
+                  await updateHost({
+                    hostId: h.id ?? "",
+                    body: { description: val || undefined },
+                  });
+                  toast.success("Notes updated.");
+                }}
+              />
             )}
           </section>
 
@@ -1638,6 +1588,7 @@ export function HostsPage() {
     useAddHostsToGroup();
   const { data: allTags = [] } = useTags();
   const { data: allGroups = [] } = useGroups();
+  const { mutateAsync: updateHostInline } = useUpdateHost();
   const { toast } = useToast();
   const navigate = useNavigate();
   const search = useSearch({ from: "/hosts" });
@@ -2196,10 +2147,23 @@ export function HostsPage() {
                           {host.ip_address ?? "—"}
                         </td>
                         {colVis.hostname && (
-                          <td className="py-3 pr-4 text-text-secondary">
-                            {(host as HostWithDetails).display_name ??
-                              host.hostname ??
-                              "—"}
+                          <td
+                            className="py-3 pr-4"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <InlineEditText
+                              value={host.hostname ?? ""}
+                              placeholder={
+                                (host as HostWithDetails).display_name ?? "—"
+                              }
+                              onSave={async (val) => {
+                                await updateHostInline({
+                                  hostId: host.id ?? "",
+                                  body: { hostname: val || undefined },
+                                });
+                                toast.success("Hostname updated.");
+                              }}
+                            />
                           </td>
                         )}
                         <td className="py-3 pr-4">

--- a/frontend/src/routes/hosts.tsx
+++ b/frontend/src/routes/hosts.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { Link } from "@tanstack/react-router";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { isNotFound } from "../api/errors";
 import {
@@ -33,6 +34,7 @@ import {
 } from "../api/hooks/use-hosts";
 import { useHostNetworks } from "../api/hooks/use-host-networks";
 import { useToast } from "../components/toast-provider";
+import { useDetachHost } from "../api/hooks/use-devices";
 import {
   StatusBadge,
   Skeleton,
@@ -120,6 +122,8 @@ type HostWithDetails = HostResponse & {
   banners?: PortBanner[];
   certificates?: TLSCertificate[];
   snmp_data?: SNMPData | null;
+  device_id?: string;
+  device_name?: string;
 };
 
 interface SNMPInterface {
@@ -144,6 +148,56 @@ interface SNMPData {
 }
 
 const PAGE_SIZE = 25;
+
+// ──────────────────────────────────────────────
+// Device card section
+// ──────────────────────────────────────────────
+
+function DeviceSection({ h }: { h: HostWithDetails }) {
+  const { toast } = useToast();
+  const { mutateAsync: detachHost, isPending: isDetaching } = useDetachHost();
+
+  if (!h.device_id) {
+    return (
+      <section data-testid="device-section">
+        <h3 className="text-xs font-medium text-text-primary mb-3">Device</h3>
+        <p className="text-xs text-text-muted">No device assigned.</p>
+      </section>
+    );
+  }
+
+  async function handleDetach() {
+    try {
+      await detachHost({ deviceId: h.device_id!, hostId: h.id ?? "" });
+      toast.success("Host detached from device.");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to detach host.");
+    }
+  }
+
+  return (
+    <section data-testid="device-section">
+      <h3 className="text-xs font-medium text-text-primary mb-3">Device</h3>
+      <div className="bg-surface rounded border border-border p-3 text-xs flex items-center justify-between gap-2">
+        <Link
+          to="/devices/$id"
+          params={{ id: h.device_id! }}
+          className="font-medium text-accent hover:underline truncate"
+        >
+          {h.device_name ?? h.device_id}
+        </Link>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => void handleDetach()}
+          loading={isDetaching}
+        >
+          Detach
+        </Button>
+      </div>
+    </section>
+  );
+}
 
 // ──────────────────────────────────────────────
 // Host detail panel
@@ -1293,6 +1347,9 @@ function HostDetailPanel({
                 </div>
               )}
           </section>
+
+          {/* Device */}
+          <DeviceSection h={h} />
 
           </> /* end overview tab */}
 

--- a/frontend/src/routes/hosts.tsx
+++ b/frontend/src/routes/hosts.tsx
@@ -491,6 +491,8 @@ function HostDetailPanel({
   // Scan history pagination
   const [scanHistoryPage, setScanHistoryPage] = useState(1);
   const SCAN_HISTORY_PAGE_SIZE = 5;
+  // Scan comparison — holds at most 2 selected scan IDs
+  const [selectedScanIds, setSelectedScanIds] = useState<string[]>([]);
 
   const { toast } = useToast();
   const { mutateAsync: updateHost, isPending: isUpdatingHost } =
@@ -1388,9 +1390,25 @@ function HostDetailPanel({
 
           {/* Scan History */}
           <section>
-            <h3 className="text-xs font-medium text-text-primary mb-3">
-              Scan History
-            </h3>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-xs font-medium text-text-primary">
+                Scan History
+              </h3>
+              {selectedScanIds.length === 2 && (
+                <Link
+                  to="/scans/diff"
+                  search={{ a: selectedScanIds[0], b: selectedScanIds[1] }}
+                  className="inline-flex items-center gap-1 text-[11px] font-medium text-accent hover:underline"
+                >
+                  Compare →
+                </Link>
+              )}
+            </div>
+            {selectedScanIds.length === 1 && (
+              <p className="text-[11px] text-text-muted mb-2">
+                Select one more scan to compare
+              </p>
+            )}
             {hostScansLoading ? (
               <div className="space-y-2">
                 {Array.from({ length: 3 }).map((_, i) => (
@@ -1406,25 +1424,45 @@ function HostDetailPanel({
               </p>
             ) : (
               <div className="space-y-1">
-                {(hostScansData?.data ?? []).map((scan) => (
-                  <div
-                    key={scan.id}
-                    className="flex items-center justify-between gap-2 py-1 border-b border-border/40 last:border-0"
-                  >
-                    <div className="flex items-center gap-2 min-w-0">
-                      <StatusBadge status={scan.status ?? "unknown"} />
-                      <span className="text-xs font-mono text-text-muted truncate">
-                        {(scan.targets as string[] | undefined)?.join(", ") ??
-                          "—"}
+                {(hostScansData?.data ?? []).map((scan) => {
+                  const scanId = scan.id ?? "";
+                  const isSelected = selectedScanIds.includes(scanId);
+                  const isDisabled =
+                    !isSelected && selectedScanIds.length >= 2;
+                  return (
+                    <div
+                      key={scan.id}
+                      className="flex items-center justify-between gap-2 py-1 border-b border-border/40 last:border-0"
+                    >
+                      <div className="flex items-center gap-2 min-w-0">
+                        <input
+                          type="checkbox"
+                          aria-label={`Select scan ${scanId}`}
+                          checked={isSelected}
+                          disabled={isDisabled}
+                          onChange={() => {
+                            setSelectedScanIds((prev) =>
+                              prev.includes(scanId)
+                                ? prev.filter((id) => id !== scanId)
+                                : [...prev, scanId],
+                            );
+                          }}
+                          className="shrink-0 accent-accent disabled:opacity-30"
+                        />
+                        <StatusBadge status={scan.status ?? "unknown"} />
+                        <span className="text-xs font-mono text-text-muted truncate">
+                          {(scan.targets as string[] | undefined)?.join(", ") ??
+                            "—"}
+                        </span>
+                      </div>
+                      <span className="text-xs text-text-muted whitespace-nowrap shrink-0">
+                        {scan.started_at
+                          ? formatRelativeTime(scan.started_at)
+                          : "—"}
                       </span>
                     </div>
-                    <span className="text-xs text-text-muted whitespace-nowrap shrink-0">
-                      {scan.started_at
-                        ? formatRelativeTime(scan.started_at)
-                        : "—"}
-                    </span>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             )}
 

--- a/frontend/src/routes/hosts.tsx
+++ b/frontend/src/routes/hosts.tsx
@@ -58,6 +58,13 @@ import {
 } from "../api/hooks/use-smart-scan";
 import { HostSmartScanPreviewModal } from "../components/smart-scan-preview-modal";
 import { InlineEditText } from "../components/inline-edit-text";
+import {
+  useHostAlertRules,
+  useCreateAlertRule,
+  useDeleteAlertRule,
+  type AlertRule,
+  type CreateAlertRuleBody,
+} from "../api/hooks/use-alerts";
 
 type HostResponse = components["schemas"]["docs.HostResponse"];
 
@@ -199,6 +206,161 @@ function DeviceSection({ h }: { h: HostWithDetails }) {
 }
 
 // ──────────────────────────────────────────────
+// Alerts section
+// ──────────────────────────────────────────────
+
+const TRIGGER_LABELS: Record<string, string> = {
+  online: "Online",
+  offline: "Offline",
+  both: "Both",
+};
+
+function AlertsSection({ hostID }: { hostID: string }) {
+  const { toast } = useToast();
+  const { data: rules = [], isLoading, isError } = useHostAlertRules(hostID);
+  const { mutateAsync: createRule, isPending: isCreating } = useCreateAlertRule();
+  const { mutateAsync: deleteRule, isPending: isDeleting } = useDeleteAlertRule();
+
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState<{ trigger: "online" | "offline" | "both"; channel_url: string }>({
+    trigger: "online",
+    channel_url: "",
+  });
+
+  async function handleCreate() {
+    if (!form.channel_url.startsWith("http://") && !form.channel_url.startsWith("https://")) {
+      toast.error("Channel URL must start with http:// or https://");
+      return;
+    }
+    try {
+      const body: CreateAlertRuleBody = {
+        host_id: hostID,
+        trigger: form.trigger,
+        channel_url: form.channel_url,
+      };
+      await createRule(body);
+      toast.success("Alert rule created.");
+      setShowForm(false);
+      setForm({ trigger: "online", channel_url: "" });
+    } catch {
+      toast.error("Failed to create alert rule.");
+    }
+  }
+
+  async function handleDelete(rule: AlertRule) {
+    try {
+      await deleteRule({ id: rule.id, hostID });
+      toast.success("Alert rule deleted.");
+    } catch {
+      toast.error("Failed to delete alert rule.");
+    }
+  }
+
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-xs font-medium text-text-primary">Alert Rules</h3>
+        <button
+          type="button"
+          onClick={() => setShowForm((v) => !v)}
+          className="text-xs text-accent hover:underline"
+        >
+          {showForm ? "Cancel" : "+ Add Rule"}
+        </button>
+      </div>
+
+      {showForm && (
+        <div className="mb-4 p-3 rounded border border-border bg-surface space-y-2">
+          <div className="flex gap-2">
+            <div className="flex-1">
+              <label className="text-[10px] text-text-muted block mb-1">Trigger</label>
+              <select
+                value={form.trigger}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    trigger: e.target.value as "online" | "offline" | "both",
+                  }))
+                }
+                className="w-full text-xs rounded border border-border bg-surface px-2 py-1 text-text-primary"
+              >
+                <option value="online">Online</option>
+                <option value="offline">Offline</option>
+                <option value="both">Both</option>
+              </select>
+            </div>
+          </div>
+          <div>
+            <label className="text-[10px] text-text-muted block mb-1">Webhook URL</label>
+            <input
+              type="url"
+              placeholder="https://hooks.example.com/..."
+              value={form.channel_url}
+              onChange={(e) => setForm((f) => ({ ...f, channel_url: e.target.value }))}
+              className="w-full text-xs rounded border border-border bg-surface px-2 py-1 text-text-primary font-mono"
+            />
+          </div>
+          <div className="flex justify-end">
+            <Button size="sm" onClick={() => void handleCreate()} loading={isCreating}>
+              Save Rule
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <Skeleton key={i} className="h-8 w-full" />
+          ))}
+        </div>
+      ) : isError ? (
+        <p className="text-xs text-danger">Failed to load alert rules.</p>
+      ) : rules.length === 0 ? (
+        <p className="text-xs text-text-muted">No alert rules for this host.</p>
+      ) : (
+        <div className="space-y-1">
+          {rules.map((rule) => (
+            <div
+              key={rule.id}
+              className="flex items-center gap-2 py-2 border-b border-border/40 last:border-0"
+            >
+              <span
+                className={cn(
+                  "shrink-0 inline-block px-1.5 py-0.5 rounded text-[10px] font-medium",
+                  rule.trigger === "online"
+                    ? "bg-green-500/10 text-green-400"
+                    : rule.trigger === "offline"
+                      ? "bg-red-500/10 text-red-400"
+                      : "bg-warning/10 text-warning",
+                )}
+              >
+                {TRIGGER_LABELS[rule.trigger] ?? rule.trigger}
+              </span>
+              <span className="flex-1 text-xs font-mono text-text-muted truncate">
+                {rule.channel_url}
+              </span>
+              {!rule.enabled && (
+                <span className="text-[10px] text-text-muted shrink-0">(disabled)</span>
+              )}
+              <button
+                type="button"
+                aria-label="Delete alert rule"
+                onClick={() => void handleDelete(rule)}
+                disabled={isDeleting}
+                className="shrink-0 p-0.5 text-text-muted hover:text-danger transition-colors"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ──────────────────────────────────────────────
 // Host detail panel
 // ──────────────────────────────────────────────
 
@@ -253,7 +415,7 @@ function HostDetailPanel({
   // Active detail tab. "interfaces" is only shown when SNMP interface data is
   // present; "identity" is always available.
   const [detailTab, setDetailTab] = useState<
-    "overview" | "identity" | "interfaces"
+    "overview" | "identity" | "interfaces" | "alerts"
   >("overview");
   // Controls the inline chevron panel on the Overview tab's Identity row.
   const [identityExpanded, setIdentityExpanded] = useState(false);
@@ -434,6 +596,7 @@ function HostDetailPanel({
               ...(h.snmp_data?.interfaces && h.snmp_data.interfaces.length > 0
                 ? (["interfaces"] as const)
                 : []),
+              "alerts",
             ] as const
           ).map((tab) => (
             <button
@@ -1394,6 +1557,11 @@ function HostDetailPanel({
                 </table>
               </div>
             </section>
+          )}
+
+          {/* Alerts tab */}
+          {detailTab === "alerts" && (
+            <AlertsSection hostID={h.id ?? ""} />
           )}
         </div>
 

--- a/frontend/src/routes/scan-diff.test.tsx
+++ b/frontend/src/routes/scan-diff.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithRouter } from "../test/utils";
+import { ScanDiffPage } from "./scan-diff";
+import type { ScanDiff } from "../api/hooks/use-scan-diff";
+
+vi.mock("../api/hooks/use-scan-diff", () => ({
+  useScanDiff: vi.fn(),
+}));
+
+// TanStack Router's useSearch returns an empty object by default in test.
+// The page reads optional `a` and `b` params, so missing params renders the
+// missing-params notice without crashing.
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@tanstack/react-router")>();
+  return {
+    ...original,
+    useSearch: vi.fn(() => ({})),
+    Link: ({ children, ...rest }: { children: React.ReactNode; [key: string]: unknown }) => (
+      <a {...rest}>{children}</a>
+    ),
+  };
+});
+
+import { useScanDiff } from "../api/hooks/use-scan-diff";
+import { useSearch } from "@tanstack/react-router";
+
+const mockUseScanDiff = vi.mocked(useScanDiff);
+const mockUseSearch = vi.mocked(useSearch);
+
+const idA = "aaaaaaaa-0000-0000-0000-000000000001";
+const idB = "bbbbbbbb-0000-0000-0000-000000000002";
+
+const mockDiff: ScanDiff = {
+  scan_a_id: idA,
+  scan_b_id: idB,
+  host_id: "cccccccc-0000-0000-0000-000000000003",
+  ports: [
+    {
+      port: 443,
+      protocol: "tcp",
+      state: "open",
+      service_name: "https",
+      status: "new",
+    },
+    {
+      port: 80,
+      protocol: "tcp",
+      state: "open",
+      service_name: "http",
+      status: "unchanged",
+    },
+    {
+      port: 22,
+      protocol: "tcp",
+      state: "open",
+      service_name: "ssh",
+      status: "changed",
+      prev_state: "filtered",
+      prev_service_name: "ssh-old",
+    },
+  ],
+  os_changed: false,
+  new_count: 1,
+  closed_count: 0,
+  changed_count: 1,
+  unchanged_count: 1,
+};
+
+function setupDefaultMocks() {
+  mockUseScanDiff.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    error: null,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+describe("ScanDiffPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+    mockUseSearch.mockReturnValue({ a: idA, b: idB });
+  });
+
+  it("shows missing-params notice when no IDs in URL", async () => {
+    mockUseSearch.mockReturnValue({});
+    const { getByText } = await renderWithRouter(<ScanDiffPage />);
+    expect(getByText(/Two scan IDs are required/i)).toBeTruthy();
+  });
+
+  it("shows loading skeleton when isLoading is true", async () => {
+    mockUseScanDiff.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const { container } = await renderWithRouter(<ScanDiffPage />);
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows error message when isError is true", async () => {
+    mockUseScanDiff.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("scan not found"),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const { getByText } = await renderWithRouter(<ScanDiffPage />);
+    expect(getByText(/Failed to load diff/i)).toBeTruthy();
+    expect(getByText(/scan not found/i)).toBeTruthy();
+  });
+
+  it("renders port table with correct status badges on success", async () => {
+    mockUseScanDiff.mockReturnValue({
+      data: mockDiff,
+      isLoading: false,
+      isError: false,
+      error: null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const { getAllByText, getByText } = await renderWithRouter(<ScanDiffPage />);
+
+    // Summary counts (check badge labels are rendered)
+    expect(getByText("new")).toBeTruthy();
+
+    // Status badges
+    expect(getAllByText("NEW").length).toBeGreaterThan(0);
+    expect(getAllByText("CHANGED").length).toBeGreaterThan(0);
+
+    // Port numbers appear
+    expect(getByText("443/tcp")).toBeTruthy();
+    expect(getByText("80/tcp")).toBeTruthy();
+    expect(getByText("22/tcp")).toBeTruthy();
+  });
+
+  it("shows OS changed banner when os_changed is true", async () => {
+    mockUseScanDiff.mockReturnValue({
+      data: {
+        ...mockDiff,
+        os_changed: true,
+        prev_os_name: "Ubuntu 20.04",
+        curr_os_name: "Ubuntu 22.04",
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const { getByText } = await renderWithRouter(<ScanDiffPage />);
+    expect(getByText(/OS changed/i)).toBeTruthy();
+    expect(getByText("Ubuntu 22.04")).toBeTruthy();
+  });
+
+  it("shows no-changes notice when all counts are zero", async () => {
+    mockUseScanDiff.mockReturnValue({
+      data: {
+        ...mockDiff,
+        ports: [],
+        new_count: 0,
+        closed_count: 0,
+        changed_count: 0,
+        unchanged_count: 0,
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const { getByText } = await renderWithRouter(<ScanDiffPage />);
+    expect(getByText(/No changes detected/i)).toBeTruthy();
+  });
+});

--- a/frontend/src/routes/scan-diff.tsx
+++ b/frontend/src/routes/scan-diff.tsx
@@ -1,0 +1,239 @@
+import { useSearch, Link } from "@tanstack/react-router";
+import { ArrowLeft, GitCompare } from "lucide-react";
+import { useScanDiff } from "../api/hooks/use-scan-diff";
+import type { ScanDiffEntry } from "../api/hooks/use-scan-diff";
+import { Skeleton } from "../components";
+import { cn } from "../lib/utils";
+
+// ── Status badge ──────────────────────────────────────────────────────────────
+
+type DiffStatus = "new" | "closed" | "changed" | "unchanged";
+
+const STATUS_LABELS: Record<DiffStatus, string> = {
+  new: "NEW",
+  closed: "CLOSED",
+  changed: "CHANGED",
+  unchanged: "–",
+};
+
+const STATUS_CLASSES: Record<DiffStatus, string> = {
+  new: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300",
+  closed: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300",
+  changed: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300",
+  unchanged: "bg-surface-muted text-text-muted",
+};
+
+function DiffBadge({ status }: { status: string }) {
+  const s = (status as DiffStatus) in STATUS_LABELS ? (status as DiffStatus) : "unchanged";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider",
+        STATUS_CLASSES[s],
+      )}
+    >
+      {STATUS_LABELS[s]}
+    </span>
+  );
+}
+
+// ── Loading skeleton ──────────────────────────────────────────────────────────
+
+function DiffSkeleton() {
+  return (
+    <div className="space-y-2">
+      <Skeleton className="h-4 w-48 animate-pulse" />
+      <Skeleton className="h-4 w-full animate-pulse" />
+      <Skeleton className="h-4 w-full animate-pulse" />
+      <Skeleton className="h-4 w-3/4 animate-pulse" />
+    </div>
+  );
+}
+
+// ── Port row ─────────────────────────────────────────────────────────────────
+
+function PortRow({ entry }: { entry: ScanDiffEntry }) {
+  const isChanged = entry.status === "changed";
+  const isClosed = entry.status === "closed";
+
+  const currentService = entry.service_name ?? "—";
+  const prevService = entry.prev_service_name ?? "—";
+
+  return (
+    <tr
+      className={cn(
+        "border-b border-border/50 text-xs last:border-0",
+        entry.status === "new" && "bg-emerald-50/40 dark:bg-emerald-950/20",
+        isClosed && "bg-red-50/40 dark:bg-red-950/20",
+        isChanged && "bg-amber-50/30 dark:bg-amber-950/15",
+      )}
+    >
+      {/* Port / Protocol */}
+      <td className="py-2 pr-4 font-mono text-text-primary">
+        {entry.port}/{entry.protocol}
+      </td>
+
+      {/* Status */}
+      <td className="py-2 pr-4">
+        <DiffBadge status={entry.status ?? "unchanged"} />
+      </td>
+
+      {/* State */}
+      <td className="py-2 pr-4 text-text-secondary">
+        {entry.state ?? "—"}
+      </td>
+
+      {/* Current service */}
+      <td className="py-2 pr-4 text-text-secondary">
+        {isClosed ? (
+          <span className="line-through text-text-muted">{prevService}</span>
+        ) : (
+          currentService
+        )}
+      </td>
+
+      {/* Previous service (only shown for changed/closed) */}
+      <td className="py-2 text-text-muted">
+        {(isChanged || isClosed) ? (
+          <span className="line-through">{prevService}</span>
+        ) : null}
+        {isChanged && entry.prev_state && entry.prev_state !== entry.state && (
+          <span className="ml-1 text-text-muted">({entry.prev_state})</span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+interface ScanDiffSearchParams {
+  a?: string;
+  b?: string;
+}
+
+export function ScanDiffPage() {
+  // TanStack Router typed search params
+  const search = useSearch({ strict: false }) as ScanDiffSearchParams;
+  const scanAId = search.a;
+  const scanBId = search.b;
+
+  const { data: diff, isLoading, isError, error } = useScanDiff(scanAId, scanBId);
+
+  // ── Missing params ──────────────────────────────────────────────────────────
+  if (!scanAId || !scanBId) {
+    return (
+      <div className="p-6 text-sm text-text-muted">
+        <p>Two scan IDs are required. Use ?a=&lt;id&gt;&amp;b=&lt;id&gt; in the URL.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6 max-w-5xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Link
+          to="/scans"
+          className="inline-flex items-center gap-1.5 text-xs text-text-muted hover:text-text-primary"
+        >
+          <ArrowLeft size={14} />
+          Back to scans
+        </Link>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <GitCompare size={20} className="text-accent shrink-0" />
+        <h1 className="text-lg font-semibold text-text-primary">Scan Comparison</h1>
+      </div>
+
+      {/* Scan ID pills */}
+      <div className="flex flex-wrap items-center gap-2 text-xs text-text-muted">
+        <span className="font-medium text-text-secondary">Baseline:</span>
+        <code className="font-mono bg-surface-muted px-2 py-0.5 rounded">{scanAId}</code>
+        <span>→</span>
+        <span className="font-medium text-text-secondary">Current:</span>
+        <code className="font-mono bg-surface-muted px-2 py-0.5 rounded">{scanBId}</code>
+      </div>
+
+      {/* Loading */}
+      {isLoading && <DiffSkeleton />}
+
+      {/* Error */}
+      {isError && (
+        <div className="rounded-md border border-border bg-surface p-4 text-sm text-red-600 dark:text-red-400">
+          Failed to load diff: {error instanceof Error ? error.message : "Unknown error"}
+        </div>
+      )}
+
+      {/* Results */}
+      {diff && (
+        <>
+          {/* OS change notice */}
+          {diff.os_changed && (
+            <div className="rounded-md border border-amber-300 bg-amber-50 px-4 py-2.5 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-950/30 dark:text-amber-300">
+              OS changed:{" "}
+              <span className="line-through mr-1">{diff.prev_os_name ?? "unknown"}</span>
+              →{" "}
+              <span className="font-semibold">{diff.curr_os_name ?? "unknown"}</span>
+            </div>
+          )}
+
+          {/* Summary counts */}
+          <div className="flex flex-wrap gap-3 text-sm">
+            {(diff.new_count ?? 0) > 0 && (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-3 py-1 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300">
+                <span className="font-semibold">{diff.new_count}</span> new
+              </span>
+            )}
+            {(diff.closed_count ?? 0) > 0 && (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-red-100 px-3 py-1 text-red-800 dark:bg-red-900/40 dark:text-red-300">
+                <span className="font-semibold">{diff.closed_count}</span> closed
+              </span>
+            )}
+            {(diff.changed_count ?? 0) > 0 && (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-3 py-1 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+                <span className="font-semibold">{diff.changed_count}</span> changed
+              </span>
+            )}
+            {(diff.unchanged_count ?? 0) > 0 && (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-surface-muted px-3 py-1 text-text-muted">
+                <span className="font-semibold">{diff.unchanged_count}</span> unchanged
+              </span>
+            )}
+            {diff.new_count === 0 &&
+              diff.closed_count === 0 &&
+              diff.changed_count === 0 &&
+              (diff.unchanged_count ?? 0) === 0 && (
+              <span className="text-text-muted">No changes detected between these scans.</span>
+            )}
+          </div>
+
+          {/* Port table */}
+          {(diff.ports?.length ?? 0) > 0 ? (
+            <div className="overflow-x-auto rounded-lg border border-border">
+              <table className="w-full text-xs border-collapse">
+                <thead>
+                  <tr className="bg-surface-muted text-left text-text-muted text-[11px] uppercase tracking-wider">
+                    <th className="px-3 py-2.5 font-medium">Port</th>
+                    <th className="px-3 py-2.5 font-medium">Status</th>
+                    <th className="px-3 py-2.5 font-medium">State</th>
+                    <th className="px-3 py-2.5 font-medium">Service</th>
+                    <th className="px-3 py-2.5 font-medium">Previous</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {diff.ports.map((entry, i) => (
+                    <PortRow key={`${entry.port}-${entry.protocol}-${i}`} entry={entry} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="text-sm text-text-muted">No port data for these scans.</p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/routes/scans.test.tsx
+++ b/frontend/src/routes/scans.test.tsx
@@ -3,6 +3,13 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ScansPage } from "./scans";
 
+const mockNavigate = vi.fn();
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
 vi.mock("../api/hooks/use-scans", () => ({
   useScans: vi.fn(),
   useScanResults: vi.fn(),
@@ -93,6 +100,22 @@ const mockScans = [
     ports: undefined,
     profile_id: undefined,
     error_message: "Connection refused",
+  },
+  {
+    id: "scan-4",
+    status: "completed" as const,
+    targets: ["10.0.0.0/8"],
+    hosts_discovered: 5,
+    ports_scanned: "22",
+    duration: "2m10s",
+    started_at: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+    completed_at: new Date().toISOString(),
+    name: undefined,
+    scan_type: "connect" as const,
+    ports: "22",
+    profile_id: undefined,
+    error_message: undefined,
   },
 ];
 
@@ -257,9 +280,9 @@ describe("ScansPage", () => {
 
   it("renders a row for each scan", () => {
     render(<ScansPage />);
-    // 1 header row + 3 data rows
+    // 1 header row + 4 data rows
     const rows = screen.getAllByRole("row");
-    expect(rows).toHaveLength(4);
+    expect(rows).toHaveLength(5);
   });
 
   // ── Scan data ─────────────────────────────────────────────────
@@ -271,7 +294,7 @@ describe("ScansPage", () => {
 
   it("renders StatusBadge for each scan", () => {
     render(<ScansPage />);
-    expect(screen.getByText("completed")).toBeInTheDocument();
+    expect(screen.getAllByText("completed")).toHaveLength(2);
     expect(screen.getByText("running")).toBeInTheDocument();
     expect(screen.getByText("failed")).toBeInTheDocument();
   });
@@ -292,8 +315,8 @@ describe("ScansPage", () => {
     const rows = screen.getAllByRole("row");
     // scan-3 is the last data row (index 3)
     const cells = within(rows[3]).getAllByRole("cell");
-    // Targets is index 0
-    expect(cells[0]).toHaveTextContent("—");
+    // Targets is index 1 (checkbox at 0)
+    expect(cells[1]).toHaveTextContent("—");
   });
 
   it("shows em-dash for missing ports_scanned", () => {
@@ -301,8 +324,8 @@ describe("ScansPage", () => {
     const rows = screen.getAllByRole("row");
     // scan-2 is index 2
     const cells = within(rows[2]).getAllByRole("cell");
-    // Ports is index 2 (Targets, Status, Ports, Duration, Started)
-    expect(cells[2]).toHaveTextContent("—");
+    // Ports is index 3 (checkbox, Targets, Status, Ports, Duration, Started)
+    expect(cells[3]).toHaveTextContent("—");
   });
 
   it("shows em-dash for missing duration", () => {
@@ -310,8 +333,8 @@ describe("ScansPage", () => {
     const rows = screen.getAllByRole("row");
     // scan-2 is index 2
     const cells = within(rows[2]).getAllByRole("cell");
-    // Duration is index 3 (Targets, Status, Ports, Duration, Started)
-    expect(cells[3]).toHaveTextContent("—");
+    // Duration is index 4 (checkbox, Targets, Status, Ports, Duration, Started)
+    expect(cells[4]).toHaveTextContent("—");
   });
 
   it("shows em-dash for missing started_at", () => {
@@ -319,8 +342,8 @@ describe("ScansPage", () => {
     const rows = screen.getAllByRole("row");
     // scan-3 is index 3 — no started_at
     const cells = within(rows[3]).getAllByRole("cell");
-    // Started is index 4 (Targets, Status, Ports, Duration, Started)
-    expect(cells[4]).toHaveTextContent("—");
+    // Started is index 5 (checkbox, Targets, Status, Ports, Duration, Started)
+    expect(cells[5]).toHaveTextContent("—");
   });
 
   // ── Status filter interaction ─────────────────────────────────
@@ -568,5 +591,47 @@ describe("ScansPage", () => {
     // containerProps mock sets tabIndex: 0 on the wrapping div
     const navDiv = document.querySelector('[tabindex="0"]');
     expect(navDiv).toBeInTheDocument();
+  });
+
+  // ── Compare button ────────────────────────────────────────────
+  describe("Compare button", () => {
+    beforeEach(() => mockNavigate.mockClear());
+
+    it("does not show Compare button initially", () => {
+      render(<ScansPage />);
+      expect(screen.queryByRole("button", { name: /compare/i })).not.toBeInTheDocument();
+    });
+
+    it("shows Compare button when exactly 2 completed scans are checked", async () => {
+      render(<ScansPage />);
+      const checkboxes = screen.getAllByRole("checkbox");
+      // scan-1 (idx 0) and scan-4 (idx 3) are completed; scan-2 (idx 1) and scan-3 (idx 2) are disabled
+      await userEvent.click(checkboxes[0]); // scan-1
+      expect(screen.queryByRole("button", { name: /compare/i })).not.toBeInTheDocument();
+      await userEvent.click(checkboxes[3]); // scan-4
+      expect(screen.getByRole("button", { name: /compare/i })).toBeInTheDocument();
+    });
+
+    it("navigates to /scans/diff with correct a and b params on Compare click", async () => {
+      render(<ScansPage />);
+      const checkboxes = screen.getAllByRole("checkbox");
+      await userEvent.click(checkboxes[0]); // scan-1
+      await userEvent.click(checkboxes[3]); // scan-4
+      await userEvent.click(screen.getByRole("button", { name: /compare/i }));
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/scans/diff",
+        search: { a: "scan-1", b: "scan-4" },
+      });
+    });
+
+    it("disables checkboxes for non-completed scans", () => {
+      render(<ScansPage />);
+      const checkboxes = screen.getAllByRole("checkbox");
+      // scan-2 is running, scan-3 is failed — both disabled
+      const disabled = checkboxes.filter(
+        (cb) => (cb as HTMLInputElement).disabled,
+      );
+      expect(disabled).toHaveLength(2);
+    });
   });
 });

--- a/frontend/src/routes/scans.tsx
+++ b/frontend/src/routes/scans.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from "react";
-import { ScanLine } from "lucide-react";
+import { ScanLine, GitCompare } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
 import { SortHeader } from "../components/sort-header";
 import type { SortOrder } from "../components/sort-header";
 import { Button } from "../components/button";
@@ -40,7 +41,8 @@ function SkeletonRows({
     <>
       {Array.from({ length: count }).map((_, i) => (
         <tr key={i} className="border-b border-border/50">
-          <td className="py-3 px-4 pr-4">
+          <td className="py-3 px-4 w-8" />
+          <td className="py-3 pr-4">
             <Skeleton className="h-3.5 w-40" />
           </td>
           <td className="py-3 pr-4">
@@ -71,13 +73,17 @@ function SkeletonRows({
 // Main page
 // ──────────────────────────────────────────────
 
+const MAX_COMPARE = 2;
+
 export function ScansPage() {
+  const navigate = useNavigate();
   const [page, setPage] = useState(1);
   const [statusFilter, setStatusFilter] = useState<ScanStatus>("all");
   const [sortBy, setSortBy] = useState("created_at");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
   const [selectedScanId, setSelectedScanId] = useState<string | null>(null);
   const [showRunScan, setShowRunScan] = useState(false);
+  const [compareIds, setCompareIds] = useState<Set<string>>(new Set());
   const [colVis, setColVis] = useState<Record<string, boolean>>(() =>
     Object.fromEntries(SCAN_COLUMNS.map((c) => [c.key, true])),
   );
@@ -106,6 +112,24 @@ export function ScansPage() {
     [sortBy],
   );
 
+  const toggleCompare = useCallback((id: string) => {
+    setCompareIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else if (next.size < MAX_COMPARE) {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleCompare = useCallback(() => {
+    const [a, b] = [...compareIds];
+    if (!a || !b) return;
+    void navigate({ to: "/scans/diff", search: { a, b } });
+  }, [compareIds, navigate]);
+
   const queryParams = {
     page,
     page_size: PAGE_SIZE,
@@ -126,9 +150,9 @@ export function ScansPage() {
     onEscape: () => setSelectedScanId(null),
   });
 
-  const visibleColCount = SCAN_COLUMNS.filter(
-    (c) => colVis[c.key] !== false,
-  ).length;
+  // +1 for the always-present checkbox column
+  const visibleColCount =
+    SCAN_COLUMNS.filter((c) => colVis[c.key] !== false).length + 1;
 
   // Reset keyboard focus when page/filters change
   useEffect(() => {
@@ -176,6 +200,15 @@ export function ScansPage() {
           </select>
 
           <div className="flex items-center gap-2 sm:ml-auto">
+            {compareIds.size === MAX_COMPARE && (
+              <Button
+                onClick={handleCompare}
+                icon={<GitCompare className="h-3.5 w-3.5" />}
+                variant="secondary"
+              >
+                Compare
+              </Button>
+            )}
             <Button
               onClick={() => setShowRunScan(true)}
               icon={<ScanLine className="h-3.5 w-3.5" />}
@@ -203,7 +236,8 @@ export function ScansPage() {
               <table className="w-full text-xs">
                 <thead>
                   <tr className="border-b border-border bg-surface">
-                    <th className="text-left font-medium text-text-muted px-4 py-3 pr-4">
+                    <th className="py-3 px-4 w-8" aria-label="Select for comparison" />
+                    <th className="text-left font-medium text-text-muted py-3 pr-4">
                       Targets
                     </th>
                     <SortHeader
@@ -256,7 +290,14 @@ export function ScansPage() {
                       </td>
                     </tr>
                   ) : (
-                    scans.map((scan, idx) => (
+                    scans.map((scan, idx) => {
+                      const id = scan.id ?? "";
+                      const isCompleted = scan.status === "completed";
+                      const isChecked = compareIds.has(id);
+                      const isDisabled =
+                        !isCompleted ||
+                        (!isChecked && compareIds.size >= MAX_COMPARE);
+                      return (
                       <tr
                         key={scan.id}
                         onClick={() => {
@@ -270,7 +311,20 @@ export function ScansPage() {
                             "ring-1 ring-inset ring-accent/60 bg-surface-raised/40",
                         )}
                       >
-                        <td className="py-3 px-4 pr-4 font-mono text-text-secondary max-w-50 truncate">
+                        <td
+                          className="py-3 px-4 w-8"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={isChecked}
+                            disabled={isDisabled}
+                            onChange={() => toggleCompare(id)}
+                            aria-label={`Select scan ${id} for comparison`}
+                            className="cursor-pointer disabled:cursor-not-allowed"
+                          />
+                        </td>
+                        <td className="py-3 pr-4 font-mono text-text-secondary max-w-50 truncate">
                           {scan.targets?.join(", ") ?? "—"}
                         </td>
                         <td className="py-3 pr-4">
@@ -294,7 +348,8 @@ export function ScansPage() {
                           </td>
                         )}
                       </tr>
-                    ))
+                    );
+                    })
                   )}
                 </tbody>
               </table>

--- a/frontend/src/routes/scans.tsx
+++ b/frontend/src/routes/scans.tsx
@@ -143,6 +143,16 @@ export function ScansPage() {
     }
   }, [isLoading, page, totalPages, setPage]);
 
+  // Open the new-scan modal when the keyboard shortcut `n` fires on this page.
+  useEffect(() => {
+    function handleNewScanRequested() {
+      setShowRunScan(true);
+    }
+    document.addEventListener("new-scan-requested", handleNewScanRequested);
+    return () =>
+      document.removeEventListener("new-scan-requested", handleNewScanRequested);
+  }, []);
+
   return (
     <>
       <div className="space-y-4">

--- a/frontend/src/routes/scans.tsx
+++ b/frontend/src/routes/scans.tsx
@@ -16,6 +16,7 @@ import { formatRelativeTime } from "../lib/utils";
 import { cn } from "../lib/utils";
 import { ColumnToggle } from "../components/column-toggle";
 import type { ColumnDef } from "../components/column-toggle";
+import { ExportButton } from "../components/export-button";
 import { useTableKeyNav } from "../hooks/use-table-key-nav";
 
 const PAGE_SIZE = 25;
@@ -215,6 +216,14 @@ export function ScansPage() {
             >
               New scan
             </Button>
+            <ExportButton
+              basePath="/api/v1/scans/export"
+              params={{
+                sort_by: sortBy,
+                sort_order: sortOrder,
+                ...(statusFilter !== "all" ? { status: statusFilter } : {}),
+              }}
+            />
             <ColumnToggle
               columns={SCAN_COLUMNS}
               visibility={colVis}

--- a/internal/api/handlers/alerts.go
+++ b/internal/api/handlers/alerts.go
@@ -1,0 +1,312 @@
+// Package handlers — alert rule management endpoints.
+package handlers
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/anstrom/scanorama/internal/db"
+	"github.com/anstrom/scanorama/internal/metrics"
+)
+
+const entityTypeAlertRule = "alert rule"
+
+// AlertHandler handles HTTP requests for alert rule management.
+type AlertHandler struct {
+	svc     AlertServicer
+	logger  *slog.Logger
+	metrics *metrics.Registry
+}
+
+// NewAlertHandler creates a new AlertHandler.
+func NewAlertHandler(svc AlertServicer, logger *slog.Logger, m *metrics.Registry) *AlertHandler {
+	return &AlertHandler{
+		svc:     svc,
+		logger:  logger.With("handler", "alert"),
+		metrics: m,
+	}
+}
+
+// createAlertRuleRequest is the body for POST /api/v1/alerts.
+type createAlertRuleRequest struct {
+	HostID     *string `json:"host_id"`
+	GroupID    *string `json:"group_id"`
+	Tag        *string `json:"tag"`
+	Trigger    string  `json:"trigger"`
+	ChannelURL string  `json:"channel_url"`
+}
+
+// updateAlertRuleRequest is the body for PATCH /api/v1/alerts/{id}.
+type updateAlertRuleRequest struct {
+	Trigger    *string `json:"trigger"`
+	ChannelURL *string `json:"channel_url"`
+	Enabled    *bool   `json:"enabled"`
+}
+
+// ListAlertRules handles GET /api/v1/alerts.
+//
+//	@Summary     List all alert rules
+//	@Tags        alerts
+//	@Produce     json
+//	@Success     200  {object}  map[string]any
+//	@Failure     500  {object}  map[string]any
+//	@Router      /alerts [get]
+func (h *AlertHandler) ListAlertRules(w http.ResponseWriter, r *http.Request) {
+	rules, err := h.svc.ListAlertRules(r.Context())
+	if err != nil {
+		handleDatabaseError(w, r, err, "list", "alert rules", h.logger)
+		return
+	}
+	if rules == nil {
+		rules = make([]*db.AlertRule, 0)
+	}
+	writeJSON(w, r, http.StatusOK, map[string]any{"alert_rules": rules})
+}
+
+// CreateAlertRule handles POST /api/v1/alerts.
+//
+//	@Summary     Create an alert rule
+//	@Tags        alerts
+//	@Accept      json
+//	@Produce     json
+//	@Param       body  body      createAlertRuleRequest  true  "Alert rule input"
+//	@Success     201   {object}  db.AlertRule
+//	@Failure     400   {object}  map[string]any
+//	@Failure     500   {object}  map[string]any
+//	@Router      /alerts [post]
+func (h *AlertHandler) CreateAlertRule(w http.ResponseWriter, r *http.Request) {
+	var req createAlertRuleRequest
+	if err := parseJSON(r, &req); err != nil {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err))
+		return
+	}
+
+	if err := validateAlertRuleTrigger(req.Trigger); err != nil {
+		writeError(w, r, http.StatusBadRequest, err)
+		return
+	}
+	if err := validateAlertRuleChannelURL(req.ChannelURL); err != nil {
+		writeError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	input, err := buildCreateAlertInput(req)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, err)
+		return
+	}
+	if err := validateAlertRuleTarget(input); err != nil {
+		writeError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	rule, err := h.svc.CreateAlertRule(r.Context(), input)
+	if err != nil {
+		handleDatabaseError(w, r, err, "create", entityTypeAlertRule, h.logger)
+		return
+	}
+	writeJSON(w, r, http.StatusCreated, rule)
+}
+
+// GetAlertRule handles GET /api/v1/alerts/{id}.
+//
+//	@Summary     Get an alert rule
+//	@Tags        alerts
+//	@Produce     json
+//	@Param       id   path      string  true  "Alert rule UUID"
+//	@Success     200  {object}  db.AlertRule
+//	@Failure     400  {object}  map[string]any
+//	@Failure     404  {object}  map[string]any
+//	@Failure     500  {object}  map[string]any
+//	@Router      /alerts/{id} [get]
+func (h *AlertHandler) GetAlertRule(w http.ResponseWriter, r *http.Request) {
+	id, err := extractUUIDFromPath(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid alert rule ID: %w", err))
+		return
+	}
+	rule, err := h.svc.GetAlertRule(r.Context(), id)
+	if err != nil {
+		handleDatabaseError(w, r, err, "get", entityTypeAlertRule, h.logger)
+		return
+	}
+	writeJSON(w, r, http.StatusOK, rule)
+}
+
+// UpdateAlertRule handles PATCH /api/v1/alerts/{id}.
+//
+//	@Summary     Update an alert rule
+//	@Tags        alerts
+//	@Accept      json
+//	@Produce     json
+//	@Param       id    path      string                true  "Alert rule UUID"
+//	@Param       body  body      updateAlertRuleRequest true  "Update fields"
+//	@Success     200   {object}  db.AlertRule
+//	@Failure     400   {object}  map[string]any
+//	@Failure     404   {object}  map[string]any
+//	@Failure     500   {object}  map[string]any
+//	@Router      /alerts/{id} [patch]
+func (h *AlertHandler) UpdateAlertRule(w http.ResponseWriter, r *http.Request) {
+	id, err := extractUUIDFromPath(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid alert rule ID: %w", err))
+		return
+	}
+
+	var req updateAlertRuleRequest
+	if err := parseJSON(r, &req); err != nil {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err))
+		return
+	}
+
+	if req.Trigger != nil {
+		if err := validateAlertRuleTrigger(*req.Trigger); err != nil {
+			writeError(w, r, http.StatusBadRequest, err)
+			return
+		}
+	}
+	if req.ChannelURL != nil {
+		if err := validateAlertRuleChannelURL(*req.ChannelURL); err != nil {
+			writeError(w, r, http.StatusBadRequest, err)
+			return
+		}
+	}
+
+	rule, err := h.svc.UpdateAlertRule(r.Context(), id, db.UpdateAlertRuleInput{
+		Trigger:    req.Trigger,
+		ChannelURL: req.ChannelURL,
+		Enabled:    req.Enabled,
+	})
+	if err != nil {
+		handleDatabaseError(w, r, err, "update", entityTypeAlertRule, h.logger)
+		return
+	}
+	writeJSON(w, r, http.StatusOK, rule)
+}
+
+// DeleteAlertRule handles DELETE /api/v1/alerts/{id}.
+//
+//	@Summary     Delete an alert rule
+//	@Tags        alerts
+//	@Param       id  path  string  true  "Alert rule UUID"
+//	@Success     204
+//	@Failure     400  {object}  map[string]any
+//	@Failure     404  {object}  map[string]any
+//	@Failure     500  {object}  map[string]any
+//	@Router      /alerts/{id} [delete]
+func (h *AlertHandler) DeleteAlertRule(w http.ResponseWriter, r *http.Request) {
+	id, err := extractUUIDFromPath(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid alert rule ID: %w", err))
+		return
+	}
+	if err := h.svc.DeleteAlertRule(r.Context(), id); err != nil {
+		handleDatabaseError(w, r, err, "delete", entityTypeAlertRule, h.logger)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ListAlertRulesForHost handles GET /api/v1/hosts/{id}/alerts.
+//
+//	@Summary     List alert rules for a host
+//	@Tags        alerts
+//	@Produce     json
+//	@Param       id   path      string  true  "Host UUID"
+//	@Success     200  {object}  map[string]any
+//	@Failure     400  {object}  map[string]any
+//	@Failure     500  {object}  map[string]any
+//	@Router      /hosts/{id}/alerts [get]
+func (h *AlertHandler) ListAlertRulesForHost(w http.ResponseWriter, r *http.Request) {
+	hostID, err := extractUUIDFromPath(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid host ID: %w", err))
+		return
+	}
+	rules, err := h.svc.ListAlertRulesForHost(r.Context(), hostID)
+	if err != nil {
+		handleDatabaseError(w, r, err, "list", "host alert rules", h.logger)
+		return
+	}
+	if rules == nil {
+		rules = make([]*db.AlertRule, 0)
+	}
+	writeJSON(w, r, http.StatusOK, map[string]any{"alert_rules": rules})
+}
+
+// validateAlertRuleTrigger checks that the trigger value is allowed.
+func validateAlertRuleTrigger(trigger string) error {
+	switch trigger {
+	case db.AlertTriggerOnline, db.AlertTriggerOffline, db.AlertTriggerBoth:
+		return nil
+	default:
+		return fmt.Errorf("trigger must be one of: online, offline, both")
+	}
+}
+
+// validateAlertRuleChannelURL checks the channel URL is non-empty and http/https.
+func validateAlertRuleChannelURL(url string) error {
+	if url == "" {
+		return fmt.Errorf("channel_url is required")
+	}
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		return fmt.Errorf("channel_url must start with http:// or https://")
+	}
+	return nil
+}
+
+// validateAlertRuleTarget checks that exactly one of HostID, GroupID, or Tag is set.
+func validateAlertRuleTarget(input db.CreateAlertRuleInput) error {
+	count := 0
+	if input.HostID != nil {
+		count++
+	}
+	if input.GroupID != nil {
+		count++
+	}
+	if input.Tag != nil && *input.Tag != "" {
+		count++
+	}
+	if count != 1 {
+		return fmt.Errorf("exactly one of host_id, group_id, or tag must be set")
+	}
+	return nil
+}
+
+// buildCreateAlertInput converts the HTTP request into a CreateAlertRuleInput,
+// parsing UUID strings and validating the target constraint.
+func buildCreateAlertInput(req createAlertRuleRequest) (db.CreateAlertRuleInput, error) {
+	input := db.CreateAlertRuleInput{
+		Trigger:    req.Trigger,
+		ChannelURL: req.ChannelURL,
+		Tag:        req.Tag,
+	}
+	if req.HostID != nil {
+		id, err := parseUUIDField("host_id", *req.HostID)
+		if err != nil {
+			return db.CreateAlertRuleInput{}, err
+		}
+		input.HostID = &id
+	}
+	if req.GroupID != nil {
+		id, err := parseUUIDField("group_id", *req.GroupID)
+		if err != nil {
+			return db.CreateAlertRuleInput{}, err
+		}
+		input.GroupID = &id
+	}
+	return input, nil
+}
+
+// parseUUIDField parses a UUID string and returns a descriptive error on failure.
+func parseUUIDField(field, value string) (uuid.UUID, error) {
+	id, err := uuid.Parse(value)
+	if err != nil {
+		return uuid.UUID{}, fmt.Errorf("invalid %s: %w", field, err)
+	}
+	return id, nil
+}

--- a/internal/api/handlers/alerts_test.go
+++ b/internal/api/handlers/alerts_test.go
@@ -1,0 +1,478 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/db"
+	apierrors "github.com/anstrom/scanorama/internal/errors"
+	"github.com/anstrom/scanorama/internal/metrics"
+)
+
+// ── mock ─────────────────────────────────────────────────────────────────────
+
+type mockAlertServicer struct {
+	listFn        func(ctx context.Context) ([]*db.AlertRule, error)
+	listForHostFn func(ctx context.Context, hostID uuid.UUID) ([]*db.AlertRule, error)
+	createFn      func(ctx context.Context, input db.CreateAlertRuleInput) (*db.AlertRule, error)
+	getFn         func(ctx context.Context, id uuid.UUID) (*db.AlertRule, error)
+	updateFn      func(ctx context.Context, id uuid.UUID, input db.UpdateAlertRuleInput) (*db.AlertRule, error)
+	deleteFn      func(ctx context.Context, id uuid.UUID) error
+}
+
+func (m *mockAlertServicer) ListAlertRules(ctx context.Context) ([]*db.AlertRule, error) {
+	return m.listFn(ctx)
+}
+
+func (m *mockAlertServicer) ListAlertRulesForHost(
+	ctx context.Context, hostID uuid.UUID,
+) ([]*db.AlertRule, error) {
+	return m.listForHostFn(ctx, hostID)
+}
+
+func (m *mockAlertServicer) CreateAlertRule(
+	ctx context.Context, input db.CreateAlertRuleInput,
+) (*db.AlertRule, error) {
+	return m.createFn(ctx, input)
+}
+
+func (m *mockAlertServicer) GetAlertRule(ctx context.Context, id uuid.UUID) (*db.AlertRule, error) {
+	return m.getFn(ctx, id)
+}
+
+func (m *mockAlertServicer) UpdateAlertRule(
+	ctx context.Context, id uuid.UUID, input db.UpdateAlertRuleInput,
+) (*db.AlertRule, error) {
+	return m.updateFn(ctx, id, input)
+}
+
+func (m *mockAlertServicer) DeleteAlertRule(ctx context.Context, id uuid.UUID) error {
+	return m.deleteFn(ctx, id)
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func newAlertRouter(h *AlertHandler) *mux.Router {
+	r := mux.NewRouter()
+	r.HandleFunc("/alerts", h.ListAlertRules).Methods(http.MethodGet)
+	r.HandleFunc("/alerts", h.CreateAlertRule).Methods(http.MethodPost)
+	r.HandleFunc("/alerts/{id}", h.GetAlertRule).Methods(http.MethodGet)
+	r.HandleFunc("/alerts/{id}", h.UpdateAlertRule).Methods(http.MethodPatch)
+	r.HandleFunc("/alerts/{id}", h.DeleteAlertRule).Methods(http.MethodDelete)
+	r.HandleFunc("/hosts/{id}/alerts", h.ListAlertRulesForHost).Methods(http.MethodGet)
+	return r
+}
+
+func newAlertHandler(svc *mockAlertServicer) *AlertHandler {
+	return NewAlertHandler(svc, createTestLogger(), metrics.NewRegistry())
+}
+
+func makeAlertRule(id, hostID uuid.UUID) *db.AlertRule {
+	hid := hostID
+	return &db.AlertRule{
+		ID:          id,
+		HostID:      &hid,
+		Trigger:     db.AlertTriggerOnline,
+		ChannelType: db.AlertChannelTypeWebhook,
+		ChannelURL:  "https://example.com/hook",
+		Enabled:     true,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+}
+
+// ── ListAlertRules ────────────────────────────────────────────────────────────
+
+func TestListAlertRules_Success(t *testing.T) {
+	id1 := uuid.New()
+	hostID := uuid.New()
+	svc := &mockAlertServicer{
+		listFn: func(_ context.Context) ([]*db.AlertRule, error) {
+			return []*db.AlertRule{makeAlertRule(id1, hostID)}, nil
+		},
+	}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	req := httptest.NewRequest(http.MethodGet, "/alerts", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var raw map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&raw))
+	rules, ok := raw["alert_rules"].([]any)
+	require.True(t, ok)
+	assert.Len(t, rules, 1)
+}
+
+func TestListAlertRules_Empty(t *testing.T) {
+	svc := &mockAlertServicer{
+		listFn: func(_ context.Context) ([]*db.AlertRule, error) {
+			return make([]*db.AlertRule, 0), nil
+		},
+	}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	req := httptest.NewRequest(http.MethodGet, "/alerts", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var raw map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&raw))
+	rules, ok := raw["alert_rules"].([]any)
+	require.True(t, ok)
+	assert.Len(t, rules, 0)
+}
+
+func TestListAlertRules_ServiceError(t *testing.T) {
+	svc := &mockAlertServicer{
+		listFn: func(_ context.Context) ([]*db.AlertRule, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	req := httptest.NewRequest(http.MethodGet, "/alerts", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ── CreateAlertRule ───────────────────────────────────────────────────────────
+
+func TestCreateAlertRule_Success(t *testing.T) {
+	id := uuid.New()
+	hostID := uuid.New()
+	svc := &mockAlertServicer{
+		createFn: func(_ context.Context, input db.CreateAlertRuleInput) (*db.AlertRule, error) {
+			return makeAlertRule(id, hostID), nil
+		},
+	}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	body := `{"host_id":"` + hostID.String() + `","trigger":"online","channel_url":"https://example.com/hook"}`
+	req := httptest.NewRequest(http.MethodPost, "/alerts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	var raw map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&raw))
+	assert.Equal(t, "https://example.com/hook", raw["channel_url"])
+	assert.Equal(t, "online", raw["trigger"])
+}
+
+func TestCreateAlertRule_InvalidTrigger(t *testing.T) {
+	svc := &mockAlertServicer{}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	hostID := uuid.New()
+	body := `{"host_id":"` + hostID.String() + `","trigger":"invalid","channel_url":"https://example.com/hook"}`
+	req := httptest.NewRequest(http.MethodPost, "/alerts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreateAlertRule_InvalidURL(t *testing.T) {
+	svc := &mockAlertServicer{}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	hostID := uuid.New()
+	body := `{"host_id":"` + hostID.String() + `","trigger":"online","channel_url":"ftp://bad"}`
+	req := httptest.NewRequest(http.MethodPost, "/alerts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreateAlertRule_MissingTarget(t *testing.T) {
+	svc := &mockAlertServicer{}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	body := `{"trigger":"online","channel_url":"https://example.com/hook"}`
+	req := httptest.NewRequest(http.MethodPost, "/alerts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreateAlertRule_ServiceError(t *testing.T) {
+	hostID := uuid.New()
+	svc := &mockAlertServicer{
+		createFn: func(_ context.Context, _ db.CreateAlertRuleInput) (*db.AlertRule, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	body := `{"host_id":"` + hostID.String() + `","trigger":"online","channel_url":"https://example.com/hook"}`
+	req := httptest.NewRequest(http.MethodPost, "/alerts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ── GetAlertRule ──────────────────────────────────────────────────────────────
+
+func TestGetAlertRule_Success(t *testing.T) {
+	id := uuid.New()
+	hostID := uuid.New()
+	svc := &mockAlertServicer{
+		getFn: func(_ context.Context, _ uuid.UUID) (*db.AlertRule, error) {
+			return makeAlertRule(id, hostID), nil
+		},
+	}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	req := httptest.NewRequest(http.MethodGet, "/alerts/"+id.String(), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var raw map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&raw))
+	assert.Equal(t, id.String(), raw["id"])
+}
+
+func TestGetAlertRule_BadUUID(t *testing.T) {
+	svc := &mockAlertServicer{}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	req := httptest.NewRequest(http.MethodGet, "/alerts/not-a-uuid", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetAlertRule_NotFound(t *testing.T) {
+	svc := &mockAlertServicer{
+		getFn: func(_ context.Context, _ uuid.UUID) (*db.AlertRule, error) {
+			return nil, apierrors.NewScanError(apierrors.CodeNotFound, "alert rule not found")
+		},
+	}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	req := httptest.NewRequest(http.MethodGet, "/alerts/"+uuid.New().String(), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// ── UpdateAlertRule ───────────────────────────────────────────────────────────
+
+func TestUpdateAlertRule_Success(t *testing.T) {
+	id := uuid.New()
+	hostID := uuid.New()
+	svc := &mockAlertServicer{
+		updateFn: func(_ context.Context, _ uuid.UUID, _ db.UpdateAlertRuleInput) (*db.AlertRule, error) {
+			r := makeAlertRule(id, hostID)
+			r.Enabled = false
+			return r, nil
+		},
+	}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	body := `{"enabled":false}`
+	req := httptest.NewRequest(http.MethodPatch, "/alerts/"+id.String(), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var raw map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&raw))
+	assert.Equal(t, false, raw["enabled"])
+}
+
+func TestUpdateAlertRule_BadUUID(t *testing.T) {
+	svc := &mockAlertServicer{}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	req := httptest.NewRequest(http.MethodPatch, "/alerts/not-a-uuid", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdateAlertRule_InvalidTrigger(t *testing.T) {
+	svc := &mockAlertServicer{}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	body := `{"trigger":"invalid"}`
+	req := httptest.NewRequest(http.MethodPatch, "/alerts/"+uuid.New().String(), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdateAlertRule_InvalidChannelURL(t *testing.T) {
+	svc := &mockAlertServicer{}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	body := `{"channel_url":"ftp://bad"}`
+	req := httptest.NewRequest(http.MethodPatch, "/alerts/"+uuid.New().String(), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdateAlertRule_NotFound(t *testing.T) {
+	svc := &mockAlertServicer{
+		updateFn: func(_ context.Context, _ uuid.UUID, _ db.UpdateAlertRuleInput) (*db.AlertRule, error) {
+			return nil, apierrors.NewScanError(apierrors.CodeNotFound, "alert rule not found")
+		},
+	}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	body := `{"enabled":false}`
+	req := httptest.NewRequest(http.MethodPatch, "/alerts/"+uuid.New().String(), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestUpdateAlertRule_ServiceError(t *testing.T) {
+	svc := &mockAlertServicer{
+		updateFn: func(_ context.Context, _ uuid.UUID, _ db.UpdateAlertRuleInput) (*db.AlertRule, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	body := `{"enabled":false}`
+	req := httptest.NewRequest(http.MethodPatch, "/alerts/"+uuid.New().String(), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ── DeleteAlertRule ───────────────────────────────────────────────────────────
+
+func TestDeleteAlertRule_Success(t *testing.T) {
+	id := uuid.New()
+	svc := &mockAlertServicer{
+		deleteFn: func(_ context.Context, _ uuid.UUID) error { return nil },
+	}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	req := httptest.NewRequest(http.MethodDelete, "/alerts/"+id.String(), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestDeleteAlertRule_BadUUID(t *testing.T) {
+	svc := &mockAlertServicer{}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	req := httptest.NewRequest(http.MethodDelete, "/alerts/not-a-uuid", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDeleteAlertRule_NotFound(t *testing.T) {
+	svc := &mockAlertServicer{
+		deleteFn: func(_ context.Context, _ uuid.UUID) error {
+			return apierrors.NewScanError(apierrors.CodeNotFound, "alert rule not found")
+		},
+	}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	req := httptest.NewRequest(http.MethodDelete, "/alerts/"+uuid.New().String(), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// ── ListAlertRulesForHost ────────────────────────────────────────────────────
+
+func TestListAlertRulesForHost_Success(t *testing.T) {
+	hostID := uuid.New()
+	ruleID := uuid.New()
+	svc := &mockAlertServicer{
+		listForHostFn: func(_ context.Context, _ uuid.UUID) ([]*db.AlertRule, error) {
+			return []*db.AlertRule{makeAlertRule(ruleID, hostID)}, nil
+		},
+	}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	req := httptest.NewRequest(http.MethodGet, "/hosts/"+hostID.String()+"/alerts", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var raw map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&raw))
+	rules, ok := raw["alert_rules"].([]any)
+	require.True(t, ok)
+	assert.Len(t, rules, 1)
+}
+
+func TestListAlertRulesForHost_BadUUID(t *testing.T) {
+	svc := &mockAlertServicer{}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	req := httptest.NewRequest(http.MethodGet, "/hosts/not-a-uuid/alerts", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestListAlertRulesForHost_EmptyArray(t *testing.T) {
+	hostID := uuid.New()
+	svc := &mockAlertServicer{
+		listForHostFn: func(_ context.Context, _ uuid.UUID) ([]*db.AlertRule, error) {
+			return make([]*db.AlertRule, 0), nil
+		},
+	}
+	router := newAlertRouter(newAlertHandler(svc))
+
+	req := httptest.NewRequest(http.MethodGet, "/hosts/"+hostID.String()+"/alerts", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	// Verify the array serializes as [] not null
+	body := w.Body.String()
+	assert.Contains(t, body, `"alert_rules":[]`)
+}

--- a/internal/api/handlers/common.go
+++ b/internal/api/handlers/common.go
@@ -31,6 +31,7 @@ const (
 	responseKeyID       = "id"
 	responseKeyReqID    = "request_id"
 	responseKeyTotal    = "total"
+	statusDelivered     = "delivered"
 	statusStarted       = "started"
 	statusStopped       = "stopped"
 	statusSuccess       = "success"

--- a/internal/api/handlers/common_test.go
+++ b/internal/api/handlers/common_test.go
@@ -64,6 +64,9 @@ func (nilScanServicer) GetScanSummary(_ context.Context, _ uuid.UUID) (*db.ScanS
 func (nilScanServicer) GetProfile(_ context.Context, _ string) (*db.ScanProfile, error) {
 	panic("nilScanServicer: GetProfile called unexpectedly")
 }
+func (nilScanServicer) GetScanDiff(_ context.Context, _, _ uuid.UUID) (*db.ScanDiff, error) {
+	panic("nilScanServicer: GetScanDiff called unexpectedly")
+}
 
 // nilScheduleServicer is a ScheduleServicer that panics if any method is called.
 type nilScheduleServicer struct{}

--- a/internal/api/handlers/export_host.go
+++ b/internal/api/handlers/export_host.go
@@ -1,0 +1,189 @@
+// Package handlers provides HTTP request handlers for the Scanorama API.
+// This file implements the host export endpoint that streams hosts as CSV or JSON.
+package handlers
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+const (
+	exportPageSize      = 1000
+	exportFormatCSV     = "csv"
+	exportFormatJSON    = "json"
+	exportDefaultFormat = exportFormatCSV
+
+	// exportColHostname is the CSV column name for the hostname field.
+	exportColHostname = "hostname"
+)
+
+// ExportHosts handles GET /api/v1/hosts/export?format=csv|json
+// Streams all hosts matching the active filters without pagination.
+// Uses chunked reads (exportPageSize rows per page) to avoid buffering all rows.
+func (h *HostHandler) ExportHosts(w http.ResponseWriter, r *http.Request) {
+	format := r.URL.Query().Get("format")
+	if format != exportFormatCSV && format != exportFormatJSON {
+		format = exportDefaultFormat
+	}
+
+	filters := h.getHostFilters(r)
+	filename := fmt.Sprintf("hosts-%s.%s", time.Now().Format("2006-01-02"), format)
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+
+	if format == exportFormatCSV {
+		w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+		h.exportHostsCSV(w, r.Context(), filters)
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+		h.exportHostsJSON(w, r.Context(), filters)
+	}
+}
+
+// exportHostsCSV streams hosts in CSV format, paging through the DB in chunks.
+func (h *HostHandler) exportHostsCSV(w http.ResponseWriter, ctx context.Context, filters *db.HostFilters) {
+	cw := csv.NewWriter(w)
+
+	// Write header row.
+	header := []string{
+		"ip", exportColHostname, "mac", "vendor", "os",
+		responseKeyStatus, "first_seen", "last_seen", "open_port_count",
+	}
+	if err := cw.Write(header); err != nil {
+		return
+	}
+
+	offset := 0
+	for {
+		hosts, _, err := h.service.ListHosts(ctx, filters, offset, exportPageSize)
+		if err != nil {
+			h.logger.Error("export hosts read error", "offset", offset, "error", err)
+			break
+		}
+		if len(hosts) == 0 {
+			break
+		}
+
+		for _, host := range hosts {
+			if err := cw.Write(hostToCSVRow(host)); err != nil {
+				return
+			}
+		}
+		cw.Flush()
+
+		if len(hosts) < exportPageSize {
+			break
+		}
+		offset += exportPageSize
+	}
+
+	cw.Flush()
+}
+
+// exportHostsJSON streams hosts as a JSON array, paging through the DB in chunks.
+func (h *HostHandler) exportHostsJSON(w http.ResponseWriter, ctx context.Context, filters *db.HostFilters) {
+	enc := json.NewEncoder(w)
+	_, _ = fmt.Fprint(w, "[")
+
+	offset := 0
+	first := true
+	for {
+		hosts, _, err := h.service.ListHosts(ctx, filters, offset, exportPageSize)
+		if err != nil {
+			h.logger.Error("export hosts read error", "offset", offset, "error", err)
+			break
+		}
+		if len(hosts) == 0 {
+			break
+		}
+
+		for _, host := range hosts {
+			if !first {
+				_, _ = fmt.Fprint(w, ",")
+			}
+			first = false
+			if encErr := enc.Encode(hostToExportJSON(host)); encErr != nil {
+				return
+			}
+		}
+
+		if len(hosts) < exportPageSize {
+			break
+		}
+		offset += exportPageSize
+	}
+
+	_, _ = fmt.Fprint(w, "]")
+}
+
+// hostExportRow is the JSON shape for a single exported host.
+type hostExportRow struct {
+	IP            string `json:"ip"`
+	Hostname      string `json:"hostname"`
+	MAC           string `json:"mac"`
+	Vendor        string `json:"vendor"`
+	OS            string `json:"os"`
+	Status        string `json:"status"`
+	FirstSeen     string `json:"first_seen"`
+	LastSeen      string `json:"last_seen"`
+	OpenPortCount int    `json:"open_port_count"`
+}
+
+func hostToExportJSON(host *db.Host) hostExportRow {
+	row := hostExportRow{
+		IP:            host.IPAddress.String(),
+		Status:        host.Status,
+		FirstSeen:     host.FirstSeen.UTC().Format(time.RFC3339),
+		LastSeen:      host.LastSeen.UTC().Format(time.RFC3339),
+		OpenPortCount: host.TotalPorts,
+	}
+	if host.Hostname != nil {
+		row.Hostname = *host.Hostname
+	}
+	if host.MACAddress != nil {
+		row.MAC = host.MACAddress.String()
+	}
+	if host.Vendor != nil {
+		row.Vendor = *host.Vendor
+	}
+	if host.OSFamily != nil {
+		row.OS = *host.OSFamily
+	}
+	return row
+}
+
+func hostToCSVRow(host *db.Host) []string {
+	hostname := ""
+	if host.Hostname != nil {
+		hostname = *host.Hostname
+	}
+	mac := ""
+	if host.MACAddress != nil {
+		mac = host.MACAddress.String()
+	}
+	vendor := ""
+	if host.Vendor != nil {
+		vendor = *host.Vendor
+	}
+	osFamily := ""
+	if host.OSFamily != nil {
+		osFamily = *host.OSFamily
+	}
+	return []string{
+		host.IPAddress.String(),
+		hostname,
+		mac,
+		vendor,
+		osFamily,
+		host.Status,
+		host.FirstSeen.UTC().Format(time.RFC3339),
+		host.LastSeen.UTC().Format(time.RFC3339),
+		strconv.Itoa(host.TotalPorts),
+	}
+}

--- a/internal/api/handlers/export_host_test.go
+++ b/internal/api/handlers/export_host_test.go
@@ -1,0 +1,223 @@
+package handlers
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+// sampleHost builds a minimal *db.Host for export tests.
+func sampleHost(ip string) *db.Host {
+	hostname := "testhost.local"
+	vendor := "Acme Corp"
+	osFamily := "Linux"
+	return &db.Host{
+		IPAddress:  db.IPAddr{IP: net.ParseIP(ip)},
+		Hostname:   &hostname,
+		Vendor:     &vendor,
+		OSFamily:   &osFamily,
+		Status:     "up",
+		TotalPorts: 3,
+		FirstSeen:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		LastSeen:   time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestHostHandler_ExportHosts_DefaultsToCSV(t *testing.T) {
+	h, store, ctrl := newHostHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	// Returning 1 host (< exportPageSize) ends the loop on the first page.
+	store.EXPECT().
+		ListHosts(gomock.Any(), gomock.Any(), 0, exportPageSize).
+		Return([]*db.Host{sampleHost("10.0.0.1")}, int64(1), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts/export", nil)
+	w := httptest.NewRecorder()
+	h.ExportHosts(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "hosts-")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), ".csv")
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/csv")
+}
+
+func TestHostHandler_ExportHosts_CSVFormat(t *testing.T) {
+	h, store, ctrl := newHostHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	host := sampleHost("192.168.1.1")
+
+	// One host returned on first page — loop stops without a second call.
+	store.EXPECT().
+		ListHosts(gomock.Any(), gomock.Any(), 0, exportPageSize).
+		Return([]*db.Host{host}, int64(1), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts/export?format=csv", nil)
+	w := httptest.NewRecorder()
+	h.ExportHosts(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	r := csv.NewReader(strings.NewReader(w.Body.String()))
+	rows, err := r.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, rows, 2) // header + 1 data row
+
+	header := rows[0]
+	assert.Equal(t, "ip", header[0])
+	assert.Equal(t, "hostname", header[1])
+	assert.Equal(t, "open_port_count", header[8])
+
+	data := rows[1]
+	assert.Equal(t, "192.168.1.1", data[0])
+	assert.Equal(t, "testhost.local", data[1])
+	assert.Equal(t, "up", data[5])
+	assert.Equal(t, "3", data[8]) // open_port_count field (TotalPorts)
+}
+
+func TestHostHandler_ExportHosts_JSONFormat(t *testing.T) {
+	h, store, ctrl := newHostHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	host := sampleHost("10.1.2.3")
+
+	// One host — loop stops after the first page.
+	store.EXPECT().
+		ListHosts(gomock.Any(), gomock.Any(), 0, exportPageSize).
+		Return([]*db.Host{host}, int64(1), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts/export?format=json", nil)
+	w := httptest.NewRecorder()
+	h.ExportHosts(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), ".json")
+
+	body := w.Body.String()
+	// Must be a JSON array.
+	var rows []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(body), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "10.1.2.3", rows[0]["ip"])
+	assert.Equal(t, "testhost.local", rows[0]["hostname"])
+	assert.Equal(t, "up", rows[0]["status"])
+	assert.Equal(t, float64(3), rows[0]["open_port_count"])
+}
+
+func TestHostHandler_ExportHosts_InvalidFormatDefaultsToCSV(t *testing.T) {
+	h, store, ctrl := newHostHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	store.EXPECT().
+		ListHosts(gomock.Any(), gomock.Any(), 0, exportPageSize).
+		Return([]*db.Host{}, int64(0), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts/export?format=xlsx", nil)
+	w := httptest.NewRecorder()
+	h.ExportHosts(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/csv")
+}
+
+func TestHostHandler_ExportHosts_ContentDispositionFilename(t *testing.T) {
+	h, store, ctrl := newHostHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	store.EXPECT().
+		ListHosts(gomock.Any(), gomock.Any(), 0, exportPageSize).
+		Return([]*db.Host{}, int64(0), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts/export", nil)
+	w := httptest.NewRecorder()
+	h.ExportHosts(w, req)
+
+	cd := w.Header().Get("Content-Disposition")
+	assert.True(t, strings.HasPrefix(cd, `attachment; filename="`), "expected attachment; got: %s", cd)
+	assert.Contains(t, cd, "hosts-")
+}
+
+func TestHostHandler_ExportHosts_ServiceError_EmitsNoRows(t *testing.T) {
+	h, store, ctrl := newHostHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	store.EXPECT().
+		ListHosts(gomock.Any(), gomock.Any(), 0, exportPageSize).
+		Return(nil, int64(0), fmt.Errorf("db error"))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts/export?format=csv", nil)
+	w := httptest.NewRecorder()
+	h.ExportHosts(w, req)
+
+	// On error the handler stops; the header row was already written.
+	assert.Equal(t, http.StatusOK, w.Code)
+	r := csv.NewReader(strings.NewReader(w.Body.String()))
+	rows, _ := r.ReadAll()
+	assert.Len(t, rows, 1, "only the header row should be present on error")
+}
+
+func TestHostHandler_ExportHosts_ServiceError_JSON_EmitsEmptyArray(t *testing.T) {
+	h, store, ctrl := newHostHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	store.EXPECT().
+		ListHosts(gomock.Any(), gomock.Any(), 0, exportPageSize).
+		Return(nil, int64(0), fmt.Errorf("db error"))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts/export?format=json", nil)
+	w := httptest.NewRecorder()
+	h.ExportHosts(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &rows))
+	assert.Empty(t, rows)
+}
+
+func TestHostHandler_ExportHosts_MultiPage_CSV(t *testing.T) {
+	h, store, ctrl := newHostHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	// Build a full first page of hosts.
+	page1 := make([]*db.Host, exportPageSize)
+	for i := range page1 {
+		page1[i] = sampleHost(fmt.Sprintf("10.0.%d.%d", i/256, i%256))
+	}
+	page2 := []*db.Host{sampleHost("10.1.0.1")}
+
+	// First call returns a full page → loop continues.
+	// Second call returns a partial page → loop exits.
+	gomock.InOrder(
+		store.EXPECT().
+			ListHosts(gomock.Any(), gomock.Any(), 0, exportPageSize).
+			Return(page1, int64(exportPageSize+1), nil),
+		store.EXPECT().
+			ListHosts(gomock.Any(), gomock.Any(), exportPageSize, exportPageSize).
+			Return(page2, int64(exportPageSize+1), nil),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts/export?format=csv", nil)
+	w := httptest.NewRecorder()
+	h.ExportHosts(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	r := csv.NewReader(strings.NewReader(w.Body.String()))
+	rows, err := r.ReadAll()
+	require.NoError(t, err)
+	// header + exportPageSize data rows + 1 overflow row
+	assert.Len(t, rows, exportPageSize+2)
+}

--- a/internal/api/handlers/export_scan.go
+++ b/internal/api/handlers/export_scan.go
@@ -1,0 +1,173 @@
+// Package handlers provides HTTP request handlers for the Scanorama API.
+// This file implements the scan export endpoint that streams scans as CSV or JSON.
+package handlers
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+// ExportScans handles GET /api/v1/scans/export?format=csv|json
+// Streams all scans matching the active filters without pagination.
+// Uses chunked reads (exportPageSize rows per page) to avoid buffering all rows.
+func (h *ScanHandler) ExportScans(w http.ResponseWriter, r *http.Request) {
+	format := r.URL.Query().Get("format")
+	if format != exportFormatCSV && format != exportFormatJSON {
+		format = exportDefaultFormat
+	}
+
+	filters := h.getScanFilters(r)
+	filename := fmt.Sprintf("scans-%s.%s", time.Now().Format("2006-01-02"), format)
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+
+	if format == exportFormatCSV {
+		w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+		h.exportScansCSV(w, r.Context(), filters)
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+		h.exportScansJSON(w, r.Context(), filters)
+	}
+}
+
+// exportScansCSV streams scans in CSV format, paging through the DB in chunks.
+func (h *ScanHandler) exportScansCSV(w http.ResponseWriter, ctx context.Context, filters db.ScanFilters) {
+	cw := csv.NewWriter(w)
+
+	// Write header row.
+	header := []string{
+		"scan_id", "targets", "profile_id", responseKeyStatus,
+		"started_at", "duration", "ports_scanned",
+	}
+	if err := cw.Write(header); err != nil {
+		return
+	}
+
+	offset := 0
+	for {
+		scans, _, err := h.service.ListScans(ctx, filters, offset, exportPageSize)
+		if err != nil {
+			h.logger.Error("export scans read error", "offset", offset, "error", err)
+			break
+		}
+		if len(scans) == 0 {
+			break
+		}
+
+		for _, scan := range scans {
+			if err := cw.Write(scanToCSVRow(scan)); err != nil {
+				return
+			}
+		}
+		cw.Flush()
+
+		if len(scans) < exportPageSize {
+			break
+		}
+		offset += exportPageSize
+	}
+
+	cw.Flush()
+}
+
+// exportScansJSON streams scans as a JSON array, paging through the DB in chunks.
+func (h *ScanHandler) exportScansJSON(w http.ResponseWriter, ctx context.Context, filters db.ScanFilters) {
+	enc := json.NewEncoder(w)
+	_, _ = fmt.Fprint(w, "[")
+
+	offset := 0
+	first := true
+	for {
+		scans, _, err := h.service.ListScans(ctx, filters, offset, exportPageSize)
+		if err != nil {
+			h.logger.Error("export scans read error", "offset", offset, "error", err)
+			break
+		}
+		if len(scans) == 0 {
+			break
+		}
+
+		for _, scan := range scans {
+			if !first {
+				_, _ = fmt.Fprint(w, ",")
+			}
+			first = false
+			if encErr := enc.Encode(scanToExportJSON(scan)); encErr != nil {
+				return
+			}
+		}
+
+		if len(scans) < exportPageSize {
+			break
+		}
+		offset += exportPageSize
+	}
+
+	_, _ = fmt.Fprint(w, "]")
+}
+
+// scanExportRow is the JSON shape for a single exported scan.
+type scanExportRow struct {
+	ScanID       string `json:"scan_id"`
+	Targets      string `json:"targets"`
+	ProfileID    string `json:"profile_id"`
+	Status       string `json:"status"`
+	StartedAt    string `json:"started_at"`
+	Duration     string `json:"duration"`
+	PortsScanned string `json:"ports_scanned"`
+}
+
+func scanToExportJSON(scan *db.Scan) scanExportRow {
+	row := scanExportRow{
+		ScanID:  scan.ID.String(),
+		Targets: strings.Join(scan.Targets, ";"),
+		Status:  scan.Status,
+	}
+	if scan.ProfileID != nil {
+		row.ProfileID = *scan.ProfileID
+	}
+	if scan.StartedAt != nil {
+		row.StartedAt = scan.StartedAt.UTC().Format(time.RFC3339)
+	}
+	if scan.DurationStr != nil {
+		row.Duration = *scan.DurationStr
+	}
+	if scan.PortsScanned != nil {
+		row.PortsScanned = *scan.PortsScanned
+	}
+	return row
+}
+
+func scanToCSVRow(scan *db.Scan) []string {
+	profileID := ""
+	if scan.ProfileID != nil {
+		profileID = *scan.ProfileID
+	}
+	startedAt := ""
+	if scan.StartedAt != nil {
+		startedAt = scan.StartedAt.UTC().Format(time.RFC3339)
+	}
+	duration := ""
+	if scan.DurationStr != nil {
+		duration = *scan.DurationStr
+	}
+	portsScanned := ""
+	if scan.PortsScanned != nil {
+		portsScanned = *scan.PortsScanned
+	}
+	return []string{
+		scan.ID.String(),
+		strings.Join(scan.Targets, ";"),
+		profileID,
+		scan.Status,
+		startedAt,
+		duration,
+		portsScanned,
+	}
+}

--- a/internal/api/handlers/export_scan_test.go
+++ b/internal/api/handlers/export_scan_test.go
@@ -1,0 +1,221 @@
+package handlers
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+// sampleScan builds a minimal *db.Scan for export tests.
+func sampleScan() *db.Scan {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	profileID := "profile-abc"
+	durationStr := "5m30s"
+	portsScanned := "22 open / 100 total"
+	return &db.Scan{
+		ID:           uuid.New(),
+		Targets:      []string{"10.0.0.0/24", "10.0.1.0/24"},
+		ProfileID:    &profileID,
+		Status:       "completed",
+		StartedAt:    &now,
+		DurationStr:  &durationStr,
+		PortsScanned: &portsScanned,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+}
+
+func TestScanHandler_ExportScans_DefaultsToCSV(t *testing.T) {
+	h, store, ctrl := newScanHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	// One scan returned — loop stops after the first page.
+	store.EXPECT().
+		ListScans(gomock.Any(), gomock.Any(), 0, exportPageSize).
+		Return([]*db.Scan{sampleScan()}, int64(1), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scans/export", nil)
+	w := httptest.NewRecorder()
+	h.ExportScans(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "scans-")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), ".csv")
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/csv")
+}
+
+func TestScanHandler_ExportScans_CSVFormat(t *testing.T) {
+	h, store, ctrl := newScanHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	scan := sampleScan()
+
+	// One scan — loop stops after first page.
+	store.EXPECT().
+		ListScans(gomock.Any(), gomock.Any(), 0, exportPageSize).
+		Return([]*db.Scan{scan}, int64(1), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scans/export?format=csv", nil)
+	w := httptest.NewRecorder()
+	h.ExportScans(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	r := csv.NewReader(strings.NewReader(w.Body.String()))
+	rows, err := r.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, rows, 2) // header + 1 data row
+
+	header := rows[0]
+	assert.Equal(t, "scan_id", header[0])
+	assert.Equal(t, "targets", header[1])
+	assert.Equal(t, "profile_id", header[2])
+	assert.Equal(t, "status", header[3])
+
+	data := rows[1]
+	assert.Equal(t, scan.ID.String(), data[0])
+	assert.Equal(t, "10.0.0.0/24;10.0.1.0/24", data[1])
+	assert.Equal(t, "profile-abc", data[2])
+	assert.Equal(t, "completed", data[3])
+	assert.Equal(t, "5m30s", data[5])
+	assert.Equal(t, "22 open / 100 total", data[6])
+}
+
+func TestScanHandler_ExportScans_JSONFormat(t *testing.T) {
+	h, store, ctrl := newScanHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	scan := sampleScan()
+
+	// One scan — loop stops after first page.
+	store.EXPECT().
+		ListScans(gomock.Any(), gomock.Any(), 0, exportPageSize).
+		Return([]*db.Scan{scan}, int64(1), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scans/export?format=json", nil)
+	w := httptest.NewRecorder()
+	h.ExportScans(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), ".json")
+
+	var rows []map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, scan.ID.String(), rows[0]["scan_id"])
+	assert.Equal(t, "10.0.0.0/24;10.0.1.0/24", rows[0]["targets"])
+	assert.Equal(t, "profile-abc", rows[0]["profile_id"])
+	assert.Equal(t, "completed", rows[0]["status"])
+}
+
+func TestScanHandler_ExportScans_InvalidFormatDefaultsToCSV(t *testing.T) {
+	h, store, ctrl := newScanHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	store.EXPECT().
+		ListScans(gomock.Any(), gomock.Any(), 0, exportPageSize).
+		Return([]*db.Scan{}, int64(0), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scans/export?format=xml", nil)
+	w := httptest.NewRecorder()
+	h.ExportScans(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/csv")
+}
+
+func TestScanHandler_ExportScans_ContentDispositionFilename(t *testing.T) {
+	h, store, ctrl := newScanHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	store.EXPECT().
+		ListScans(gomock.Any(), gomock.Any(), 0, exportPageSize).
+		Return([]*db.Scan{}, int64(0), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scans/export", nil)
+	w := httptest.NewRecorder()
+	h.ExportScans(w, req)
+
+	cd := w.Header().Get("Content-Disposition")
+	assert.True(t, strings.HasPrefix(cd, `attachment; filename="`), "expected attachment; got: %s", cd)
+	assert.Contains(t, cd, "scans-")
+}
+
+func TestScanHandler_ExportScans_ServiceError_EmitsNoRows(t *testing.T) {
+	h, store, ctrl := newScanHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	store.EXPECT().
+		ListScans(gomock.Any(), gomock.Any(), 0, exportPageSize).
+		Return(nil, int64(0), fmt.Errorf("db error"))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scans/export?format=csv", nil)
+	w := httptest.NewRecorder()
+	h.ExportScans(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	r := csv.NewReader(strings.NewReader(w.Body.String()))
+	rows, _ := r.ReadAll()
+	assert.Len(t, rows, 1, "only the header row should be present on error")
+}
+
+func TestScanHandler_ExportScans_ServiceError_JSON_EmitsEmptyArray(t *testing.T) {
+	h, store, ctrl := newScanHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	store.EXPECT().
+		ListScans(gomock.Any(), gomock.Any(), 0, exportPageSize).
+		Return(nil, int64(0), fmt.Errorf("db error"))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scans/export?format=json", nil)
+	w := httptest.NewRecorder()
+	h.ExportScans(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &rows))
+	assert.Empty(t, rows)
+}
+
+func TestScanHandler_ExportScans_MultiPage_CSV(t *testing.T) {
+	h, store, ctrl := newScanHandlerWithMock(t)
+	defer ctrl.Finish()
+
+	page1 := make([]*db.Scan, exportPageSize)
+	for i := range page1 {
+		page1[i] = sampleScan()
+	}
+	page2 := []*db.Scan{sampleScan()}
+
+	gomock.InOrder(
+		store.EXPECT().
+			ListScans(gomock.Any(), gomock.Any(), 0, exportPageSize).
+			Return(page1, int64(exportPageSize+1), nil),
+		store.EXPECT().
+			ListScans(gomock.Any(), gomock.Any(), exportPageSize, exportPageSize).
+			Return(page2, int64(exportPageSize+1), nil),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scans/export?format=csv", nil)
+	w := httptest.NewRecorder()
+	h.ExportScans(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	r := csv.NewReader(strings.NewReader(w.Body.String()))
+	rows, err := r.ReadAll()
+	require.NoError(t, err)
+	assert.Len(t, rows, exportPageSize+2)
+}

--- a/internal/api/handlers/host.go
+++ b/internal/api/handlers/host.go
@@ -19,7 +19,10 @@ import (
 	"github.com/anstrom/scanorama/internal/services"
 )
 
-const entityTypeHost = "host"
+const (
+	entityTypeHost  = "host"
+	entityTypeHosts = "hosts"
+)
 
 // Validation constants for host fields.
 const (
@@ -175,7 +178,7 @@ type HostScanResponse struct {
 // ListHosts handles GET /api/v1/hosts - list all hosts with pagination.
 func (h *HostHandler) ListHosts(w http.ResponseWriter, r *http.Request) {
 	listOp := &ListOperation[*db.Host, *db.HostFilters]{
-		EntityType: "hosts",
+		EntityType: entityTypeHosts,
 		MetricName: "api_hosts_listed_total",
 		Logger:     h.logger,
 		Metrics:    h.metrics,

--- a/internal/api/handlers/interfaces.go
+++ b/internal/api/handlers/interfaces.go
@@ -156,6 +156,16 @@ type GroupServicer interface {
 	GetGroupMembers(ctx context.Context, groupID uuid.UUID, offset, limit int) ([]*db.Host, int64, error)
 }
 
+// AlertServicer is the service-level interface consumed by AlertHandler.
+type AlertServicer interface {
+	ListAlertRules(ctx context.Context) ([]*db.AlertRule, error)
+	ListAlertRulesForHost(ctx context.Context, hostID uuid.UUID) ([]*db.AlertRule, error)
+	CreateAlertRule(ctx context.Context, input db.CreateAlertRuleInput) (*db.AlertRule, error)
+	GetAlertRule(ctx context.Context, id uuid.UUID) (*db.AlertRule, error)
+	UpdateAlertRule(ctx context.Context, id uuid.UUID, input db.UpdateAlertRuleInput) (*db.AlertRule, error)
+	DeleteAlertRule(ctx context.Context, id uuid.UUID) error
+}
+
 // WebhookServicer is the service-level interface consumed by WebhookHandler.
 //
 //nolint:dupl // interface is structurally similar to the test mock by design

--- a/internal/api/handlers/interfaces.go
+++ b/internal/api/handlers/interfaces.go
@@ -155,3 +155,16 @@ type GroupServicer interface {
 	RemoveHostsFromGroup(ctx context.Context, groupID uuid.UUID, hostIDs []uuid.UUID) error
 	GetGroupMembers(ctx context.Context, groupID uuid.UUID, offset, limit int) ([]*db.Host, int64, error)
 }
+
+// WebhookServicer is the service-level interface consumed by WebhookHandler.
+//
+//nolint:dupl // interface is structurally similar to the test mock by design
+type WebhookServicer interface {
+	ListWebhooks(ctx context.Context) ([]*db.WebhookEndpoint, error)
+	CreateWebhook(ctx context.Context, input db.CreateWebhookInput) (*db.WebhookEndpoint, error)
+	GetWebhook(ctx context.Context, id uuid.UUID) (*db.WebhookEndpoint, error)
+	UpdateWebhook(ctx context.Context, id uuid.UUID, input db.UpdateWebhookInput) (*db.WebhookEndpoint, error)
+	DeleteWebhook(ctx context.Context, id uuid.UUID) error
+	SendTestDelivery(ctx context.Context, id uuid.UUID) error
+	ListDeliveryLogs(ctx context.Context, endpointID uuid.UUID, limit int) ([]*db.WebhookDeliveryLog, error)
+}

--- a/internal/api/handlers/interfaces.go
+++ b/internal/api/handlers/interfaces.go
@@ -32,6 +32,8 @@ type ScanServicer interface {
 	GetScanResults(ctx context.Context, scanID uuid.UUID, offset, limit int) ([]*db.ScanResult, int64, error)
 	GetScanSummary(ctx context.Context, scanID uuid.UUID) (*db.ScanSummary, error)
 	GetProfile(ctx context.Context, id string) (*db.ScanProfile, error)
+	// GetScanDiff compares two scans of the same host and returns a structured diff.
+	GetScanDiff(ctx context.Context, scanAID, scanBID uuid.UUID) (*db.ScanDiff, error)
 }
 
 // ScheduleServicer is the service-level interface consumed by ScheduleHandler.

--- a/internal/api/handlers/mocks/mock_scan_servicer.go
+++ b/internal/api/handlers/mocks/mock_scan_servicer.go
@@ -196,6 +196,46 @@ func (c *MockScanServicerGetProfileCall) DoAndReturn(f func(context.Context, str
 	return c
 }
 
+// GetScanDiff mocks base method.
+func (m *MockScanServicer) GetScanDiff(ctx context.Context, scanAID, scanBID uuid.UUID) (*db.ScanDiff, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetScanDiff", ctx, scanAID, scanBID)
+	ret0, _ := ret[0].(*db.ScanDiff)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetScanDiff indicates an expected call of GetScanDiff.
+func (mr *MockScanServicerMockRecorder) GetScanDiff(ctx, scanAID, scanBID any) *MockScanServicerGetScanDiffCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScanDiff",
+		reflect.TypeOf((*MockScanServicer)(nil).GetScanDiff), ctx, scanAID, scanBID)
+	return &MockScanServicerGetScanDiffCall{Call: call}
+}
+
+// MockScanServicerGetScanDiffCall wrap *gomock.Call
+type MockScanServicerGetScanDiffCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockScanServicerGetScanDiffCall) Return(arg0 *db.ScanDiff, arg1 error) *MockScanServicerGetScanDiffCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockScanServicerGetScanDiffCall) Do(f func(context.Context, uuid.UUID, uuid.UUID) (*db.ScanDiff, error)) *MockScanServicerGetScanDiffCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockScanServicerGetScanDiffCall) DoAndReturn(f func(context.Context, uuid.UUID, uuid.UUID) (*db.ScanDiff, error)) *MockScanServicerGetScanDiffCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetScan mocks base method.
 func (m *MockScanServicer) GetScan(ctx context.Context, id uuid.UUID) (*db.Scan, error) {
 	m.ctrl.T.Helper()

--- a/internal/api/handlers/mocks/mock_scan_servicer.go
+++ b/internal/api/handlers/mocks/mock_scan_servicer.go
@@ -196,46 +196,6 @@ func (c *MockScanServicerGetProfileCall) DoAndReturn(f func(context.Context, str
 	return c
 }
 
-// GetScanDiff mocks base method.
-func (m *MockScanServicer) GetScanDiff(ctx context.Context, scanAID, scanBID uuid.UUID) (*db.ScanDiff, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetScanDiff", ctx, scanAID, scanBID)
-	ret0, _ := ret[0].(*db.ScanDiff)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetScanDiff indicates an expected call of GetScanDiff.
-func (mr *MockScanServicerMockRecorder) GetScanDiff(ctx, scanAID, scanBID any) *MockScanServicerGetScanDiffCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScanDiff",
-		reflect.TypeOf((*MockScanServicer)(nil).GetScanDiff), ctx, scanAID, scanBID)
-	return &MockScanServicerGetScanDiffCall{Call: call}
-}
-
-// MockScanServicerGetScanDiffCall wrap *gomock.Call
-type MockScanServicerGetScanDiffCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockScanServicerGetScanDiffCall) Return(arg0 *db.ScanDiff, arg1 error) *MockScanServicerGetScanDiffCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockScanServicerGetScanDiffCall) Do(f func(context.Context, uuid.UUID, uuid.UUID) (*db.ScanDiff, error)) *MockScanServicerGetScanDiffCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockScanServicerGetScanDiffCall) DoAndReturn(f func(context.Context, uuid.UUID, uuid.UUID) (*db.ScanDiff, error)) *MockScanServicerGetScanDiffCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetScan mocks base method.
 func (m *MockScanServicer) GetScan(ctx context.Context, id uuid.UUID) (*db.Scan, error) {
 	m.ctrl.T.Helper()
@@ -271,6 +231,45 @@ func (c *MockScanServicerGetScanCall) Do(f func(context.Context, uuid.UUID) (*db
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockScanServicerGetScanCall) DoAndReturn(f func(context.Context, uuid.UUID) (*db.Scan, error)) *MockScanServicerGetScanCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetScanDiff mocks base method.
+func (m *MockScanServicer) GetScanDiff(ctx context.Context, scanAID, scanBID uuid.UUID) (*db.ScanDiff, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetScanDiff", ctx, scanAID, scanBID)
+	ret0, _ := ret[0].(*db.ScanDiff)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetScanDiff indicates an expected call of GetScanDiff.
+func (mr *MockScanServicerMockRecorder) GetScanDiff(ctx, scanAID, scanBID any) *MockScanServicerGetScanDiffCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScanDiff", reflect.TypeOf((*MockScanServicer)(nil).GetScanDiff), ctx, scanAID, scanBID)
+	return &MockScanServicerGetScanDiffCall{Call: call}
+}
+
+// MockScanServicerGetScanDiffCall wrap *gomock.Call
+type MockScanServicerGetScanDiffCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockScanServicerGetScanDiffCall) Return(arg0 *db.ScanDiff, arg1 error) *MockScanServicerGetScanDiffCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockScanServicerGetScanDiffCall) Do(f func(context.Context, uuid.UUID, uuid.UUID) (*db.ScanDiff, error)) *MockScanServicerGetScanDiffCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockScanServicerGetScanDiffCall) DoAndReturn(f func(context.Context, uuid.UUID, uuid.UUID) (*db.ScanDiff, error)) *MockScanServicerGetScanDiffCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/api/handlers/profile.go
+++ b/internal/api/handlers/profile.go
@@ -51,6 +51,8 @@ func NewDuration(d time.Duration) Duration {
 	return Duration(d)
 }
 
+const entityTypeProfiles = "profiles"
+
 // Profile validation constants.
 const (
 	maxProfileNameLength  = 255
@@ -157,7 +159,7 @@ type ProfileResponse struct {
 // ListProfiles handles GET /api/v1/profiles - list all profiles with pagination.
 func (h *ProfileHandler) ListProfiles(w http.ResponseWriter, r *http.Request) {
 	listOp := &ListOperation[*db.ScanProfile, db.ProfileFilters]{
-		EntityType: "profiles",
+		EntityType: entityTypeProfiles,
 		MetricName: "api_profiles_listed_total",
 		Logger:     h.logger,
 		Metrics:    h.metrics,

--- a/internal/api/handlers/scan.go
+++ b/internal/api/handlers/scan.go
@@ -730,4 +730,47 @@ func (h *ScanHandler) resultToResponse(result *db.ScanResult) ScanResult {
 	}
 }
 
+// GetScanDiff handles GET /api/v1/scans/diff?a=<id>&b=<id>
+// It compares two scans of the same host and returns a structured port diff.
+func (h *ScanHandler) GetScanDiff(w http.ResponseWriter, r *http.Request) {
+	aStr := r.URL.Query().Get("a")
+	bStr := r.URL.Query().Get("b")
+
+	if aStr == "" || bStr == "" {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("query params 'a' and 'b' are required"))
+		return
+	}
+
+	scanAID, err := uuid.Parse(aStr)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid scan id 'a': must be a valid UUID"))
+		return
+	}
+
+	scanBID, err := uuid.Parse(bStr)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid scan id 'b': must be a valid UUID"))
+		return
+	}
+
+	diff, err := h.service.GetScanDiff(r.Context(), scanAID, scanBID)
+	if err != nil {
+		if errors.IsCode(err, errors.CodeNotFound) {
+			writeError(w, r, http.StatusNotFound, err)
+			return
+		}
+		if errors.IsCode(err, errors.CodeValidation) {
+			writeError(w, r, http.StatusBadRequest, err)
+			return
+		}
+		h.logger.Error("Failed to compute scan diff",
+			"scan_a", aStr, "scan_b", bStr, "error", err)
+		writeError(w, r, http.StatusInternalServerError,
+			fmt.Errorf("failed to compute scan diff: %w", err))
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, diff)
+}
+
 // Helper functions for response utilities

--- a/internal/api/handlers/scan.go
+++ b/internal/api/handlers/scan.go
@@ -29,6 +29,7 @@ const (
 	scanStatusFailed    = "failed"
 	scanStatusRunning   = "running"
 	entityTypeScan      = "scan"
+	entityTypeScans     = "scans"
 )
 
 // ScanHandler handles scan-related API endpoints.
@@ -152,7 +153,7 @@ type ScanResult struct {
 // ListScans handles GET /api/v1/scans - list scans with filtering and pagination.
 func (h *ScanHandler) ListScans(w http.ResponseWriter, r *http.Request) {
 	listOp := &ListOperation[*db.Scan, db.ScanFilters]{
-		EntityType: "scans",
+		EntityType: entityTypeScans,
 		MetricName: "api_scans_listed_total",
 		Logger:     h.logger,
 		Metrics:    h.metrics,

--- a/internal/api/handlers/scan_diff_test.go
+++ b/internal/api/handlers/scan_diff_test.go
@@ -1,0 +1,186 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/db"
+	apierrors "github.com/anstrom/scanorama/internal/errors"
+	"github.com/anstrom/scanorama/internal/metrics"
+)
+
+// mockDiffScanServicer is a ScanServicer that delegates only GetScanDiff.
+type mockDiffScanServicer struct {
+	nilScanServicer
+	getScanDiffFn func(ctx context.Context, a, b uuid.UUID) (*db.ScanDiff, error)
+}
+
+func (m *mockDiffScanServicer) GetScanDiff(ctx context.Context, a, b uuid.UUID) (*db.ScanDiff, error) {
+	return m.getScanDiffFn(ctx, a, b)
+}
+
+func TestScanHandler_GetScanDiff(t *testing.T) {
+	idA := uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000001")
+	idB := uuid.MustParse("bbbbbbbb-0000-0000-0000-000000000002")
+	hostID := uuid.MustParse("cccccccc-0000-0000-0000-000000000003")
+
+	svcName := "https"
+	prevSvc := "http"
+
+	successDiff := &db.ScanDiff{
+		ScanAID: idA,
+		ScanBID: idB,
+		HostID:  hostID,
+		Ports: []db.ScanDiffEntry{
+			{Port: 443, Protocol: "tcp", State: "open", ServiceName: &svcName, Status: db.DiffStatusNew},
+			{Port: 80, Protocol: "tcp", State: "open", ServiceName: &svcName, Status: db.DiffStatusChanged,
+				PrevState:       func() *string { s := "filtered"; return &s }(),
+				PrevServiceName: &prevSvc,
+			},
+		},
+		OSChanged:      false,
+		NewCount:       1,
+		ClosedCount:    0,
+		ChangedCount:   1,
+		UnchangedCount: 0,
+	}
+
+	tests := []struct {
+		name           string
+		queryString    string
+		svc            ScanServicer
+		expectedStatus int
+		checkBody      func(t *testing.T, body []byte)
+	}{
+		{
+			name:        "200 success",
+			queryString: "?a=" + idA.String() + "&b=" + idB.String(),
+			svc: &mockDiffScanServicer{
+				getScanDiffFn: func(_ context.Context, a, b uuid.UUID) (*db.ScanDiff, error) {
+					assert.Equal(t, idA, a)
+					assert.Equal(t, idB, b)
+					return successDiff, nil
+				},
+			},
+			expectedStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body []byte) {
+				var raw map[string]any
+				require.NoError(t, json.Unmarshal(body, &raw))
+				assert.Equal(t, idA.String(), raw["scan_a_id"])
+				assert.Equal(t, idB.String(), raw["scan_b_id"])
+				assert.Equal(t, hostID.String(), raw["host_id"])
+				assert.InDelta(t, 1, raw["new_count"], 0)
+				assert.InDelta(t, 1, raw["changed_count"], 0)
+				assert.False(t, raw["os_changed"].(bool))
+				ports, ok := raw["ports"].([]any)
+				require.True(t, ok)
+				assert.Len(t, ports, 2)
+			},
+		},
+		{
+			name:           "400 missing a param",
+			queryString:    "?b=" + idB.String(),
+			svc:            nilScanServicer{},
+			expectedStatus: http.StatusBadRequest,
+			checkBody: func(t *testing.T, body []byte) {
+				var raw map[string]any
+				require.NoError(t, json.Unmarshal(body, &raw))
+				assert.Contains(t, raw["message"], "'a'")
+			},
+		},
+		{
+			name:           "400 missing b param",
+			queryString:    "?a=" + idA.String(),
+			svc:            nilScanServicer{},
+			expectedStatus: http.StatusBadRequest,
+			checkBody: func(t *testing.T, body []byte) {
+				var raw map[string]any
+				require.NoError(t, json.Unmarshal(body, &raw))
+				assert.Contains(t, raw["message"], "'b'")
+			},
+		},
+		{
+			name:           "400 invalid UUID for a",
+			queryString:    "?a=not-a-uuid&b=" + idB.String(),
+			svc:            nilScanServicer{},
+			expectedStatus: http.StatusBadRequest,
+			checkBody: func(t *testing.T, body []byte) {
+				var raw map[string]any
+				require.NoError(t, json.Unmarshal(body, &raw))
+				assert.Contains(t, raw["message"], "invalid scan id 'a'")
+			},
+		},
+		{
+			name:           "400 invalid UUID for b",
+			queryString:    "?a=" + idA.String() + "&b=not-a-uuid",
+			svc:            nilScanServicer{},
+			expectedStatus: http.StatusBadRequest,
+			checkBody: func(t *testing.T, body []byte) {
+				var raw map[string]any
+				require.NoError(t, json.Unmarshal(body, &raw))
+				assert.Contains(t, raw["message"], "invalid scan id 'b'")
+			},
+		},
+		{
+			name:        "400 scans from different hosts",
+			queryString: "?a=" + idA.String() + "&b=" + idB.String(),
+			svc: &mockDiffScanServicer{
+				getScanDiffFn: func(_ context.Context, _, _ uuid.UUID) (*db.ScanDiff, error) {
+					return nil, apierrors.NewScanError(apierrors.CodeValidation,
+						"scans belong to different hosts")
+				},
+			},
+			expectedStatus: http.StatusBadRequest,
+			checkBody: func(t *testing.T, body []byte) {
+				var raw map[string]any
+				require.NoError(t, json.Unmarshal(body, &raw))
+				assert.Contains(t, raw["message"], "different hosts")
+			},
+		},
+		{
+			name:        "404 scan not found",
+			queryString: "?a=" + idA.String() + "&b=" + idB.String(),
+			svc: &mockDiffScanServicer{
+				getScanDiffFn: func(_ context.Context, _, _ uuid.UUID) (*db.ScanDiff, error) {
+					return nil, apierrors.ErrNotFoundWithID("scan", idA.String())
+				},
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:        "500 service error",
+			queryString: "?a=" + idA.String() + "&b=" + idB.String(),
+			svc: &mockDiffScanServicer{
+				getScanDiffFn: func(_ context.Context, _, _ uuid.UUID) (*db.ScanDiff, error) {
+					return nil, fmt.Errorf("database connection failed")
+				},
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := createTestLogger()
+			h := NewScanHandler(tt.svc, logger, metrics.NewRegistry())
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/scans/diff"+tt.queryString, http.NoBody)
+			w := httptest.NewRecorder()
+
+			h.GetScanDiff(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.checkBody != nil {
+				tt.checkBody(t, w.Body.Bytes())
+			}
+		})
+	}
+}

--- a/internal/api/handlers/search.go
+++ b/internal/api/handlers/search.go
@@ -1,0 +1,94 @@
+// Package handlers provides HTTP request handlers for the Scanorama API.
+// This file implements the unified search endpoint.
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/anstrom/scanorama/internal/db"
+	apierrors "github.com/anstrom/scanorama/internal/errors"
+	"github.com/anstrom/scanorama/internal/metrics"
+)
+
+const (
+	searchDefaultLimit = 10
+	searchMaxLimit     = 50
+	searchMinQueryLen  = 2
+	searchMaxQueryLen  = 100
+)
+
+// SearchServicer is the service-level interface consumed by SearchHandler.
+type SearchServicer interface {
+	Search(ctx context.Context, q string, limit int) (*db.SearchResults, error)
+}
+
+// SearchHandler handles the unified search endpoint.
+type SearchHandler struct {
+	service SearchServicer
+	logger  *slog.Logger
+	metrics *metrics.Registry
+}
+
+// NewSearchHandler creates a new SearchHandler.
+func NewSearchHandler(service SearchServicer, logger *slog.Logger, m *metrics.Registry) *SearchHandler {
+	return &SearchHandler{
+		service: service,
+		logger:  logger.With("handler", "search"),
+		metrics: m,
+	}
+}
+
+// Search handles GET /api/v1/search.
+//
+//	@Summary		Unified cross-entity search
+//	@Description	Search across hosts, networks, scans, and profiles in a single request.
+//	@Tags			search
+//	@Produce		json
+//	@Param			q		query		string	true	"Search query (2–100 characters)"
+//	@Param			limit	query		int		false	"Maximum results per entity type (default 10, max 50)"
+//	@Success		200		{object}	db.SearchResults
+//	@Failure		400		{object}	ErrorResponse
+//	@Failure		500		{object}	ErrorResponse
+//	@Router			/search [get]
+func (h *SearchHandler) Search(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("q")
+	if len(q) < searchMinQueryLen {
+		writeError(w, r, http.StatusBadRequest,
+			apierrors.NewScanError(apierrors.CodeValidation, "q must be at least 2 characters"),
+		)
+		return
+	}
+	if len(q) > searchMaxQueryLen {
+		writeError(w, r, http.StatusBadRequest,
+			apierrors.NewScanError(apierrors.CodeValidation, "q must be at most 100 characters"),
+		)
+		return
+	}
+
+	limit := searchDefaultLimit
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 {
+			writeError(w, r, http.StatusBadRequest,
+				apierrors.NewScanError(apierrors.CodeValidation, "limit must be a positive integer"),
+			)
+			return
+		}
+		if n > searchMaxLimit {
+			n = searchMaxLimit
+		}
+		limit = n
+	}
+
+	results, err := h.service.Search(r.Context(), q, limit)
+	if err != nil {
+		h.logger.Error("search failed", "query", q, "error", err)
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, results)
+}

--- a/internal/api/handlers/search_test.go
+++ b/internal/api/handlers/search_test.go
@@ -1,0 +1,196 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/db"
+	"github.com/anstrom/scanorama/internal/metrics"
+)
+
+// ── mock ──────────────────────────────────────────────────────────────────────
+
+type mockSearchServicer struct {
+	searchFn func(ctx context.Context, q string, limit int) (*db.SearchResults, error)
+}
+
+func (m *mockSearchServicer) Search(
+	ctx context.Context, q string, limit int,
+) (*db.SearchResults, error) {
+	if m.searchFn != nil {
+		return m.searchFn(ctx, q, limit)
+	}
+	return &db.SearchResults{
+		Results: map[string][]db.SearchResult{
+			"hosts":    {},
+			"networks": {},
+			"scans":    {},
+			"profiles": {},
+		},
+		Total: 0,
+	}, nil
+}
+
+func newTestSearchHandler(svc SearchServicer) *SearchHandler {
+	return NewSearchHandler(svc, createTestLogger(), metrics.NewRegistry())
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func buildSearchRequest(query string) *http.Request {
+	u := &url.URL{Path: "/api/v1/search", RawQuery: url.Values{"q": {query}}.Encode()}
+	return httptest.NewRequest(http.MethodGet, u.String(), nil)
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+func TestSearchHandler_Success(t *testing.T) {
+	hostResult := db.SearchResult{
+		ID:    "host-uuid",
+		Label: "192.168.1.1 (myhost)",
+		URL:   "/hosts/host-uuid",
+		Type:  "host",
+	}
+
+	svc := &mockSearchServicer{
+		searchFn: func(_ context.Context, q string, limit int) (*db.SearchResults, error) {
+			assert.Equal(t, "myhost", q)
+			assert.Equal(t, searchDefaultLimit, limit)
+			return &db.SearchResults{
+				Results: map[string][]db.SearchResult{
+					"hosts":    {hostResult},
+					"networks": {},
+					"scans":    {},
+					"profiles": {},
+				},
+				Total: 1,
+			}, nil
+		},
+	}
+
+	req := buildSearchRequest("myhost")
+	w := httptest.NewRecorder()
+	newTestSearchHandler(svc).Search(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var raw map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&raw))
+	assert.EqualValues(t, float64(1), raw["total"])
+
+	results, ok := raw["results"].(map[string]any)
+	require.True(t, ok)
+	hosts, ok := results["hosts"].([]any)
+	require.True(t, ok)
+	require.Len(t, hosts, 1)
+
+	h := hosts[0].(map[string]any)
+	assert.Equal(t, "host-uuid", h["id"])
+	assert.Equal(t, "192.168.1.1 (myhost)", h["label"])
+	assert.Equal(t, "/hosts/host-uuid", h["url"])
+	assert.Equal(t, "host", h["type"])
+}
+
+func TestSearchHandler_QueryTooShort(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=x", nil)
+	w := httptest.NewRecorder()
+	newTestSearchHandler(&mockSearchServicer{}).Search(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var raw map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&raw))
+	assert.Contains(t, raw["message"], "at least 2")
+}
+
+func TestSearchHandler_QueryMissing(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search", nil)
+	w := httptest.NewRecorder()
+	newTestSearchHandler(&mockSearchServicer{}).Search(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSearchHandler_QueryTooLong(t *testing.T) {
+	longQ := ""
+	for i := 0; i < searchMaxQueryLen+1; i++ {
+		longQ += "a"
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q="+longQ, nil)
+	w := httptest.NewRecorder()
+	newTestSearchHandler(&mockSearchServicer{}).Search(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSearchHandler_InvalidLimit(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=host&limit=abc", nil)
+	w := httptest.NewRecorder()
+	newTestSearchHandler(&mockSearchServicer{}).Search(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSearchHandler_LimitCappedAtMax(t *testing.T) {
+	var gotLimit int
+	svc := &mockSearchServicer{
+		searchFn: func(_ context.Context, _ string, limit int) (*db.SearchResults, error) {
+			gotLimit = limit
+			return &db.SearchResults{
+				Results: map[string][]db.SearchResult{
+					"hosts": {}, "networks": {}, "scans": {}, "profiles": {},
+				},
+			}, nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=host&limit=999", nil)
+	w := httptest.NewRecorder()
+	newTestSearchHandler(svc).Search(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, searchMaxLimit, gotLimit)
+}
+
+func TestSearchHandler_ServiceError(t *testing.T) {
+	svc := &mockSearchServicer{
+		searchFn: func(_ context.Context, _ string, _ int) (*db.SearchResults, error) {
+			return nil, fmt.Errorf("database unavailable")
+		},
+	}
+
+	req := buildSearchRequest("host")
+	w := httptest.NewRecorder()
+	newTestSearchHandler(svc).Search(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestSearchHandler_CustomLimit(t *testing.T) {
+	var gotLimit int
+	svc := &mockSearchServicer{
+		searchFn: func(_ context.Context, _ string, limit int) (*db.SearchResults, error) {
+			gotLimit = limit
+			return &db.SearchResults{
+				Results: map[string][]db.SearchResult{
+					"hosts": {}, "networks": {}, "scans": {}, "profiles": {},
+				},
+			}, nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=host&limit=5", nil)
+	w := httptest.NewRecorder()
+	newTestSearchHandler(svc).Search(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 5, gotLimit)
+}

--- a/internal/api/handlers/webhooks.go
+++ b/internal/api/handlers/webhooks.go
@@ -1,0 +1,301 @@
+// Package handlers — webhook management endpoints.
+package handlers
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/anstrom/scanorama/internal/db"
+	"github.com/anstrom/scanorama/internal/metrics"
+	"github.com/anstrom/scanorama/internal/services"
+)
+
+const (
+	entityTypeWebhook = "webhook"
+	defaultLogLimit   = 50
+	maxLogLimit       = 200
+	queryParamLimit   = "limit"
+)
+
+// WebhookHandler handles HTTP requests for webhook management.
+type WebhookHandler struct {
+	svc     WebhookServicer
+	logger  *slog.Logger
+	metrics *metrics.Registry
+}
+
+// NewWebhookHandler creates a new WebhookHandler.
+func NewWebhookHandler(svc WebhookServicer, logger *slog.Logger, m *metrics.Registry) *WebhookHandler {
+	return &WebhookHandler{
+		svc:     svc,
+		logger:  logger.With("handler", "webhook"),
+		metrics: m,
+	}
+}
+
+// createWebhookRequest is the body for POST /api/v1/webhooks.
+type createWebhookRequest struct {
+	URL    string   `json:"url"`
+	Secret string   `json:"secret"`
+	Events []string `json:"events"`
+}
+
+// updateWebhookRequest is the body for PATCH /api/v1/webhooks/{id}.
+type updateWebhookRequest struct {
+	URL     *string  `json:"url"`
+	Secret  *string  `json:"secret"`
+	Events  []string `json:"events"`
+	Enabled *bool    `json:"enabled"`
+}
+
+// ListWebhooks handles GET /api/v1/webhooks.
+//
+//	@Summary     List webhook endpoints
+//	@Tags        webhooks
+//	@Produce     json
+//	@Success     200  {object}  map[string]any
+//	@Failure     500  {object}  map[string]any
+//	@Router      /webhooks [get]
+func (h *WebhookHandler) ListWebhooks(w http.ResponseWriter, r *http.Request) {
+	endpoints, err := h.svc.ListWebhooks(r.Context())
+	if err != nil {
+		handleDatabaseError(w, r, err, "list", "webhooks", h.logger)
+		return
+	}
+	resp := make([]*db.WebhookResponse, 0, len(endpoints))
+	for _, ep := range endpoints {
+		resp = append(resp, ep.ToResponse())
+	}
+	writeJSON(w, r, http.StatusOK, map[string]any{"webhooks": resp})
+}
+
+// CreateWebhook handles POST /api/v1/webhooks.
+//
+//	@Summary     Create a webhook endpoint
+//	@Tags        webhooks
+//	@Accept      json
+//	@Produce     json
+//	@Param       body  body      createWebhookRequest  true  "Webhook input"
+//	@Success     201   {object}  db.WebhookCreateResponse
+//	@Failure     400   {object}  map[string]any
+//	@Failure     500   {object}  map[string]any
+//	@Router      /webhooks [post]
+func (h *WebhookHandler) CreateWebhook(w http.ResponseWriter, r *http.Request) {
+	var req createWebhookRequest
+	if err := parseJSON(r, &req); err != nil {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err))
+		return
+	}
+
+	if err := validateWebhookURL(req.URL); err != nil {
+		writeError(w, r, http.StatusBadRequest, err)
+		return
+	}
+	if err := validateWebhookEvents(req.Events); err != nil {
+		writeError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	endpoint, err := h.svc.CreateWebhook(r.Context(), db.CreateWebhookInput{
+		URL:    req.URL,
+		Secret: req.Secret,
+		Events: req.Events,
+	})
+	if err != nil {
+		handleDatabaseError(w, r, err, "create", entityTypeWebhook, h.logger)
+		return
+	}
+	writeJSON(w, r, http.StatusCreated, endpoint.ToCreateResponse())
+}
+
+// GetWebhook handles GET /api/v1/webhooks/{id}.
+//
+//	@Summary     Get a webhook endpoint
+//	@Tags        webhooks
+//	@Produce     json
+//	@Param       id   path      string  true  "Webhook UUID"
+//	@Success     200  {object}  db.WebhookResponse
+//	@Failure     400  {object}  map[string]any
+//	@Failure     404  {object}  map[string]any
+//	@Failure     500  {object}  map[string]any
+//	@Router      /webhooks/{id} [get]
+func (h *WebhookHandler) GetWebhook(w http.ResponseWriter, r *http.Request) {
+	id, err := extractUUIDFromPath(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid webhook ID: %w", err))
+		return
+	}
+	endpoint, err := h.svc.GetWebhook(r.Context(), id)
+	if err != nil {
+		handleDatabaseError(w, r, err, "get", entityTypeWebhook, h.logger)
+		return
+	}
+	writeJSON(w, r, http.StatusOK, endpoint.ToResponse())
+}
+
+// UpdateWebhook handles PATCH /api/v1/webhooks/{id}.
+//
+//	@Summary     Update a webhook endpoint
+//	@Tags        webhooks
+//	@Accept      json
+//	@Produce     json
+//	@Param       id    path      string               true  "Webhook UUID"
+//	@Param       body  body      updateWebhookRequest true  "Update fields"
+//	@Success     200   {object}  db.WebhookResponse
+//	@Failure     400   {object}  map[string]any
+//	@Failure     404   {object}  map[string]any
+//	@Failure     500   {object}  map[string]any
+//	@Router      /webhooks/{id} [patch]
+func (h *WebhookHandler) UpdateWebhook(w http.ResponseWriter, r *http.Request) {
+	id, err := extractUUIDFromPath(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid webhook ID: %w", err))
+		return
+	}
+
+	var req updateWebhookRequest
+	if err := parseJSON(r, &req); err != nil {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err))
+		return
+	}
+
+	if req.URL != nil {
+		if err := validateWebhookURL(*req.URL); err != nil {
+			writeError(w, r, http.StatusBadRequest, err)
+			return
+		}
+	}
+	if len(req.Events) > 0 {
+		if err := validateWebhookEvents(req.Events); err != nil {
+			writeError(w, r, http.StatusBadRequest, err)
+			return
+		}
+	}
+
+	endpoint, err := h.svc.UpdateWebhook(r.Context(), id, db.UpdateWebhookInput{
+		URL:     req.URL,
+		Secret:  req.Secret,
+		Events:  req.Events,
+		Enabled: req.Enabled,
+	})
+	if err != nil {
+		handleDatabaseError(w, r, err, "update", entityTypeWebhook, h.logger)
+		return
+	}
+	writeJSON(w, r, http.StatusOK, endpoint.ToResponse())
+}
+
+// DeleteWebhook handles DELETE /api/v1/webhooks/{id}.
+//
+//	@Summary     Delete a webhook endpoint
+//	@Tags        webhooks
+//	@Param       id  path  string  true  "Webhook UUID"
+//	@Success     204
+//	@Failure     400  {object}  map[string]any
+//	@Failure     404  {object}  map[string]any
+//	@Failure     500  {object}  map[string]any
+//	@Router      /webhooks/{id} [delete]
+func (h *WebhookHandler) DeleteWebhook(w http.ResponseWriter, r *http.Request) {
+	id, err := extractUUIDFromPath(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid webhook ID: %w", err))
+		return
+	}
+	if err := h.svc.DeleteWebhook(r.Context(), id); err != nil {
+		handleDatabaseError(w, r, err, "delete", entityTypeWebhook, h.logger)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// TestWebhook handles POST /api/v1/webhooks/{id}/test.
+//
+//	@Summary     Send a test delivery to a webhook endpoint
+//	@Tags        webhooks
+//	@Param       id  path  string  true  "Webhook UUID"
+//	@Success     200  {object}  map[string]any
+//	@Failure     400  {object}  map[string]any
+//	@Failure     404  {object}  map[string]any
+//	@Failure     500  {object}  map[string]any
+//	@Router      /webhooks/{id}/test [post]
+func (h *WebhookHandler) TestWebhook(w http.ResponseWriter, r *http.Request) {
+	id, err := extractUUIDFromPath(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid webhook ID: %w", err))
+		return
+	}
+	if err := h.svc.SendTestDelivery(r.Context(), id); err != nil {
+		handleDatabaseError(w, r, err, "test", entityTypeWebhook, h.logger)
+		return
+	}
+	writeJSON(w, r, http.StatusOK, map[string]any{responseKeyStatus: statusDelivered})
+}
+
+// ListDeliveryLogs handles GET /api/v1/webhooks/{id}/logs.
+//
+//	@Summary     List delivery logs for a webhook endpoint
+//	@Tags        webhooks
+//	@Produce     json
+//	@Param       id     path      string  true  "Webhook UUID"
+//	@Param       limit  query     int     false "Maximum log entries (default 50, max 200)"
+//	@Success     200    {object}  map[string]any
+//	@Failure     400    {object}  map[string]any
+//	@Failure     500    {object}  map[string]any
+//	@Router      /webhooks/{id}/logs [get]
+func (h *WebhookHandler) ListDeliveryLogs(w http.ResponseWriter, r *http.Request) {
+	id, err := extractUUIDFromPath(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid webhook ID: %w", err))
+		return
+	}
+
+	limit, err := getQueryParamInt(r, queryParamLimit, defaultLogLimit)
+	if err != nil || limit < 1 {
+		limit = defaultLogLimit
+	}
+	if limit > maxLogLimit {
+		limit = maxLogLimit
+	}
+
+	logs, err := h.svc.ListDeliveryLogs(r.Context(), id, limit)
+	if err != nil {
+		handleDatabaseError(w, r, err, "list", "delivery logs", h.logger)
+		return
+	}
+	if logs == nil {
+		logs = make([]*db.WebhookDeliveryLog, 0)
+	}
+	writeJSON(w, r, http.StatusOK, map[string]any{"logs": logs})
+}
+
+// validateWebhookURL checks that the URL is non-empty and starts with http/https.
+func validateWebhookURL(url string) error {
+	if url == "" {
+		return fmt.Errorf("url is required")
+	}
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		return fmt.Errorf("url must start with http:// or https://")
+	}
+	return nil
+}
+
+// validateWebhookEvents checks that all event types are from the allowed set
+// and that there are no duplicates.
+func validateWebhookEvents(events []string) error {
+	if len(events) == 0 {
+		return fmt.Errorf("at least one event type is required")
+	}
+	seen := make(map[string]struct{}, len(events))
+	for _, e := range events {
+		if _, ok := services.AllowedWebhookEvents[e]; !ok {
+			return fmt.Errorf("unknown event type %q", e)
+		}
+		if _, dup := seen[e]; dup {
+			return fmt.Errorf("duplicate event type %q", e)
+		}
+		seen[e] = struct{}{}
+	}
+	return nil
+}

--- a/internal/api/handlers/webhooks_test.go
+++ b/internal/api/handlers/webhooks_test.go
@@ -1,0 +1,629 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/db"
+	apierrors "github.com/anstrom/scanorama/internal/errors"
+	"github.com/anstrom/scanorama/internal/metrics"
+)
+
+// ── mock ─────────────────────────────────────────────────────────────────────
+
+type mockWebhookServicer struct {
+	listFn     func(ctx context.Context) ([]*db.WebhookEndpoint, error)
+	createFn   func(ctx context.Context, input db.CreateWebhookInput) (*db.WebhookEndpoint, error)
+	getFn      func(ctx context.Context, id uuid.UUID) (*db.WebhookEndpoint, error)
+	updateFn   func(ctx context.Context, id uuid.UUID, input db.UpdateWebhookInput) (*db.WebhookEndpoint, error)
+	deleteFn   func(ctx context.Context, id uuid.UUID) error
+	testFn     func(ctx context.Context, id uuid.UUID) error
+	listLogsFn func(ctx context.Context, endpointID uuid.UUID, limit int) ([]*db.WebhookDeliveryLog, error)
+}
+
+func (m *mockWebhookServicer) ListWebhooks(ctx context.Context) ([]*db.WebhookEndpoint, error) {
+	return m.listFn(ctx)
+}
+
+func (m *mockWebhookServicer) CreateWebhook(
+	ctx context.Context, input db.CreateWebhookInput,
+) (*db.WebhookEndpoint, error) {
+	return m.createFn(ctx, input)
+}
+
+func (m *mockWebhookServicer) GetWebhook(ctx context.Context, id uuid.UUID) (*db.WebhookEndpoint, error) {
+	return m.getFn(ctx, id)
+}
+
+func (m *mockWebhookServicer) UpdateWebhook(
+	ctx context.Context, id uuid.UUID, input db.UpdateWebhookInput,
+) (*db.WebhookEndpoint, error) {
+	return m.updateFn(ctx, id, input)
+}
+
+func (m *mockWebhookServicer) DeleteWebhook(ctx context.Context, id uuid.UUID) error {
+	return m.deleteFn(ctx, id)
+}
+
+func (m *mockWebhookServicer) SendTestDelivery(ctx context.Context, id uuid.UUID) error {
+	return m.testFn(ctx, id)
+}
+
+func (m *mockWebhookServicer) ListDeliveryLogs(
+	ctx context.Context, endpointID uuid.UUID, limit int,
+) ([]*db.WebhookDeliveryLog, error) {
+	return m.listLogsFn(ctx, endpointID, limit)
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func newWebhookRouter(h *WebhookHandler) *mux.Router {
+	r := mux.NewRouter()
+	r.HandleFunc("/webhooks", h.ListWebhooks).Methods(http.MethodGet)
+	r.HandleFunc("/webhooks", h.CreateWebhook).Methods(http.MethodPost)
+	r.HandleFunc("/webhooks/{id}", h.GetWebhook).Methods(http.MethodGet)
+	r.HandleFunc("/webhooks/{id}", h.UpdateWebhook).Methods(http.MethodPatch)
+	r.HandleFunc("/webhooks/{id}", h.DeleteWebhook).Methods(http.MethodDelete)
+	r.HandleFunc("/webhooks/{id}/test", h.TestWebhook).Methods(http.MethodPost)
+	r.HandleFunc("/webhooks/{id}/logs", h.ListDeliveryLogs).Methods(http.MethodGet)
+	return r
+}
+
+func newWebhookHandler(svc *mockWebhookServicer) *WebhookHandler {
+	return NewWebhookHandler(svc, createTestLogger(), metrics.NewRegistry())
+}
+
+func makeWebhookEndpoint(id uuid.UUID, url string) *db.WebhookEndpoint {
+	return &db.WebhookEndpoint{
+		ID:        id,
+		URL:       url,
+		Secret:    "s3cr3t",
+		Events:    []string{"host.online"},
+		Enabled:   true,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+}
+
+func makeDeliveryLog(id, endpointID uuid.UUID) *db.WebhookDeliveryLog {
+	code := http.StatusOK
+	now := time.Now()
+	return &db.WebhookDeliveryLog{
+		ID:           id,
+		EndpointID:   endpointID,
+		EventType:    "host.online",
+		Payload:      []byte(`{}`),
+		StatusCode:   &code,
+		AttemptCount: 1,
+		DeliveredAt:  &now,
+		CreatedAt:    time.Now(),
+	}
+}
+
+func jsonBody(t *testing.T, v any) *bytes.Buffer {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return bytes.NewBuffer(b)
+}
+
+// ── ListWebhooks ──────────────────────────────────────────────────────────────
+
+func TestListWebhooks_ReturnsArray(t *testing.T) {
+	id := uuid.New()
+	svc := &mockWebhookServicer{
+		listFn: func(_ context.Context) ([]*db.WebhookEndpoint, error) {
+			return []*db.WebhookEndpoint{makeWebhookEndpoint(id, "https://example.com/hook")}, nil
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodGet, "/webhooks", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	webhooks, ok := resp["webhooks"].([]any)
+	require.True(t, ok, "expected webhooks key with JSON array")
+	assert.Len(t, webhooks, 1)
+	first := webhooks[0].(map[string]any)
+	assert.Equal(t, "https://example.com/hook", first["url"])
+}
+
+func TestListWebhooks_EmptyIsArray(t *testing.T) {
+	svc := &mockWebhookServicer{
+		listFn: func(_ context.Context) ([]*db.WebhookEndpoint, error) {
+			return make([]*db.WebhookEndpoint, 0), nil
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodGet, "/webhooks", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	webhooks, ok := resp["webhooks"].([]any)
+	require.True(t, ok, "empty list must be [] not null")
+	assert.Empty(t, webhooks)
+}
+
+func TestListWebhooks_ServiceError(t *testing.T) {
+	svc := &mockWebhookServicer{
+		listFn: func(_ context.Context) ([]*db.WebhookEndpoint, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodGet, "/webhooks", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ── CreateWebhook ─────────────────────────────────────────────────────────────
+
+func TestCreateWebhook_Success(t *testing.T) {
+	id := uuid.New()
+	svc := &mockWebhookServicer{
+		createFn: func(_ context.Context, input db.CreateWebhookInput) (*db.WebhookEndpoint, error) {
+			return makeWebhookEndpoint(id, input.URL), nil
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	body := jsonBody(t, map[string]any{
+		"url":    "https://example.com/hook",
+		"events": []string{"host.online"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/webhooks", body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "https://example.com/hook", resp["url"])
+}
+
+func TestCreateWebhook_BadURL(t *testing.T) {
+	svc := &mockWebhookServicer{}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	body := jsonBody(t, map[string]any{
+		"url":    "ftp://bad-scheme.com",
+		"events": []string{"host.online"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/webhooks", body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreateWebhook_MissingURL(t *testing.T) {
+	svc := &mockWebhookServicer{}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	body := jsonBody(t, map[string]any{
+		"url":    "",
+		"events": []string{"host.online"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/webhooks", body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreateWebhook_InvalidEvent(t *testing.T) {
+	svc := &mockWebhookServicer{}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	body := jsonBody(t, map[string]any{
+		"url":    "https://example.com/hook",
+		"events": []string{"not.a.real.event"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/webhooks", body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreateWebhook_ServiceError(t *testing.T) {
+	svc := &mockWebhookServicer{
+		createFn: func(_ context.Context, _ db.CreateWebhookInput) (*db.WebhookEndpoint, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	body := jsonBody(t, map[string]any{
+		"url":    "https://example.com/hook",
+		"events": []string{"host.online"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/webhooks", body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ── GetWebhook ────────────────────────────────────────────────────────────────
+
+func TestGetWebhook_Success(t *testing.T) {
+	id := uuid.New()
+	svc := &mockWebhookServicer{
+		getFn: func(_ context.Context, gotID uuid.UUID) (*db.WebhookEndpoint, error) {
+			assert.Equal(t, id, gotID)
+			return makeWebhookEndpoint(id, "https://example.com/hook"), nil
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodGet, "/webhooks/"+id.String(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, id.String(), resp["id"])
+}
+
+func TestGetWebhook_BadUUID(t *testing.T) {
+	svc := &mockWebhookServicer{}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodGet, "/webhooks/not-a-uuid", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetWebhook_NotFound(t *testing.T) {
+	id := uuid.New()
+	svc := &mockWebhookServicer{
+		getFn: func(_ context.Context, _ uuid.UUID) (*db.WebhookEndpoint, error) {
+			return nil, apierrors.NewScanError(apierrors.CodeNotFound, "webhook not found")
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodGet, "/webhooks/"+id.String(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// ── UpdateWebhook ─────────────────────────────────────────────────────────────
+
+func TestUpdateWebhook_Success(t *testing.T) {
+	id := uuid.New()
+	newURL := "https://new.example.com/hook"
+	enabled := true
+	svc := &mockWebhookServicer{
+		updateFn: func(_ context.Context, gotID uuid.UUID, input db.UpdateWebhookInput) (*db.WebhookEndpoint, error) {
+			assert.Equal(t, id, gotID)
+			ep := makeWebhookEndpoint(id, *input.URL)
+			ep.Enabled = *input.Enabled
+			return ep, nil
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	body := jsonBody(t, map[string]any{"url": newURL, "enabled": enabled})
+	req := httptest.NewRequest(http.MethodPatch, "/webhooks/"+id.String(), body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, newURL, resp["url"])
+}
+
+func TestUpdateWebhook_BadUUID(t *testing.T) {
+	svc := &mockWebhookServicer{}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	body := jsonBody(t, map[string]any{"enabled": false})
+	req := httptest.NewRequest(http.MethodPatch, "/webhooks/not-a-uuid", body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdateWebhook_ServiceError(t *testing.T) {
+	id := uuid.New()
+	svc := &mockWebhookServicer{
+		updateFn: func(_ context.Context, _ uuid.UUID, _ db.UpdateWebhookInput) (*db.WebhookEndpoint, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	body := jsonBody(t, map[string]any{"enabled": false})
+	req := httptest.NewRequest(http.MethodPatch, "/webhooks/"+id.String(), body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestUpdateWebhook_NotFound(t *testing.T) {
+	id := uuid.New()
+	svc := &mockWebhookServicer{
+		updateFn: func(_ context.Context, _ uuid.UUID, _ db.UpdateWebhookInput) (*db.WebhookEndpoint, error) {
+			return nil, apierrors.NewScanError(apierrors.CodeNotFound, "webhook not found")
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	body := jsonBody(t, map[string]any{"enabled": false})
+	req := httptest.NewRequest(http.MethodPatch, "/webhooks/"+id.String(), body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// ── DeleteWebhook ─────────────────────────────────────────────────────────────
+
+func TestDeleteWebhook_Success(t *testing.T) {
+	id := uuid.New()
+	svc := &mockWebhookServicer{
+		deleteFn: func(_ context.Context, gotID uuid.UUID) error {
+			assert.Equal(t, id, gotID)
+			return nil
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodDelete, "/webhooks/"+id.String(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestDeleteWebhook_NotFound(t *testing.T) {
+	id := uuid.New()
+	svc := &mockWebhookServicer{
+		deleteFn: func(_ context.Context, _ uuid.UUID) error {
+			return apierrors.NewScanError(apierrors.CodeNotFound, "webhook not found")
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodDelete, "/webhooks/"+id.String(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// ── TestWebhook ───────────────────────────────────────────────────────────────
+
+func TestTestWebhook_Success(t *testing.T) {
+	id := uuid.New()
+	svc := &mockWebhookServicer{
+		testFn: func(_ context.Context, gotID uuid.UUID) error {
+			assert.Equal(t, id, gotID)
+			return nil
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+id.String()+"/test", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "delivered", resp["status"])
+}
+
+func TestTestWebhook_DeliveryFailure(t *testing.T) {
+	id := uuid.New()
+	svc := &mockWebhookServicer{
+		testFn: func(_ context.Context, _ uuid.UUID) error {
+			return fmt.Errorf("endpoint returned 500")
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+id.String()+"/test", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestTestWebhook_NotFound(t *testing.T) {
+	id := uuid.New()
+	svc := &mockWebhookServicer{
+		testFn: func(_ context.Context, _ uuid.UUID) error {
+			return apierrors.NewScanError(apierrors.CodeNotFound, "webhook not found")
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/"+id.String()+"/test", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// ── ListDeliveryLogs ──────────────────────────────────────────────────────────
+
+func TestListDeliveryLogs_ReturnsArray(t *testing.T) {
+	endpointID := uuid.New()
+	logID := uuid.New()
+	svc := &mockWebhookServicer{
+		listLogsFn: func(_ context.Context, gotID uuid.UUID, limit int) ([]*db.WebhookDeliveryLog, error) {
+			assert.Equal(t, endpointID, gotID)
+			assert.Equal(t, defaultLogLimit, limit)
+			return []*db.WebhookDeliveryLog{makeDeliveryLog(logID, endpointID)}, nil
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodGet, "/webhooks/"+endpointID.String()+"/logs", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	logs, ok := resp["logs"].([]any)
+	require.True(t, ok, "expected logs key with JSON array")
+	assert.Len(t, logs, 1)
+	first := logs[0].(map[string]any)
+	assert.Equal(t, "host.online", first["event_type"])
+}
+
+func TestListDeliveryLogs_BadUUID(t *testing.T) {
+	svc := &mockWebhookServicer{}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodGet, "/webhooks/not-a-uuid/logs", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestListDeliveryLogs_EmptyIsArray(t *testing.T) {
+	endpointID := uuid.New()
+	svc := &mockWebhookServicer{
+		listLogsFn: func(_ context.Context, _ uuid.UUID, _ int) ([]*db.WebhookDeliveryLog, error) {
+			return make([]*db.WebhookDeliveryLog, 0), nil
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodGet, "/webhooks/"+endpointID.String()+"/logs", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	logs, ok := resp["logs"].([]any)
+	require.True(t, ok, "empty log list must be [] not null")
+	assert.Empty(t, logs)
+}
+
+func TestListDeliveryLogs_LimitFromQuery(t *testing.T) {
+	endpointID := uuid.New()
+	svc := &mockWebhookServicer{
+		listLogsFn: func(_ context.Context, _ uuid.UUID, limit int) ([]*db.WebhookDeliveryLog, error) {
+			assert.Equal(t, 100, limit)
+			return make([]*db.WebhookDeliveryLog, 0), nil
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodGet, "/webhooks/"+endpointID.String()+"/logs?limit=100", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestListDeliveryLogs_LimitCappedAtMax(t *testing.T) {
+	endpointID := uuid.New()
+	svc := &mockWebhookServicer{
+		listLogsFn: func(_ context.Context, _ uuid.UUID, limit int) ([]*db.WebhookDeliveryLog, error) {
+			assert.Equal(t, maxLogLimit, limit)
+			return make([]*db.WebhookDeliveryLog, 0), nil
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodGet, "/webhooks/"+endpointID.String()+"/logs?limit=9999", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// ── JSON key assertions ───────────────────────────────────────────────────────
+
+func TestCreateWebhook_ResponseIncludesSecret(t *testing.T) {
+	id := uuid.New()
+	svc := &mockWebhookServicer{
+		createFn: func(_ context.Context, input db.CreateWebhookInput) (*db.WebhookEndpoint, error) {
+			ep := makeWebhookEndpoint(id, input.URL)
+			ep.Secret = "supersecret"
+			return ep, nil
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	body := jsonBody(t, map[string]any{
+		"url":    "https://example.com/hook",
+		"events": []string{"host.online"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/webhooks", body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+	assert.Contains(t, raw, "secret") // secret included only on creation
+	assert.Equal(t, "supersecret", raw["secret"])
+}
+
+func TestWebhookEndpoint_JSONKeys(t *testing.T) {
+	id := uuid.New()
+	svc := &mockWebhookServicer{
+		getFn: func(_ context.Context, _ uuid.UUID) (*db.WebhookEndpoint, error) {
+			return makeWebhookEndpoint(id, "https://example.com/hook"), nil
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodGet, "/webhooks/"+id.String(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+	assert.Contains(t, raw, "id")
+	assert.Contains(t, raw, "url")
+	assert.NotContains(t, raw, "secret") // secret is omitted from GET responses
+	assert.Contains(t, raw, "events")
+	assert.Contains(t, raw, "enabled")
+	assert.Contains(t, raw, "created_at")
+	assert.Contains(t, raw, "updated_at")
+}
+
+func TestWebhookDeliveryLog_JSONKeys(t *testing.T) {
+	endpointID := uuid.New()
+	logID := uuid.New()
+	svc := &mockWebhookServicer{
+		listLogsFn: func(_ context.Context, _ uuid.UUID, _ int) ([]*db.WebhookDeliveryLog, error) {
+			return []*db.WebhookDeliveryLog{makeDeliveryLog(logID, endpointID)}, nil
+		},
+	}
+	r := newWebhookRouter(newWebhookHandler(svc))
+	req := httptest.NewRequest(http.MethodGet, "/webhooks/"+endpointID.String()+"/logs", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	logs, ok := resp["logs"].([]any)
+	require.True(t, ok)
+	require.Len(t, logs, 1)
+	raw := logs[0].(map[string]any)
+	assert.Contains(t, raw, "id")
+	assert.Contains(t, raw, "endpoint_id")
+	assert.Contains(t, raw, "event_type")
+	assert.Contains(t, raw, "status_code")
+	assert.Contains(t, raw, "attempt_count")
+	assert.Contains(t, raw, "last_error")
+	assert.Contains(t, raw, "delivered_at")
+	assert.Contains(t, raw, "created_at")
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -88,15 +88,10 @@ func (s *Server) setupRoutes() {
 	api.HandleFunc("/admin/status", s.adminStatusHandler).Methods("GET")
 	api.HandleFunc("/admin/workers", handlerManager.GetWorkerStatus).Methods("GET")
 
-	statsHandler := apihandlers.NewStatsHandler(s.database, s.logger)
-	settingsHandler := apihandlers.NewSettingsHandler(
-		db.NewSettingsRepository(s.database), s.logger)
-
-	api.HandleFunc("/stats/summary", statsHandler.GetStatsSummary).Methods("GET")
-	api.HandleFunc("/admin/settings", settingsHandler.GetSettings).Methods("GET")
-	api.HandleFunc("/admin/settings", settingsHandler.UpdateSettings).Methods("PUT")
-
+	s.setupStatsSettingsRoutes(api)
 	s.setupAdminSNMPRoutes(api)
+	s.setupWebhookRoutes(api, apihandlers.NewWebhookHandler(
+		services.NewWebhookService(db.NewWebhookRepository(s.database), s.logger), s.logger, s.metrics))
 	s.setupDocRoutes()
 	s.router.HandleFunc("/", s.redirectToAPI).Methods("GET")
 }
@@ -249,9 +244,29 @@ func (s *Server) setupPortRoutes(api *mux.Router, h *apihandlers.PortHandler) {
 	api.HandleFunc("/ports/{port}", h.GetPort).Methods("GET")
 }
 
+// setupWebhookRoutes registers webhook CRUD, test, and delivery log endpoints.
+func (s *Server) setupWebhookRoutes(api *mux.Router, h *apihandlers.WebhookHandler) {
+	api.HandleFunc("/webhooks", h.ListWebhooks).Methods("GET")
+	api.HandleFunc("/webhooks", h.CreateWebhook).Methods("POST")
+	api.HandleFunc("/webhooks/{id}", h.GetWebhook).Methods("GET")
+	api.HandleFunc("/webhooks/{id}", h.UpdateWebhook).Methods("PATCH")
+	api.HandleFunc("/webhooks/{id}", h.DeleteWebhook).Methods("DELETE")
+	api.HandleFunc("/webhooks/{id}/test", h.TestWebhook).Methods("POST")
+	api.HandleFunc("/webhooks/{id}/logs", h.ListDeliveryLogs).Methods("GET")
+}
+
 // setupCertificateRoutes registers TLS certificate endpoints.
 func (s *Server) setupCertificateRoutes(api *mux.Router, h *apihandlers.CertificateHandler) {
 	api.HandleFunc("/certificates/expiring", h.GetExpiringCertificates).Methods("GET")
+}
+
+// setupStatsSettingsRoutes registers stats summary and settings endpoints.
+func (s *Server) setupStatsSettingsRoutes(api *mux.Router) {
+	statsHandler := apihandlers.NewStatsHandler(s.database, s.logger)
+	settingsHandler := apihandlers.NewSettingsHandler(db.NewSettingsRepository(s.database), s.logger)
+	api.HandleFunc("/stats/summary", statsHandler.GetStatsSummary).Methods("GET")
+	api.HandleFunc("/admin/settings", settingsHandler.GetSettings).Methods("GET")
+	api.HandleFunc("/admin/settings", settingsHandler.UpdateSettings).Methods("PUT")
 }
 
 // setupAdminSNMPRoutes registers SNMP credential management endpoints.

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -68,6 +68,19 @@ func (s *Server) setupRoutes() {
 		networkHandler = networkHandler.WithScanQueue(s.scanQueue)
 	}
 
+	networkSvc := services.NewNetworkService(s.database)
+	searchHandler := apihandlers.NewSearchHandler(
+		services.NewSearchService(
+			db.NewHostRepository(s.database),
+			db.NewScanRepository(s.database),
+			db.NewProfileRepository(s.database),
+			networkSvc,
+			s.logger,
+		),
+		s.logger,
+		s.metrics,
+	)
+
 	s.setupSmartScanRoutes(api, smartScanHandler)
 	s.setupScanRoutes(api, scanHandler)
 	s.setupHostRoutes(api, hostHandler)
@@ -80,6 +93,7 @@ func (s *Server) setupRoutes() {
 	s.setupNetworkRoutes(api, networkHandler)
 	s.setupPortRoutes(api, portHandler)
 	s.setupCertificateRoutes(api, certHandler)
+	api.HandleFunc("/search", searchHandler.Search).Methods("GET")
 
 	api.HandleFunc("/ws", handlerManager.GeneralWebSocket).Methods("GET")
 	api.HandleFunc("/ws/scans", handlerManager.ScanWebSocket).Methods("GET")

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -90,8 +90,7 @@ func (s *Server) setupRoutes() {
 
 	s.setupStatsSettingsRoutes(api)
 	s.setupAdminSNMPRoutes(api)
-	s.setupWebhookRoutes(api, apihandlers.NewWebhookHandler(
-		services.NewWebhookService(db.NewWebhookRepository(s.database), s.logger), s.logger, s.metrics))
+	s.setupWebhookAlertRoutes(api)
 	s.setupDocRoutes()
 	s.router.HandleFunc("/", s.redirectToAPI).Methods("GET")
 }
@@ -242,6 +241,25 @@ func (s *Server) setupPortRoutes(api *mux.Router, h *apihandlers.PortHandler) {
 	api.HandleFunc("/ports/host-counts", h.ListPortHostCounts).Methods("GET")
 	api.HandleFunc("/ports", h.ListPorts).Methods("GET")
 	api.HandleFunc("/ports/{port}", h.GetPort).Methods("GET")
+}
+
+// setupWebhookAlertRoutes wires the webhook and alert services and registers their routes.
+func (s *Server) setupWebhookAlertRoutes(api *mux.Router) {
+	webhookSvc := services.NewWebhookService(db.NewWebhookRepository(s.database), s.logger)
+	s.setupWebhookRoutes(api, apihandlers.NewWebhookHandler(webhookSvc, s.logger, s.metrics))
+	alertSvc := services.NewAlertService(db.NewAlertRepository(s.database), webhookSvc, s.logger)
+	s.setupAlertRoutes(api, apihandlers.NewAlertHandler(alertSvc, s.logger, s.metrics))
+	scanning.SetAlertEvaluator(alertSvc.EvaluateAlerts)
+}
+
+// setupAlertRoutes registers alert rule CRUD and host-scoped endpoints.
+func (s *Server) setupAlertRoutes(api *mux.Router, h *apihandlers.AlertHandler) {
+	api.HandleFunc("/alerts", h.ListAlertRules).Methods("GET")
+	api.HandleFunc("/alerts", h.CreateAlertRule).Methods("POST")
+	api.HandleFunc("/alerts/{id}", h.GetAlertRule).Methods("GET")
+	api.HandleFunc("/alerts/{id}", h.UpdateAlertRule).Methods("PATCH")
+	api.HandleFunc("/alerts/{id}", h.DeleteAlertRule).Methods("DELETE")
+	api.HandleFunc("/hosts/{id}/alerts", h.ListAlertRulesForHost).Methods("GET")
 }
 
 // setupWebhookRoutes registers webhook CRUD, test, and delivery log endpoints.

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -117,6 +117,8 @@ func (s *Server) setupSmartScanRoutes(api *mux.Router, h *apihandlers.SmartScanH
 
 // setupScanRoutes registers scan CRUD and action endpoints.
 func (s *Server) setupScanRoutes(api *mux.Router, h *apihandlers.ScanHandler) {
+	// Fixed-path routes must be registered before /scans/{id} to avoid mux ambiguity.
+	api.HandleFunc("/scans/diff", h.GetScanDiff).Methods("GET")
 	api.HandleFunc("/scans", h.ListScans).Methods("GET")
 	api.HandleFunc("/scans", h.CreateScan).Methods("POST")
 	api.HandleFunc("/scans/{id}", h.GetScan).Methods("GET")

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -116,9 +116,12 @@ func (s *Server) setupSmartScanRoutes(api *mux.Router, h *apihandlers.SmartScanH
 }
 
 // setupScanRoutes registers scan CRUD and action endpoints.
+//
+//nolint:dupl // route functions share structural patterns by design
 func (s *Server) setupScanRoutes(api *mux.Router, h *apihandlers.ScanHandler) {
 	// Fixed-path routes must be registered before /scans/{id} to avoid mux ambiguity.
 	api.HandleFunc("/scans/diff", h.GetScanDiff).Methods("GET")
+	api.HandleFunc("/scans/export", h.ExportScans).Methods("GET")
 	api.HandleFunc("/scans", h.ListScans).Methods("GET")
 	api.HandleFunc("/scans", h.CreateScan).Methods("POST")
 	api.HandleFunc("/scans/{id}", h.GetScan).Methods("GET")
@@ -130,7 +133,11 @@ func (s *Server) setupScanRoutes(api *mux.Router, h *apihandlers.ScanHandler) {
 }
 
 // setupHostRoutes registers host CRUD endpoints.
+//
+//nolint:dupl // route functions share structural patterns by design
 func (s *Server) setupHostRoutes(api *mux.Router, h *apihandlers.HostHandler) {
+	// Fixed-path routes must be registered before /hosts/{id} to avoid mux ambiguity.
+	api.HandleFunc("/hosts/export", h.ExportHosts).Methods("GET")
 	api.HandleFunc("/hosts", h.ListHosts).Methods("GET")
 	api.HandleFunc("/hosts", h.CreateHost).Methods("POST")
 	api.HandleFunc("/hosts", h.BulkDeleteHosts).Methods("DELETE")

--- a/internal/auth/apikey.go
+++ b/internal/auth/apikey.go
@@ -5,7 +5,6 @@ package auth
 
 import (
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base32"
 	"fmt"
 	"strings"
@@ -121,11 +120,11 @@ func HashAPIKey(apiKey string) (string, error) {
 		return "", fmt.Errorf("API key cannot be empty")
 	}
 
-	// bcrypt has a 72-byte limit, so for longer keys we first hash with SHA-256
+	// bcrypt has a 72-byte limit; truncate longer keys rather than pre-hashing,
+	// since API keys are high-entropy random strings and truncation is safe.
 	keyBytes := []byte(apiKey)
 	if len(keyBytes) > BcryptMaxInputLength {
-		sha256Hash := sha256.Sum256(keyBytes)
-		keyBytes = sha256Hash[:]
+		keyBytes = keyBytes[:BcryptMaxInputLength]
 	}
 
 	hash, err := bcrypt.GenerateFromPassword(keyBytes, BcryptCost)
@@ -142,11 +141,10 @@ func ValidateAPIKey(apiKey, storedHash string) bool {
 		return false
 	}
 
-	// Apply the same pre-processing as HashAPIKey for consistency
+	// Apply the same pre-processing as HashAPIKey for consistency.
 	keyBytes := []byte(apiKey)
 	if len(keyBytes) > BcryptMaxInputLength {
-		sha256Hash := sha256.Sum256(keyBytes)
-		keyBytes = sha256Hash[:]
+		keyBytes = keyBytes[:BcryptMaxInputLength]
 	}
 
 	err := bcrypt.CompareHashAndPassword([]byte(storedHash), keyBytes)

--- a/internal/db/029_webhooks.sql
+++ b/internal/db/029_webhooks.sql
@@ -1,0 +1,23 @@
+CREATE TABLE webhook_endpoints (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    url         TEXT NOT NULL,
+    secret      TEXT NOT NULL,
+    events      TEXT[] NOT NULL,
+    enabled     BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE webhook_delivery_log (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    endpoint_id     UUID NOT NULL REFERENCES webhook_endpoints(id) ON DELETE CASCADE,
+    event_type      TEXT NOT NULL,
+    payload         JSONB NOT NULL,
+    status_code     INT,
+    attempt_count   INT NOT NULL DEFAULT 0,
+    last_error      TEXT,
+    delivered_at    TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX webhook_delivery_log_endpoint_id_idx ON webhook_delivery_log(endpoint_id);

--- a/internal/db/030_alert_rules.sql
+++ b/internal/db/030_alert_rules.sql
@@ -1,0 +1,26 @@
+CREATE TYPE alert_trigger AS ENUM ('online', 'offline', 'both');
+
+CREATE TABLE alert_rules (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- target: exactly one of these must be set
+    host_id      UUID REFERENCES hosts(id) ON DELETE CASCADE,
+    group_id     UUID REFERENCES host_groups(id) ON DELETE CASCADE,
+    tag          TEXT,
+    -- rule config
+    trigger      alert_trigger NOT NULL,
+    channel_type TEXT NOT NULL DEFAULT 'webhook',
+    channel_url  TEXT NOT NULL,
+    enabled      BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- ensure exactly one target is set
+    CONSTRAINT alert_rules_single_target CHECK (
+        (host_id IS NOT NULL)::int +
+        (group_id IS NOT NULL)::int +
+        (tag IS NOT NULL)::int = 1
+    )
+);
+
+CREATE INDEX alert_rules_host_id_idx ON alert_rules(host_id) WHERE host_id IS NOT NULL;
+CREATE INDEX alert_rules_group_id_idx ON alert_rules(group_id) WHERE group_id IS NOT NULL;
+CREATE INDEX alert_rules_tag_idx ON alert_rules(tag) WHERE tag IS NOT NULL;

--- a/internal/db/alert_models.go
+++ b/internal/db/alert_models.go
@@ -1,0 +1,57 @@
+package db
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// AlertTrigger constants for alert rule trigger types.
+const (
+	AlertTriggerOnline  = "online"
+	AlertTriggerOffline = "offline"
+	AlertTriggerBoth    = "both"
+)
+
+// AlertChannelTypeWebhook is the only supported channel type for now.
+const AlertChannelTypeWebhook = "webhook"
+
+// AlertRule represents a configured alert rule for host status transitions.
+type AlertRule struct {
+	ID          uuid.UUID  `db:"id"           json:"id"`
+	HostID      *uuid.UUID `db:"host_id"      json:"host_id"`
+	GroupID     *uuid.UUID `db:"group_id"     json:"group_id"`
+	Tag         *string    `db:"tag"          json:"tag"`
+	Trigger     string     `db:"trigger"      json:"trigger"`
+	ChannelType string     `db:"channel_type" json:"channel_type"`
+	ChannelURL  string     `db:"channel_url"  json:"channel_url"`
+	Enabled     bool       `db:"enabled"      json:"enabled"`
+	CreatedAt   time.Time  `db:"created_at"   json:"created_at"`
+	UpdatedAt   time.Time  `db:"updated_at"   json:"updated_at"`
+}
+
+// CreateAlertRuleInput is the input for creating a new alert rule.
+type CreateAlertRuleInput struct {
+	HostID     *uuid.UUID
+	GroupID    *uuid.UUID
+	Tag        *string
+	Trigger    string // "online" | "offline" | "both"
+	ChannelURL string
+}
+
+// UpdateAlertRuleInput is the input for partially updating an alert rule.
+type UpdateAlertRuleInput struct {
+	Trigger    *string
+	ChannelURL *string
+	Enabled    *bool
+}
+
+// StatusTransitionRow is a row returned by GetStatusTransitionsSince,
+// enriched with the host's current tags for rule matching.
+type StatusTransitionRow struct {
+	HostID     uuid.UUID `db:"host_id"`
+	FromStatus string    `db:"from_status"`
+	ToStatus   string    `db:"to_status"`
+	ChangedAt  time.Time `db:"changed_at"`
+	Tags       []string  `db:"tags"`
+}

--- a/internal/db/alert_repository.go
+++ b/internal/db/alert_repository.go
@@ -1,0 +1,190 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	stderrors "errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+
+	"github.com/anstrom/scanorama/internal/errors"
+)
+
+// AlertRepository handles all alert-rule-related DB operations.
+type AlertRepository struct {
+	db *DB
+}
+
+// NewAlertRepository creates a new AlertRepository.
+func NewAlertRepository(db *DB) *AlertRepository {
+	return &AlertRepository{db: db}
+}
+
+const alertRuleSelectCols = `id, host_id, group_id, tag, trigger, channel_type, channel_url,
+	enabled, created_at, updated_at`
+
+// scanAlertRule scans one row into an AlertRule.
+func scanAlertRule(row interface{ Scan(...interface{}) error }) (*AlertRule, error) {
+	r := &AlertRule{}
+	err := row.Scan(
+		&r.ID, &r.HostID, &r.GroupID, &r.Tag, &r.Trigger,
+		&r.ChannelType, &r.ChannelURL, &r.Enabled, &r.CreatedAt, &r.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("scan alert rule: %w", err)
+	}
+	return r, nil
+}
+
+// ListAlertRules returns all alert rules ordered by creation time.
+func (r *AlertRepository) ListAlertRules(ctx context.Context) ([]*AlertRule, error) {
+	q := `SELECT ` + alertRuleSelectCols + `
+	      FROM alert_rules ORDER BY created_at DESC`
+
+	rows, err := r.db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, sanitizeDBError("list alert rules", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make([]*AlertRule, 0)
+	for rows.Next() {
+		ar, err := scanAlertRule(rows)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, ar)
+	}
+	return result, rows.Err()
+}
+
+// ListAlertRulesForHost returns enabled alert rules that target a specific host directly.
+func (r *AlertRepository) ListAlertRulesForHost(
+	ctx context.Context, hostID uuid.UUID,
+) ([]*AlertRule, error) {
+	q := `SELECT ` + alertRuleSelectCols + `
+	      FROM alert_rules
+	      WHERE host_id = $1
+	      ORDER BY created_at DESC`
+
+	rows, err := r.db.QueryContext(ctx, q, hostID)
+	if err != nil {
+		return nil, sanitizeDBError("list alert rules for host", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make([]*AlertRule, 0)
+	for rows.Next() {
+		ar, err := scanAlertRule(rows)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, ar)
+	}
+	return result, rows.Err()
+}
+
+// CreateAlertRule inserts a new alert rule.
+func (r *AlertRepository) CreateAlertRule(
+	ctx context.Context, input CreateAlertRuleInput,
+) (*AlertRule, error) {
+	q := `INSERT INTO alert_rules (host_id, group_id, tag, trigger, channel_url)
+	      VALUES ($1, $2, $3, $4, $5)
+	      RETURNING ` + alertRuleSelectCols
+
+	row := r.db.QueryRowContext(ctx, q,
+		input.HostID, input.GroupID, input.Tag, input.Trigger, input.ChannelURL,
+	)
+	ar, err := scanAlertRule(row)
+	if err != nil {
+		return nil, sanitizeDBError("create alert rule", err)
+	}
+	return ar, nil
+}
+
+// GetAlertRule retrieves a single alert rule by ID.
+func (r *AlertRepository) GetAlertRule(ctx context.Context, id uuid.UUID) (*AlertRule, error) {
+	q := `SELECT ` + alertRuleSelectCols + `
+	      FROM alert_rules WHERE id = $1`
+
+	row := r.db.QueryRowContext(ctx, q, id)
+	ar, err := scanAlertRule(row)
+	if stderrors.Is(err, sql.ErrNoRows) {
+		return nil, errors.NewScanError(errors.CodeNotFound, "alert rule not found")
+	}
+	if err != nil {
+		return nil, sanitizeDBError("get alert rule", err)
+	}
+	return ar, nil
+}
+
+// UpdateAlertRule applies partial updates to an alert rule.
+func (r *AlertRepository) UpdateAlertRule(
+	ctx context.Context, id uuid.UUID, input UpdateAlertRuleInput,
+) (*AlertRule, error) {
+	q := `UPDATE alert_rules SET
+	          trigger     = COALESCE($2, trigger),
+	          channel_url = COALESCE($3, channel_url),
+	          enabled     = COALESCE($4, enabled),
+	          updated_at  = NOW()
+	      WHERE id = $1
+	      RETURNING ` + alertRuleSelectCols
+
+	row := r.db.QueryRowContext(ctx, q, id, input.Trigger, input.ChannelURL, input.Enabled)
+	ar, err := scanAlertRule(row)
+	if stderrors.Is(err, sql.ErrNoRows) {
+		return nil, errors.NewScanError(errors.CodeNotFound, "alert rule not found")
+	}
+	if err != nil {
+		return nil, sanitizeDBError("update alert rule", err)
+	}
+	return ar, nil
+}
+
+// DeleteAlertRule removes an alert rule by ID.
+func (r *AlertRepository) DeleteAlertRule(ctx context.Context, id uuid.UUID) error {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM alert_rules WHERE id = $1`, id)
+	if err != nil {
+		return sanitizeDBError("delete alert rule", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return errors.NewScanError(errors.CodeNotFound, "alert rule not found")
+	}
+	return nil
+}
+
+// GetStatusTransitionsSince returns host status transitions since the given time,
+// enriched with the host's current tags for alert rule matching.
+func (r *AlertRepository) GetStatusTransitionsSince(
+	ctx context.Context, since time.Time,
+) ([]StatusTransitionRow, error) {
+	q := `SELECT se.host_id, se.from_status, se.to_status, se.changed_at, h.tags
+	      FROM host_status_events se
+	      JOIN hosts h ON h.id = se.host_id
+	      WHERE se.changed_at >= $1
+	      ORDER BY se.changed_at DESC`
+
+	rows, err := r.db.QueryContext(ctx, q, since)
+	if err != nil {
+		return nil, sanitizeDBError("get status transitions since", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make([]StatusTransitionRow, 0)
+	for rows.Next() {
+		var row StatusTransitionRow
+		var tags pq.StringArray
+		if err := rows.Scan(
+			&row.HostID, &row.FromStatus, &row.ToStatus, &row.ChangedAt, &tags,
+		); err != nil {
+			return nil, fmt.Errorf("scan status transition row: %w", err)
+		}
+		row.Tags = []string(tags)
+		result = append(result, row)
+	}
+	return result, rows.Err()
+}

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -259,6 +259,15 @@ func (m *Migrator) Reset(ctx context.Context) error {
 			LOOP
 				EXECUTE 'DROP VIEW IF EXISTS ' || r || ' CASCADE';
 			END LOOP;
+			FOR r IN
+				SELECT quote_ident(t.typname)
+				FROM pg_type t
+				JOIN pg_namespace n ON t.typnamespace = n.oid
+				WHERE n.nspname = 'public'
+				AND t.typtype = 'e'
+			LOOP
+				EXECUTE 'DROP TYPE IF EXISTS ' || r || ' CASCADE';
+			END LOOP;
 		END $$;
 	`)
 	if err != nil {

--- a/internal/db/repository_alert_unit_test.go
+++ b/internal/db/repository_alert_unit_test.go
@@ -1,0 +1,259 @@
+// Package db — unit tests for AlertRepository using sqlmock.
+// These run without a live database.
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/errors"
+)
+
+// alertRuleCols mirrors the column list used by alert_rules SELECT queries.
+var alertRuleCols = []string{
+	"id", "host_id", "group_id", "tag",
+	"trigger", "channel_type", "channel_url",
+	"enabled", "created_at", "updated_at",
+}
+
+// ── NewAlertRepository ──────────────────────────────────────────────────────
+
+func TestAlertRepository_New(t *testing.T) {
+	db, _ := newMockDB(t)
+	repo := NewAlertRepository(db)
+	require.NotNil(t, repo)
+}
+
+// ── ListAlertRules ──────────────────────────────────────────────────────────
+
+func TestAlertRepository_ListAlertRules_Empty(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewAlertRepository(database)
+
+	mock.ExpectQuery("SELECT .* FROM alert_rules").
+		WillReturnRows(sqlmock.NewRows(alertRuleCols))
+
+	result, err := repo.ListAlertRules(context.Background())
+	require.NoError(t, err)
+	assert.NotNil(t, result, "should return [] not nil")
+	assert.Empty(t, result)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAlertRepository_ListAlertRules_WithRows(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewAlertRepository(database)
+
+	now := time.Now().UTC()
+	id1 := uuid.New()
+	id2 := uuid.New()
+	hostID := uuid.New()
+
+	rows := sqlmock.NewRows(alertRuleCols).
+		AddRow(id1, &hostID, nil, nil, "online", "webhook", "https://a.example.com", true, now, now).
+		AddRow(id2, nil, nil, nil, "offline", "webhook", "https://b.example.com", false, now, now)
+
+	mock.ExpectQuery("SELECT .* FROM alert_rules").
+		WillReturnRows(rows)
+
+	result, err := repo.ListAlertRules(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	assert.Equal(t, id1, result[0].ID)
+	assert.Equal(t, "online", result[0].Trigger)
+	assert.Equal(t, id2, result[1].ID)
+	assert.Equal(t, "offline", result[1].Trigger)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── CreateAlertRule ─────────────────────────────────────────────────────────
+
+func TestAlertRepository_CreateAlertRule(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewAlertRepository(database)
+
+	now := time.Now().UTC()
+	id := uuid.New()
+	hostID := uuid.New()
+
+	rows := sqlmock.NewRows(alertRuleCols).
+		AddRow(id, &hostID, nil, nil, "both", "webhook", "https://example.com/hook", true, now, now)
+
+	mock.ExpectQuery("INSERT INTO alert_rules").
+		WithArgs(&hostID, nil, nil, "both", "https://example.com/hook").
+		WillReturnRows(rows)
+
+	ar, err := repo.CreateAlertRule(context.Background(), CreateAlertRuleInput{
+		HostID:     &hostID,
+		Trigger:    "both",
+		ChannelURL: "https://example.com/hook",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ar)
+	assert.Equal(t, id, ar.ID)
+	assert.Equal(t, "both", ar.Trigger)
+	assert.Equal(t, "https://example.com/hook", ar.ChannelURL)
+	assert.True(t, ar.Enabled)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── GetAlertRule ────────────────────────────────────────────────────────────
+
+func TestAlertRepository_GetAlertRule_Found(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewAlertRepository(database)
+
+	now := time.Now().UTC()
+	id := uuid.New()
+
+	rows := sqlmock.NewRows(alertRuleCols).
+		AddRow(id, nil, nil, nil, "online", "webhook", "https://example.com", true, now, now)
+
+	mock.ExpectQuery("SELECT .* FROM alert_rules").
+		WithArgs(id).
+		WillReturnRows(rows)
+
+	ar, err := repo.GetAlertRule(context.Background(), id)
+	require.NoError(t, err)
+	require.NotNil(t, ar)
+	assert.Equal(t, id, ar.ID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAlertRepository_GetAlertRule_NotFound(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewAlertRepository(database)
+
+	id := uuid.New()
+
+	mock.ExpectQuery("SELECT .* FROM alert_rules").
+		WithArgs(id).
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := repo.GetAlertRule(context.Background(), id)
+	require.Error(t, err)
+	assert.True(t, errors.IsCode(err, errors.CodeNotFound),
+		"expected CodeNotFound, got: %v", err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── UpdateAlertRule ─────────────────────────────────────────────────────────
+
+func TestAlertRepository_UpdateAlertRule_Found(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewAlertRepository(database)
+
+	now := time.Now().UTC()
+	id := uuid.New()
+	newTrigger := "offline"
+	newURL := "https://updated.example.com"
+	enabled := false
+
+	rows := sqlmock.NewRows(alertRuleCols).
+		AddRow(id, nil, nil, nil, newTrigger, "webhook", newURL, enabled, now, now)
+
+	mock.ExpectQuery("UPDATE alert_rules").
+		WithArgs(id, &newTrigger, &newURL, &enabled).
+		WillReturnRows(rows)
+
+	ar, err := repo.UpdateAlertRule(context.Background(), id, UpdateAlertRuleInput{
+		Trigger:    &newTrigger,
+		ChannelURL: &newURL,
+		Enabled:    &enabled,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ar)
+	assert.Equal(t, id, ar.ID)
+	assert.Equal(t, "offline", ar.Trigger)
+	assert.Equal(t, newURL, ar.ChannelURL)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAlertRepository_UpdateAlertRule_NotFound(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewAlertRepository(database)
+
+	id := uuid.New()
+
+	mock.ExpectQuery("UPDATE alert_rules").
+		WithArgs(id, nil, nil, nil).
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := repo.UpdateAlertRule(context.Background(), id, UpdateAlertRuleInput{})
+	require.Error(t, err)
+	assert.True(t, errors.IsCode(err, errors.CodeNotFound),
+		"expected CodeNotFound, got: %v", err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── DeleteAlertRule ─────────────────────────────────────────────────────────
+
+func TestAlertRepository_DeleteAlertRule_Found(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewAlertRepository(database)
+
+	id := uuid.New()
+
+	mock.ExpectExec("DELETE FROM alert_rules").
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := repo.DeleteAlertRule(context.Background(), id)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAlertRepository_DeleteAlertRule_NotFound(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewAlertRepository(database)
+
+	id := uuid.New()
+
+	mock.ExpectExec("DELETE FROM alert_rules").
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.DeleteAlertRule(context.Background(), id)
+	require.Error(t, err)
+	assert.True(t, errors.IsCode(err, errors.CodeNotFound),
+		"expected CodeNotFound, got: %v", err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── GetStatusTransitionsSince ───────────────────────────────────────────────
+
+func TestAlertRepository_GetStatusTransitionsSince(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewAlertRepository(database)
+
+	hostID := uuid.New()
+	changedAt := time.Now().UTC()
+	since := changedAt.Add(-time.Hour)
+
+	// statusTransitionCols matches the SELECT columns in GetStatusTransitionsSince.
+	statusTransitionCols := []string{"host_id", "from_status", "to_status", "changed_at", "tags"}
+
+	rows := sqlmock.NewRows(statusTransitionCols).
+		AddRow(hostID, "down", "up", changedAt, pq.Array([]string{"web", "prod"}))
+
+	mock.ExpectQuery("SELECT .* FROM host_status_events").
+		WithArgs(since).
+		WillReturnRows(rows)
+
+	result, err := repo.GetStatusTransitionsSince(context.Background(), since)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, hostID, result[0].HostID)
+	assert.Equal(t, "down", result[0].FromStatus)
+	assert.Equal(t, "up", result[0].ToStatus)
+	assert.ElementsMatch(t, []string{"web", "prod"}, result[0].Tags)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/db/repository_scan.go
+++ b/internal/db/repository_scan.go
@@ -883,6 +883,95 @@ func (r *ScanRepository) GetScanResults(ctx context.Context, scanID uuid.UUID, o
 	return results, total, nil
 }
 
+// GetAllScanResults returns all port scan results for a scan without pagination.
+// Used for diff computation where we need the full result set.
+func (r *ScanRepository) GetAllScanResults(ctx context.Context, scanID uuid.UUID) ([]*ScanResult, error) {
+	query := `
+		SELECT
+			ps.id,
+			ps.job_id,
+			ps.host_id,
+			host(h.ip_address) AS host_ip,
+			ps.port,
+			ps.protocol,
+			ps.state,
+			ps.service_name,
+			ps.scanned_at,
+			COALESCE(h.os_name, '')    AS os_name,
+			COALESCE(h.os_family, '')  AS os_family,
+			COALESCE(h.os_version, '') AS os_version,
+			h.os_confidence,
+			ps.scan_duration_ms
+		FROM port_scans ps
+		LEFT JOIN hosts h ON h.id = ps.host_id
+		WHERE ps.job_id = $1
+		ORDER BY ps.port ASC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, scanID)
+	if err != nil {
+		return nil, sanitizeDBError("query all scan results", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Warn("error closing rows", "error", err)
+		}
+	}()
+
+	results := make([]*ScanResult, 0)
+	for rows.Next() {
+		result := &ScanResult{}
+		var serviceName *string
+
+		if err := rows.Scan(
+			&result.ID,
+			&result.ScanID,
+			&result.HostID,
+			&result.HostIP,
+			&result.Port,
+			&result.Protocol,
+			&result.State,
+			&serviceName,
+			&result.ScannedAt,
+			&result.OSName,
+			&result.OSFamily,
+			&result.OSVersion,
+			&result.OSConfidence,
+			&result.ScanDurationMs,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan result row: %w", err)
+		}
+
+		if serviceName != nil {
+			result.Service = *serviceName
+		}
+
+		results = append(results, result)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate scan result rows: %w", err)
+	}
+
+	return results, nil
+}
+
+// GetHostForScan returns the host ID associated with a scan's port results.
+// Returns sql.ErrNoRows if the scan has no port results.
+func (r *ScanRepository) GetHostForScan(ctx context.Context, scanID uuid.UUID) (uuid.UUID, error) {
+	var hostID uuid.UUID
+	err := r.db.QueryRowContext(ctx,
+		`SELECT DISTINCT host_id FROM port_scans WHERE job_id = $1 LIMIT 1`, scanID,
+	).Scan(&hostID)
+	if err != nil {
+		if stderrors.Is(err, sql.ErrNoRows) {
+			return uuid.Nil, sql.ErrNoRows
+		}
+		return uuid.Nil, sanitizeDBError("get host for scan", err)
+	}
+	return hostID, nil
+}
+
 // GetScanSummary retrieves aggregated scan statistics.
 func (r *ScanRepository) GetScanSummary(ctx context.Context, scanID uuid.UUID) (*ScanSummary, error) {
 	query := `

--- a/internal/db/repository_webhook_unit_test.go
+++ b/internal/db/repository_webhook_unit_test.go
@@ -1,0 +1,287 @@
+// Package db — unit tests for WebhookRepository using sqlmock.
+// These run without a live database.
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/errors"
+)
+
+// webhookCols mirrors the column list returned by webhook_endpoints SELECT queries.
+var webhookCols = []string{"id", "url", "secret", "events", "enabled", "created_at", "updated_at"}
+
+// deliveryLogCols mirrors the column list returned by webhook_delivery_log SELECT queries.
+var deliveryLogCols = []string{
+	"id", "endpoint_id", "event_type", "payload",
+	"status_code", "attempt_count", "last_error", "delivered_at", "created_at",
+}
+
+// ── NewWebhookRepository ────────────────────────────────────────────────────
+
+func TestWebhookRepository_New(t *testing.T) {
+	db, _ := newMockDB(t)
+	repo := NewWebhookRepository(db)
+	require.NotNil(t, repo)
+}
+
+// ── ListWebhooks ────────────────────────────────────────────────────────────
+
+func TestWebhookRepository_ListWebhooks_Empty(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewWebhookRepository(database)
+
+	mock.ExpectQuery("SELECT .* FROM webhook_endpoints").
+		WillReturnRows(sqlmock.NewRows(webhookCols))
+
+	result, err := repo.ListWebhooks(context.Background())
+	require.NoError(t, err)
+	assert.NotNil(t, result, "should return [] not nil")
+	assert.Empty(t, result)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWebhookRepository_ListWebhooks_WithRows(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewWebhookRepository(database)
+
+	now := time.Now().UTC()
+	id1 := uuid.New()
+	id2 := uuid.New()
+
+	rows := sqlmock.NewRows(webhookCols).
+		AddRow(id1, "https://a.example.com", "sec1",
+			pq.Array([]string{"host.online"}), true, now, now).
+		AddRow(id2, "https://b.example.com", "sec2",
+			pq.Array([]string{"scan.completed", "host.offline"}), false, now, now)
+
+	mock.ExpectQuery("SELECT .* FROM webhook_endpoints").
+		WillReturnRows(rows)
+
+	result, err := repo.ListWebhooks(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	assert.Equal(t, id1, result[0].ID)
+	assert.Equal(t, "https://a.example.com", result[0].URL)
+	assert.Equal(t, id2, result[1].ID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── CreateWebhook ───────────────────────────────────────────────────────────
+
+func TestWebhookRepository_CreateWebhook(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewWebhookRepository(database)
+
+	now := time.Now().UTC()
+	id := uuid.New()
+	events := []string{"host.online", "host.offline"}
+
+	rows := sqlmock.NewRows(webhookCols).
+		AddRow(id, "https://example.com/hook", "mysecret",
+			pq.Array(events), true, now, now)
+
+	mock.ExpectQuery("INSERT INTO webhook_endpoints").
+		WithArgs("https://example.com/hook", "mysecret", sqlmock.AnyArg()).
+		WillReturnRows(rows)
+
+	ep, err := repo.CreateWebhook(context.Background(), CreateWebhookInput{
+		URL:    "https://example.com/hook",
+		Secret: "mysecret",
+		Events: events,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ep)
+	assert.Equal(t, id, ep.ID)
+	assert.Equal(t, "https://example.com/hook", ep.URL)
+	assert.Equal(t, "mysecret", ep.Secret)
+	assert.True(t, ep.Enabled)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── GetWebhook ──────────────────────────────────────────────────────────────
+
+func TestWebhookRepository_GetWebhook_Found(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewWebhookRepository(database)
+
+	now := time.Now().UTC()
+	id := uuid.New()
+
+	rows := sqlmock.NewRows(webhookCols).
+		AddRow(id, "https://example.com", "secret",
+			pq.Array([]string{"host.online"}), true, now, now)
+
+	mock.ExpectQuery("SELECT .* FROM webhook_endpoints").
+		WithArgs(id).
+		WillReturnRows(rows)
+
+	ep, err := repo.GetWebhook(context.Background(), id)
+	require.NoError(t, err)
+	require.NotNil(t, ep)
+	assert.Equal(t, id, ep.ID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWebhookRepository_GetWebhook_NotFound(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewWebhookRepository(database)
+
+	id := uuid.New()
+
+	mock.ExpectQuery("SELECT .* FROM webhook_endpoints").
+		WithArgs(id).
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := repo.GetWebhook(context.Background(), id)
+	require.Error(t, err)
+	assert.True(t, errors.IsCode(err, errors.CodeNotFound),
+		"expected CodeNotFound, got: %v", err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── DeleteWebhook ───────────────────────────────────────────────────────────
+
+func TestWebhookRepository_DeleteWebhook_Found(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewWebhookRepository(database)
+
+	id := uuid.New()
+
+	mock.ExpectExec("DELETE FROM webhook_endpoints").
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := repo.DeleteWebhook(context.Background(), id)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWebhookRepository_DeleteWebhook_NotFound(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewWebhookRepository(database)
+
+	id := uuid.New()
+
+	mock.ExpectExec("DELETE FROM webhook_endpoints").
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.DeleteWebhook(context.Background(), id)
+	require.Error(t, err)
+	assert.True(t, errors.IsCode(err, errors.CodeNotFound),
+		"expected CodeNotFound, got: %v", err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── ListWebhooksByEvent ─────────────────────────────────────────────────────
+
+func TestWebhookRepository_ListWebhooksByEvent(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewWebhookRepository(database)
+
+	now := time.Now().UTC()
+	id := uuid.New()
+
+	rows := sqlmock.NewRows(webhookCols).
+		AddRow(id, "https://example.com", "sec",
+			pq.Array([]string{"host.online"}), true, now, now)
+
+	mock.ExpectQuery("SELECT .* FROM webhook_endpoints").
+		WithArgs("host.online").
+		WillReturnRows(rows)
+
+	result, err := repo.ListWebhooksByEvent(context.Background(), "host.online")
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, id, result[0].ID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── CreateDeliveryLog ───────────────────────────────────────────────────────
+
+func TestWebhookRepository_CreateDeliveryLog(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewWebhookRepository(database)
+
+	endpointID := uuid.New()
+	statusCode := 200
+	now := time.Now().UTC()
+	log := WebhookDeliveryLog{
+		EndpointID:   endpointID,
+		EventType:    "host.online",
+		Payload:      []byte(`{"type":"host.online"}`),
+		StatusCode:   &statusCode,
+		AttemptCount: 1,
+		DeliveredAt:  &now,
+	}
+
+	mock.ExpectExec("INSERT INTO webhook_delivery_log").
+		WithArgs(
+			log.EndpointID, log.EventType, log.Payload,
+			log.StatusCode, log.AttemptCount, log.LastError, log.DeliveredAt,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := repo.CreateDeliveryLog(context.Background(), log)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWebhookRepository_CreateDeliveryLog_DBError(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewWebhookRepository(database)
+
+	mock.ExpectExec("INSERT INTO webhook_delivery_log").
+		WillReturnError(fmt.Errorf("connection refused"))
+
+	err := repo.CreateDeliveryLog(context.Background(), WebhookDeliveryLog{
+		EndpointID:   uuid.New(),
+		EventType:    "host.online",
+		Payload:      []byte(`{}`),
+		AttemptCount: 1,
+	})
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── ListDeliveryLogs ────────────────────────────────────────────────────────
+
+func TestWebhookRepository_ListDeliveryLogs(t *testing.T) {
+	database, mock := newMockDB(t)
+	repo := NewWebhookRepository(database)
+
+	endpointID := uuid.New()
+	logID := uuid.New()
+	statusCode := 200
+	now := time.Now().UTC()
+	const deliveryLimit = 10
+
+	rows := sqlmock.NewRows(deliveryLogCols).
+		AddRow(
+			logID, endpointID, "host.online", []byte(`{}`),
+			&statusCode, 1, nil, &now, now,
+		)
+
+	mock.ExpectQuery("SELECT .* FROM webhook_delivery_log").
+		WithArgs(endpointID, deliveryLimit).
+		WillReturnRows(rows)
+
+	logs, err := repo.ListDeliveryLogs(context.Background(), endpointID, deliveryLimit)
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+	assert.Equal(t, logID, logs[0].ID)
+	assert.Equal(t, endpointID, logs[0].EndpointID)
+	assert.Equal(t, "host.online", logs[0].EventType)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/db/scans.go
+++ b/internal/db/scans.go
@@ -273,3 +273,43 @@ type ScanSummary struct {
 	ClosedPorts int       `json:"closed_ports"`
 	Duration    int64     `json:"duration_ms"`
 }
+
+// Diff status constants for ScanDiffEntry.
+const (
+	DiffStatusNew       = "new"
+	DiffStatusClosed    = "closed"
+	DiffStatusChanged   = "changed"
+	DiffStatusUnchanged = "unchanged"
+)
+
+// ScanDiffEntry represents a single port's state in the scan diff.
+type ScanDiffEntry struct {
+	Port           int     `json:"port"`
+	Protocol       string  `json:"protocol"`
+	State          string  `json:"state"`
+	ServiceName    *string `json:"service_name,omitempty"`
+	ServiceVersion *string `json:"service_version,omitempty"`
+	// Status is "new" | "closed" | "changed" | "unchanged"
+	Status string `json:"status"`
+	// Previous values — only set when Status == "changed" or Status == "closed"
+	PrevState          *string `json:"prev_state,omitempty"`
+	PrevServiceName    *string `json:"prev_service_name,omitempty"`
+	PrevServiceVersion *string `json:"prev_service_version,omitempty"`
+}
+
+// ScanDiff is the result of comparing two scans of the same host.
+type ScanDiff struct {
+	ScanAID uuid.UUID       `json:"scan_a_id"`
+	ScanBID uuid.UUID       `json:"scan_b_id"`
+	HostID  uuid.UUID       `json:"host_id"`
+	Ports   []ScanDiffEntry `json:"ports"`
+	// OS change between scans
+	OSChanged  bool    `json:"os_changed"`
+	PrevOSName *string `json:"prev_os_name,omitempty"`
+	CurrOSName *string `json:"curr_os_name,omitempty"`
+	// Summary counts
+	NewCount       int `json:"new_count"`
+	ClosedCount    int `json:"closed_count"`
+	ChangedCount   int `json:"changed_count"`
+	UnchangedCount int `json:"unchanged_count"`
+}

--- a/internal/db/search_models.go
+++ b/internal/db/search_models.go
@@ -1,0 +1,16 @@
+// Package db provides search result models for unified cross-entity search.
+package db
+
+// SearchResult represents a single search hit from any entity type.
+type SearchResult struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+	URL   string `json:"url"`
+	Type  string `json:"type"`
+}
+
+// SearchResults is the top-level response returned by the search endpoint.
+type SearchResults struct {
+	Results map[string][]SearchResult `json:"results"`
+	Total   int                       `json:"total"`
+}

--- a/internal/db/webhook_models.go
+++ b/internal/db/webhook_models.go
@@ -30,6 +30,54 @@ type WebhookDeliveryLog struct {
 	CreatedAt    time.Time  `db:"created_at"    json:"created_at"`
 }
 
+// WebhookResponse is the read DTO for webhook endpoints.
+// The secret is intentionally omitted to avoid leaking it after creation.
+type WebhookResponse struct {
+	ID        uuid.UUID `json:"id"`
+	URL       string    `json:"url"`
+	Events    []string  `json:"events"`
+	Enabled   bool      `json:"enabled"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// WebhookCreateResponse is the DTO returned only on POST /webhooks.
+// It includes the secret once so callers can store it.
+type WebhookCreateResponse struct {
+	ID        uuid.UUID `json:"id"`
+	URL       string    `json:"url"`
+	Secret    string    `json:"secret"`
+	Events    []string  `json:"events"`
+	Enabled   bool      `json:"enabled"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// ToResponse converts a WebhookEndpoint to the read DTO (secret omitted).
+func (e *WebhookEndpoint) ToResponse() *WebhookResponse {
+	return &WebhookResponse{
+		ID:        e.ID,
+		URL:       e.URL,
+		Events:    e.Events,
+		Enabled:   e.Enabled,
+		CreatedAt: e.CreatedAt,
+		UpdatedAt: e.UpdatedAt,
+	}
+}
+
+// ToCreateResponse converts a WebhookEndpoint to the create DTO (secret included).
+func (e *WebhookEndpoint) ToCreateResponse() *WebhookCreateResponse {
+	return &WebhookCreateResponse{
+		ID:        e.ID,
+		URL:       e.URL,
+		Secret:    e.Secret,
+		Events:    e.Events,
+		Enabled:   e.Enabled,
+		CreatedAt: e.CreatedAt,
+		UpdatedAt: e.UpdatedAt,
+	}
+}
+
 // CreateWebhookInput is the input for creating a new webhook endpoint.
 type CreateWebhookInput struct {
 	URL    string

--- a/internal/db/webhook_models.go
+++ b/internal/db/webhook_models.go
@@ -1,0 +1,46 @@
+package db
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// WebhookEndpoint represents a registered webhook delivery target.
+type WebhookEndpoint struct {
+	ID        uuid.UUID `db:"id"        json:"id"`
+	URL       string    `db:"url"       json:"url"`
+	Secret    string    `db:"secret"    json:"secret"`
+	Events    []string  `db:"events"    json:"events"`
+	Enabled   bool      `db:"enabled"   json:"enabled"`
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
+	UpdatedAt time.Time `db:"updated_at" json:"updated_at"`
+}
+
+// WebhookDeliveryLog records a single delivery attempt for a webhook endpoint.
+type WebhookDeliveryLog struct {
+	ID           uuid.UUID  `db:"id"            json:"id"`
+	EndpointID   uuid.UUID  `db:"endpoint_id"   json:"endpoint_id"`
+	EventType    string     `db:"event_type"    json:"event_type"`
+	Payload      []byte     `db:"payload"       json:"payload"`
+	StatusCode   *int       `db:"status_code"   json:"status_code"`
+	AttemptCount int        `db:"attempt_count" json:"attempt_count"`
+	LastError    *string    `db:"last_error"    json:"last_error"`
+	DeliveredAt  *time.Time `db:"delivered_at"  json:"delivered_at"`
+	CreatedAt    time.Time  `db:"created_at"    json:"created_at"`
+}
+
+// CreateWebhookInput is the input for creating a new webhook endpoint.
+type CreateWebhookInput struct {
+	URL    string
+	Secret string
+	Events []string
+}
+
+// UpdateWebhookInput is the input for updating an existing webhook endpoint.
+type UpdateWebhookInput struct {
+	URL     *string
+	Secret  *string
+	Events  []string
+	Enabled *bool
+}

--- a/internal/db/webhook_repository.go
+++ b/internal/db/webhook_repository.go
@@ -1,0 +1,199 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	stderrors "errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+
+	"github.com/anstrom/scanorama/internal/errors"
+)
+
+// WebhookRepository handles all webhook-related DB operations.
+type WebhookRepository struct {
+	db *DB
+}
+
+// NewWebhookRepository creates a new WebhookRepository.
+func NewWebhookRepository(db *DB) *WebhookRepository {
+	return &WebhookRepository{db: db}
+}
+
+// ListWebhooks returns all webhook endpoints ordered by creation time.
+func (r *WebhookRepository) ListWebhooks(ctx context.Context) ([]*WebhookEndpoint, error) {
+	q := `SELECT id, url, secret, events, enabled, created_at, updated_at
+	      FROM webhook_endpoints ORDER BY created_at DESC`
+
+	rows, err := r.db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, sanitizeDBError("list webhooks", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make([]*WebhookEndpoint, 0)
+	for rows.Next() {
+		w := &WebhookEndpoint{}
+		if err := rows.Scan(
+			&w.ID, &w.URL, &w.Secret, pq.Array(&w.Events),
+			&w.Enabled, &w.CreatedAt, &w.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan webhook endpoint: %w", err)
+		}
+		result = append(result, w)
+	}
+	return result, rows.Err()
+}
+
+// CreateWebhook inserts a new webhook endpoint.
+func (r *WebhookRepository) CreateWebhook(ctx context.Context, input CreateWebhookInput) (*WebhookEndpoint, error) {
+	q := `INSERT INTO webhook_endpoints (url, secret, events)
+	      VALUES ($1, $2, $3)
+	      RETURNING id, url, secret, events, enabled, created_at, updated_at`
+
+	w := &WebhookEndpoint{}
+	err := r.db.QueryRowContext(ctx, q, input.URL, input.Secret, pq.Array(input.Events)).Scan(
+		&w.ID, &w.URL, &w.Secret, pq.Array(&w.Events),
+		&w.Enabled, &w.CreatedAt, &w.UpdatedAt,
+	)
+	if err != nil {
+		return nil, sanitizeDBError("create webhook", err)
+	}
+	return w, nil
+}
+
+// GetWebhook retrieves a webhook endpoint by ID.
+func (r *WebhookRepository) GetWebhook(ctx context.Context, id uuid.UUID) (*WebhookEndpoint, error) {
+	q := `SELECT id, url, secret, events, enabled, created_at, updated_at
+	      FROM webhook_endpoints WHERE id = $1`
+
+	w := &WebhookEndpoint{}
+	err := r.db.QueryRowContext(ctx, q, id).Scan(
+		&w.ID, &w.URL, &w.Secret, pq.Array(&w.Events),
+		&w.Enabled, &w.CreatedAt, &w.UpdatedAt,
+	)
+	if stderrors.Is(err, sql.ErrNoRows) {
+		return nil, errors.NewScanError(errors.CodeNotFound, "webhook not found")
+	}
+	if err != nil {
+		return nil, sanitizeDBError("get webhook", err)
+	}
+	return w, nil
+}
+
+// UpdateWebhook applies partial updates to a webhook endpoint.
+func (r *WebhookRepository) UpdateWebhook(
+	ctx context.Context, id uuid.UUID, input UpdateWebhookInput,
+) (*WebhookEndpoint, error) {
+	var eventsArg interface{}
+	if len(input.Events) > 0 {
+		eventsArg = pq.Array(input.Events)
+	}
+
+	q := `UPDATE webhook_endpoints SET
+	          url        = COALESCE($2, url),
+	          secret     = COALESCE($3, secret),
+	          events     = COALESCE($4, events),
+	          enabled    = COALESCE($5, enabled),
+	          updated_at = NOW()
+	      WHERE id = $1
+	      RETURNING id, url, secret, events, enabled, created_at, updated_at`
+
+	w := &WebhookEndpoint{}
+	err := r.db.QueryRowContext(ctx, q, id, input.URL, input.Secret, eventsArg, input.Enabled).Scan(
+		&w.ID, &w.URL, &w.Secret, pq.Array(&w.Events),
+		&w.Enabled, &w.CreatedAt, &w.UpdatedAt,
+	)
+	if stderrors.Is(err, sql.ErrNoRows) {
+		return nil, errors.NewScanError(errors.CodeNotFound, "webhook not found")
+	}
+	if err != nil {
+		return nil, sanitizeDBError("update webhook", err)
+	}
+	return w, nil
+}
+
+// DeleteWebhook removes a webhook endpoint by ID.
+func (r *WebhookRepository) DeleteWebhook(ctx context.Context, id uuid.UUID) error {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM webhook_endpoints WHERE id = $1`, id)
+	if err != nil {
+		return sanitizeDBError("delete webhook", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return errors.NewScanError(errors.CodeNotFound, "webhook not found")
+	}
+	return nil
+}
+
+// ListWebhooksByEvent returns all enabled webhook endpoints subscribed to the given event type.
+func (r *WebhookRepository) ListWebhooksByEvent(ctx context.Context, eventType string) ([]*WebhookEndpoint, error) {
+	q := `SELECT id, url, secret, events, enabled, created_at, updated_at
+	      FROM webhook_endpoints
+	      WHERE enabled = TRUE AND $1 = ANY(events)
+	      ORDER BY created_at`
+
+	rows, err := r.db.QueryContext(ctx, q, eventType)
+	if err != nil {
+		return nil, sanitizeDBError("list webhooks by event", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make([]*WebhookEndpoint, 0)
+	for rows.Next() {
+		w := &WebhookEndpoint{}
+		if err := rows.Scan(
+			&w.ID, &w.URL, &w.Secret, pq.Array(&w.Events),
+			&w.Enabled, &w.CreatedAt, &w.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan webhook endpoint by event: %w", err)
+		}
+		result = append(result, w)
+	}
+	return result, rows.Err()
+}
+
+// CreateDeliveryLog inserts a delivery log record.
+func (r *WebhookRepository) CreateDeliveryLog(ctx context.Context, log WebhookDeliveryLog) error {
+	q := `INSERT INTO webhook_delivery_log
+	          (endpoint_id, event_type, payload, status_code, attempt_count, last_error, delivered_at)
+	      VALUES ($1, $2, $3, $4, $5, $6, $7)`
+	_, err := r.db.ExecContext(ctx, q,
+		log.EndpointID, log.EventType, log.Payload,
+		log.StatusCode, log.AttemptCount, log.LastError, log.DeliveredAt,
+	)
+	return sanitizeDBError("create delivery log", err)
+}
+
+// ListDeliveryLogs returns delivery logs for a webhook endpoint, newest first.
+func (r *WebhookRepository) ListDeliveryLogs(
+	ctx context.Context, endpointID uuid.UUID, limit int,
+) ([]*WebhookDeliveryLog, error) {
+	q := `SELECT id, endpoint_id, event_type, payload, status_code,
+	             attempt_count, last_error, delivered_at, created_at
+	      FROM webhook_delivery_log
+	      WHERE endpoint_id = $1
+	      ORDER BY created_at DESC
+	      LIMIT $2`
+
+	rows, err := r.db.QueryContext(ctx, q, endpointID, limit)
+	if err != nil {
+		return nil, sanitizeDBError("list delivery logs", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make([]*WebhookDeliveryLog, 0)
+	for rows.Next() {
+		l := &WebhookDeliveryLog{}
+		if err := rows.Scan(
+			&l.ID, &l.EndpointID, &l.EventType, &l.Payload,
+			&l.StatusCode, &l.AttemptCount, &l.LastError, &l.DeliveredAt, &l.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan delivery log: %w", err)
+		}
+		result = append(result, l)
+	}
+	return result, rows.Err()
+}

--- a/internal/scanning/scan.go
+++ b/internal/scanning/scan.go
@@ -681,6 +681,7 @@ func storeScanResults(
 		} else {
 			go runKnowledgeScoreUpdate(database, hostIDs)
 		}
+		go callAlertEvaluator()
 	}
 
 	// Launch banner enrichment in the background — best-effort, non-blocking.

--- a/internal/scanning/smartscan_hook.go
+++ b/internal/scanning/smartscan_hook.go
@@ -2,11 +2,70 @@
 package scanning
 
 import (
+	"context"
+	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/anstrom/scanorama/internal/db"
 	"github.com/google/uuid"
 )
+
+// alertEvalWindow is the look-back window used on the very first evaluation
+// (before a cursor has been established).
+const alertEvalWindow = 5 * time.Minute
+
+// alertEvaluatorFn is the type for the alert evaluation hook callback.
+type alertEvaluatorFn func(ctx context.Context, since time.Time) error
+
+var (
+	alertEvaluatorMu   sync.RWMutex
+	alertEvaluatorFunc alertEvaluatorFn
+	// lastAlertEvalAt is the timestamp of the last successful evaluation.
+	// Zero value means never evaluated; the initial window falls back to
+	// alertEvalWindow. Protected by alertEvaluatorMu.
+	lastAlertEvalAt time.Time
+)
+
+// SetAlertEvaluator registers a callback that evaluates alert rules after
+// each scan completes. Call once at application startup. Pass nil to clear.
+func SetAlertEvaluator(fn alertEvaluatorFn) {
+	alertEvaluatorMu.Lock()
+	alertEvaluatorFunc = fn
+	alertEvaluatorMu.Unlock()
+}
+
+// callAlertEvaluator invokes the registered alert evaluator, if any.
+// Called as a goroutine after scan results are stored. Uses a persistent
+// cursor so each transition is evaluated at most once across multiple scans.
+func callAlertEvaluator() {
+	alertEvaluatorMu.RLock()
+	fn := alertEvaluatorFunc
+	last := lastAlertEvalAt
+	alertEvaluatorMu.RUnlock()
+	if fn == nil {
+		return
+	}
+
+	var since time.Time
+	if last.IsZero() {
+		since = time.Now().Add(-alertEvalWindow)
+	} else {
+		since = last
+	}
+
+	// Snapshot call time before invoking fn so any transition recorded
+	// during this evaluation is included in the next window.
+	callTime := time.Now()
+	if err := fn(context.Background(), since); err != nil {
+		slog.Error("alert evaluation failed", "error", err)
+		return
+	}
+
+	alertEvaluatorMu.Lock()
+	lastAlertEvalAt = callTime
+	alertEvaluatorMu.Unlock()
+}
 
 // postScanHookFn is the type for post-scan hook callbacks.
 type postScanHookFn func(database *db.DB, hostIDs []uuid.UUID)

--- a/internal/services/alert_service.go
+++ b/internal/services/alert_service.go
@@ -1,0 +1,260 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+const alertDeliveryTimeout = 30 * time.Second
+
+// alertRepo is the data-access interface used by AlertService.
+type alertRepo interface {
+	ListAlertRules(ctx context.Context) ([]*db.AlertRule, error)
+	ListAlertRulesForHost(ctx context.Context, hostID uuid.UUID) ([]*db.AlertRule, error)
+	CreateAlertRule(ctx context.Context, input db.CreateAlertRuleInput) (*db.AlertRule, error)
+	GetAlertRule(ctx context.Context, id uuid.UUID) (*db.AlertRule, error)
+	UpdateAlertRule(ctx context.Context, id uuid.UUID, input db.UpdateAlertRuleInput) (*db.AlertRule, error)
+	DeleteAlertRule(ctx context.Context, id uuid.UUID) error
+	GetStatusTransitionsSince(ctx context.Context, since time.Time) ([]db.StatusTransitionRow, error)
+}
+
+// alertWebhookDeliverer is the subset of WebhookService used by AlertService.
+// It posts directly to a caller-supplied URL rather than fanning out to all
+// registered webhook subscribers.
+type alertWebhookDeliverer interface {
+	DeliverToURL(ctx context.Context, url string, event WebhookEvent) error
+}
+
+// AlertService handles alert rule management and event-driven alert evaluation.
+type AlertService struct {
+	repo    alertRepo
+	webhook alertWebhookDeliverer
+	logger  *slog.Logger
+}
+
+// NewAlertService creates a new AlertService.
+func NewAlertService(
+	repo alertRepo, webhook alertWebhookDeliverer, logger *slog.Logger,
+) *AlertService {
+	return &AlertService{
+		repo:    repo,
+		webhook: webhook,
+		logger:  logger.With("service", "alert"),
+	}
+}
+
+// ListAlertRules returns all configured alert rules.
+func (s *AlertService) ListAlertRules(ctx context.Context) ([]*db.AlertRule, error) {
+	return s.repo.ListAlertRules(ctx)
+}
+
+// ListAlertRulesForHost returns alert rules targeting a specific host.
+func (s *AlertService) ListAlertRulesForHost(
+	ctx context.Context, hostID uuid.UUID,
+) ([]*db.AlertRule, error) {
+	return s.repo.ListAlertRulesForHost(ctx, hostID)
+}
+
+// CreateAlertRule validates inputs and creates a new alert rule.
+func (s *AlertService) CreateAlertRule(
+	ctx context.Context, input db.CreateAlertRuleInput,
+) (*db.AlertRule, error) {
+	if err := validateAlertTrigger(input.Trigger); err != nil {
+		return nil, err
+	}
+	if err := validateAlertChannelURL(input.ChannelURL); err != nil {
+		return nil, err
+	}
+	if err := validateAlertTarget(input.HostID, input.GroupID, input.Tag); err != nil {
+		return nil, err
+	}
+	return s.repo.CreateAlertRule(ctx, input)
+}
+
+// GetAlertRule retrieves a single alert rule by ID.
+func (s *AlertService) GetAlertRule(ctx context.Context, id uuid.UUID) (*db.AlertRule, error) {
+	return s.repo.GetAlertRule(ctx, id)
+}
+
+// UpdateAlertRule applies partial updates to an alert rule.
+func (s *AlertService) UpdateAlertRule(
+	ctx context.Context, id uuid.UUID, input db.UpdateAlertRuleInput,
+) (*db.AlertRule, error) {
+	if input.Trigger != nil {
+		if err := validateAlertTrigger(*input.Trigger); err != nil {
+			return nil, err
+		}
+	}
+	if input.ChannelURL != nil {
+		if err := validateAlertChannelURL(*input.ChannelURL); err != nil {
+			return nil, err
+		}
+	}
+	return s.repo.UpdateAlertRule(ctx, id, input)
+}
+
+// DeleteAlertRule removes an alert rule by ID.
+func (s *AlertService) DeleteAlertRule(ctx context.Context, id uuid.UUID) error {
+	return s.repo.DeleteAlertRule(ctx, id)
+}
+
+// alertPayload is the webhook payload fired for each matched alert.
+type alertPayload struct {
+	HostID     uuid.UUID `json:"host_id"`
+	Trigger    string    `json:"trigger"`
+	FromStatus string    `json:"from_status"`
+	ToStatus   string    `json:"to_status"`
+	ChangedAt  time.Time `json:"changed_at"`
+	RuleID     uuid.UUID `json:"rule_id"`
+}
+
+// EvaluateAlerts loads recent status transitions and fires webhook deliveries
+// for each matching enabled alert rule. It returns nil even when individual
+// deliveries fail — they are non-blocking.
+func (s *AlertService) EvaluateAlerts(ctx context.Context, since time.Time) error {
+	transitions, err := s.repo.GetStatusTransitionsSince(ctx, since)
+	if err != nil {
+		return fmt.Errorf("get status transitions: %w", err)
+	}
+	if len(transitions) == 0 {
+		return nil
+	}
+
+	rules, err := s.repo.ListAlertRules(ctx)
+	if err != nil {
+		return fmt.Errorf("list alert rules: %w", err)
+	}
+
+	for i := range transitions {
+		t := &transitions[i]
+		// Skip no-op transitions (guard against identical from/to status).
+		if t.FromStatus == t.ToStatus {
+			continue
+		}
+		for _, rule := range rules {
+			if !rule.Enabled {
+				continue
+			}
+			if !ruleMatchesTransition(rule, t) {
+				continue
+			}
+			if !triggerMatchesTransition(rule.Trigger, t.ToStatus) {
+				continue
+			}
+			s.fireAlert(rule, t)
+		}
+	}
+	return nil
+}
+
+// ruleMatchesTransition returns true when the rule's target (host or tag)
+// matches the given transition. Group matching is not yet implemented.
+func ruleMatchesTransition(rule *db.AlertRule, t *db.StatusTransitionRow) bool {
+	if rule.HostID != nil && *rule.HostID == t.HostID {
+		return true
+	}
+	if rule.Tag != nil {
+		for _, tag := range t.Tags {
+			if tag == *rule.Tag {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// triggerMatchesTransition returns true when the rule trigger matches the
+// direction of the transition.
+func triggerMatchesTransition(trigger, toStatus string) bool {
+	switch trigger {
+	case db.AlertTriggerOnline:
+		return toStatus == db.HostStatusUp
+	case db.AlertTriggerOffline:
+		return toStatus == db.HostStatusDown
+	case db.AlertTriggerBoth:
+		return toStatus == db.HostStatusUp || toStatus == db.HostStatusDown
+	default:
+		return false
+	}
+}
+
+// fireAlert delivers a single alert webhook event for a matched rule.
+// It posts directly to rule.ChannelURL without going through the subscriber
+// fanout — each alert rule targets exactly one endpoint.
+func (s *AlertService) fireAlert(rule *db.AlertRule, t *db.StatusTransitionRow) {
+	eventType := EventHostOnline
+	if t.ToStatus == db.HostStatusDown {
+		eventType = EventHostOffline
+	}
+	event := WebhookEvent{
+		Type: eventType,
+		Payload: alertPayload{
+			HostID:     t.HostID,
+			Trigger:    rule.Trigger,
+			FromStatus: t.FromStatus,
+			ToStatus:   t.ToStatus,
+			ChangedAt:  t.ChangedAt,
+			RuleID:     rule.ID,
+		},
+		FiredAt: time.Now().UTC(),
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), alertDeliveryTimeout)
+		defer cancel()
+		if err := s.webhook.DeliverToURL(ctx, rule.ChannelURL, event); err != nil {
+			s.logger.Warn("alert webhook delivery failed",
+				"rule_id", rule.ID,
+				"host_id", t.HostID,
+				"error", err,
+			)
+		}
+	}()
+}
+
+// validateAlertTrigger checks that trigger is one of the allowed values.
+func validateAlertTrigger(trigger string) error {
+	switch trigger {
+	case db.AlertTriggerOnline, db.AlertTriggerOffline, db.AlertTriggerBoth:
+		return nil
+	default:
+		return fmt.Errorf("trigger must be one of: online, offline, both")
+	}
+}
+
+// validateAlertChannelURL checks that the URL is non-empty and http/https.
+func validateAlertChannelURL(url string) error {
+	if url == "" {
+		return fmt.Errorf("channel_url is required")
+	}
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		return fmt.Errorf("channel_url must start with http:// or https://")
+	}
+	return nil
+}
+
+// validateAlertTarget ensures exactly one of hostID or tag is set.
+// group_id is accepted in the schema for future use but not yet evaluated —
+// reject it at the API layer until group matching is implemented.
+func validateAlertTarget(hostID, groupID *uuid.UUID, tag *string) error {
+	if groupID != nil {
+		return fmt.Errorf("group-based alert rules are not yet supported")
+	}
+	count := 0
+	if hostID != nil {
+		count++
+	}
+	if tag != nil && *tag != "" {
+		count++
+	}
+	if count != 1 {
+		return fmt.Errorf("exactly one of host_id or tag must be set")
+	}
+	return nil
+}

--- a/internal/services/alert_service_test.go
+++ b/internal/services/alert_service_test.go
@@ -1,0 +1,603 @@
+// Package services contains unit tests for the alert service business logic.
+// These tests use hand-rolled mocks so no database or external dependencies
+// are required.
+package services
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hand-rolled mock repository
+// ─────────────────────────────────────────────────────────────────────────────
+
+// updateAlertFn is the type for the UpdateAlertRule mock function field.
+type updateAlertFn func(
+	ctx context.Context, id uuid.UUID, input db.UpdateAlertRuleInput,
+) (*db.AlertRule, error)
+
+type mockAlertRepo struct {
+	listAlertRulesFn            func(ctx context.Context) ([]*db.AlertRule, error)
+	listAlertRulesForHostFn     func(ctx context.Context, hostID uuid.UUID) ([]*db.AlertRule, error)
+	createAlertRuleFn           func(ctx context.Context, input db.CreateAlertRuleInput) (*db.AlertRule, error)
+	getAlertRuleFn              func(ctx context.Context, id uuid.UUID) (*db.AlertRule, error)
+	updateAlertRuleFn           updateAlertFn
+	deleteAlertRuleFn           func(ctx context.Context, id uuid.UUID) error
+	getStatusTransitionsSinceFn func(ctx context.Context, since time.Time) ([]db.StatusTransitionRow, error)
+}
+
+func (m *mockAlertRepo) ListAlertRules(ctx context.Context) ([]*db.AlertRule, error) {
+	if m.listAlertRulesFn != nil {
+		return m.listAlertRulesFn(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockAlertRepo) ListAlertRulesForHost(ctx context.Context, hostID uuid.UUID) ([]*db.AlertRule, error) {
+	if m.listAlertRulesForHostFn != nil {
+		return m.listAlertRulesForHostFn(ctx, hostID)
+	}
+	return nil, nil
+}
+
+func (m *mockAlertRepo) CreateAlertRule(
+	ctx context.Context, input db.CreateAlertRuleInput,
+) (*db.AlertRule, error) {
+	if m.createAlertRuleFn != nil {
+		return m.createAlertRuleFn(ctx, input)
+	}
+	return nil, nil
+}
+
+func (m *mockAlertRepo) GetAlertRule(ctx context.Context, id uuid.UUID) (*db.AlertRule, error) {
+	if m.getAlertRuleFn != nil {
+		return m.getAlertRuleFn(ctx, id)
+	}
+	return nil, nil
+}
+
+func (m *mockAlertRepo) UpdateAlertRule(
+	ctx context.Context, id uuid.UUID, input db.UpdateAlertRuleInput,
+) (*db.AlertRule, error) {
+	if m.updateAlertRuleFn != nil {
+		return m.updateAlertRuleFn(ctx, id, input)
+	}
+	return nil, nil
+}
+
+func (m *mockAlertRepo) DeleteAlertRule(ctx context.Context, id uuid.UUID) error {
+	if m.deleteAlertRuleFn != nil {
+		return m.deleteAlertRuleFn(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockAlertRepo) GetStatusTransitionsSince(
+	ctx context.Context, since time.Time,
+) ([]db.StatusTransitionRow, error) {
+	if m.getStatusTransitionsSinceFn != nil {
+		return m.getStatusTransitionsSinceFn(ctx, since)
+	}
+	return nil, nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hand-rolled mock webhook deliverer
+// ─────────────────────────────────────────────────────────────────────────────
+
+type mockWebhookDeliverer struct {
+	deliverToURLFn func(ctx context.Context, url string, event WebhookEvent) error
+}
+
+func (m *mockWebhookDeliverer) DeliverToURL(ctx context.Context, url string, event WebhookEvent) error {
+	if m.deliverToURLFn != nil {
+		return m.deliverToURLFn(ctx, url, event)
+	}
+	return nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+func newTestAlertService(repo alertRepo, webhook alertWebhookDeliverer) *AlertService {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewAlertService(repo, webhook, logger)
+}
+
+func ptr[T any](v T) *T { return &v }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CreateAlertRule — validation tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestAlertService_CreateAlertRule_InvalidTrigger(t *testing.T) {
+	svc := newTestAlertService(&mockAlertRepo{}, &mockWebhookDeliverer{})
+	hostID := uuid.New()
+	_, err := svc.CreateAlertRule(context.Background(), db.CreateAlertRuleInput{
+		Trigger:    "bad",
+		ChannelURL: "https://example.com/hook",
+		HostID:     &hostID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trigger")
+}
+
+func TestAlertService_CreateAlertRule_InvalidChannelURL(t *testing.T) {
+	svc := newTestAlertService(&mockAlertRepo{}, &mockWebhookDeliverer{})
+	hostID := uuid.New()
+	_, err := svc.CreateAlertRule(context.Background(), db.CreateAlertRuleInput{
+		Trigger:    db.AlertTriggerOnline,
+		ChannelURL: "",
+		HostID:     &hostID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "channel_url")
+}
+
+func TestAlertService_CreateAlertRule_URLNotHTTP(t *testing.T) {
+	svc := newTestAlertService(&mockAlertRepo{}, &mockWebhookDeliverer{})
+	hostID := uuid.New()
+	_, err := svc.CreateAlertRule(context.Background(), db.CreateAlertRuleInput{
+		Trigger:    db.AlertTriggerOnline,
+		ChannelURL: "ftp://example.com/hook",
+		HostID:     &hostID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "channel_url")
+}
+
+func TestAlertService_CreateAlertRule_NoTarget(t *testing.T) {
+	svc := newTestAlertService(&mockAlertRepo{}, &mockWebhookDeliverer{})
+	_, err := svc.CreateAlertRule(context.Background(), db.CreateAlertRuleInput{
+		Trigger:    db.AlertTriggerOnline,
+		ChannelURL: "https://example.com/hook",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one")
+}
+
+func TestAlertService_CreateAlertRule_MultipleTargets(t *testing.T) {
+	svc := newTestAlertService(&mockAlertRepo{}, &mockWebhookDeliverer{})
+	hostID := uuid.New()
+	tag := "server"
+	_, err := svc.CreateAlertRule(context.Background(), db.CreateAlertRuleInput{
+		Trigger:    db.AlertTriggerOnline,
+		ChannelURL: "https://example.com/hook",
+		HostID:     &hostID,
+		Tag:        &tag,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one")
+}
+
+func TestAlertService_CreateAlertRule_GroupIDRejected(t *testing.T) {
+	svc := newTestAlertService(&mockAlertRepo{}, &mockWebhookDeliverer{})
+	groupID := uuid.New()
+	_, err := svc.CreateAlertRule(context.Background(), db.CreateAlertRuleInput{
+		Trigger:    db.AlertTriggerOnline,
+		ChannelURL: "https://example.com/hook",
+		GroupID:    &groupID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "group-based alert rules are not yet supported")
+}
+
+func TestAlertService_CreateAlertRule_ValidHost(t *testing.T) {
+	hostID := uuid.New()
+	ruleID := uuid.New()
+	expected := &db.AlertRule{
+		ID:         ruleID,
+		HostID:     &hostID,
+		Trigger:    db.AlertTriggerOnline,
+		ChannelURL: "https://example.com/hook",
+		Enabled:    true,
+	}
+
+	called := false
+	repo := &mockAlertRepo{
+		createAlertRuleFn: func(_ context.Context, input db.CreateAlertRuleInput) (*db.AlertRule, error) {
+			called = true
+			assert.Equal(t, hostID, *input.HostID)
+			assert.Equal(t, db.AlertTriggerOnline, input.Trigger)
+			return expected, nil
+		},
+	}
+	svc := newTestAlertService(repo, &mockWebhookDeliverer{})
+
+	got, err := svc.CreateAlertRule(context.Background(), db.CreateAlertRuleInput{
+		Trigger:    db.AlertTriggerOnline,
+		ChannelURL: "https://example.com/hook",
+		HostID:     &hostID,
+	})
+	require.NoError(t, err)
+	require.True(t, called, "repo.CreateAlertRule was not called")
+	assert.Equal(t, expected, got)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// UpdateAlertRule — validation tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestAlertService_UpdateAlertRule_InvalidTrigger(t *testing.T) {
+	svc := newTestAlertService(&mockAlertRepo{}, &mockWebhookDeliverer{})
+	_, err := svc.UpdateAlertRule(context.Background(), uuid.New(), db.UpdateAlertRuleInput{
+		Trigger: ptr("bad"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trigger")
+}
+
+func TestAlertService_UpdateAlertRule_InvalidChannelURL(t *testing.T) {
+	svc := newTestAlertService(&mockAlertRepo{}, &mockWebhookDeliverer{})
+	_, err := svc.UpdateAlertRule(context.Background(), uuid.New(), db.UpdateAlertRuleInput{
+		ChannelURL: ptr(""),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "channel_url")
+}
+
+func TestAlertService_UpdateAlertRule_NilTrigger(t *testing.T) {
+	ruleID := uuid.New()
+	expected := &db.AlertRule{ID: ruleID, Enabled: false}
+
+	called := false
+	repo := &mockAlertRepo{
+		updateAlertRuleFn: func(_ context.Context, id uuid.UUID, _ db.UpdateAlertRuleInput) (*db.AlertRule, error) {
+			called = true
+			assert.Equal(t, ruleID, id)
+			return expected, nil
+		},
+	}
+	svc := newTestAlertService(repo, &mockWebhookDeliverer{})
+
+	got, err := svc.UpdateAlertRule(context.Background(), ruleID, db.UpdateAlertRuleInput{
+		Enabled: ptr(false),
+	})
+	require.NoError(t, err)
+	require.True(t, called, "repo.UpdateAlertRule was not called")
+	assert.Equal(t, expected, got)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// EvaluateAlerts tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestAlertService_EvaluateAlerts_NoTransitions(t *testing.T) {
+	listCalled := false
+	repo := &mockAlertRepo{
+		getStatusTransitionsSinceFn: func(_ context.Context, _ time.Time) ([]db.StatusTransitionRow, error) {
+			return []db.StatusTransitionRow{}, nil
+		},
+		listAlertRulesFn: func(_ context.Context) ([]*db.AlertRule, error) {
+			listCalled = true
+			return nil, nil
+		},
+	}
+	svc := newTestAlertService(repo, &mockWebhookDeliverer{})
+
+	err := svc.EvaluateAlerts(context.Background(), time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+	assert.False(t, listCalled, "ListAlertRules should not be called when there are no transitions")
+}
+
+func TestAlertService_EvaluateAlerts_SkipsIdenticalTransitions(t *testing.T) {
+	hostID := uuid.New()
+	ruleID := uuid.New()
+
+	repo := &mockAlertRepo{
+		getStatusTransitionsSinceFn: func(_ context.Context, _ time.Time) ([]db.StatusTransitionRow, error) {
+			return []db.StatusTransitionRow{
+				{HostID: hostID, FromStatus: db.HostStatusUp, ToStatus: db.HostStatusUp, ChangedAt: time.Now()},
+			}, nil
+		},
+		listAlertRulesFn: func(_ context.Context) ([]*db.AlertRule, error) {
+			return []*db.AlertRule{
+				{
+					ID: ruleID, HostID: &hostID,
+					Trigger: db.AlertTriggerOnline, ChannelURL: "https://x.com", Enabled: true,
+				},
+			}, nil
+		},
+	}
+	deliverCalled := false
+	webhook := &mockWebhookDeliverer{
+		deliverToURLFn: func(_ context.Context, _ string, _ WebhookEvent) error {
+			deliverCalled = true
+			return nil
+		},
+	}
+	svc := newTestAlertService(repo, webhook)
+
+	err := svc.EvaluateAlerts(context.Background(), time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+	// Allow a brief moment for any goroutines that might have been spawned.
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, deliverCalled, "Deliver should not be called for identical from/to status")
+}
+
+func TestAlertService_EvaluateAlerts_FiresForMatchingHostRule(t *testing.T) {
+	hostID := uuid.New()
+	ruleID := uuid.New()
+
+	repo := &mockAlertRepo{
+		getStatusTransitionsSinceFn: func(_ context.Context, _ time.Time) ([]db.StatusTransitionRow, error) {
+			return []db.StatusTransitionRow{
+				{HostID: hostID, FromStatus: db.HostStatusDown, ToStatus: db.HostStatusUp, ChangedAt: time.Now()},
+			}, nil
+		},
+		listAlertRulesFn: func(_ context.Context) ([]*db.AlertRule, error) {
+			return []*db.AlertRule{
+				{
+					ID: ruleID, HostID: &hostID,
+					Trigger: db.AlertTriggerOnline, ChannelURL: "https://x.com", Enabled: true,
+				},
+			}, nil
+		},
+	}
+
+	delivered := make(chan WebhookEvent, 1)
+	webhook := &mockWebhookDeliverer{
+		deliverToURLFn: func(_ context.Context, _ string, event WebhookEvent) error {
+			delivered <- event
+			return nil
+		},
+	}
+	svc := newTestAlertService(repo, webhook)
+
+	err := svc.EvaluateAlerts(context.Background(), time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+
+	select {
+	case event := <-delivered:
+		assert.Equal(t, EventHostOnline, event.Type)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for webhook delivery")
+	}
+}
+
+func TestAlertService_EvaluateAlerts_SkipsDisabledRule(t *testing.T) {
+	hostID := uuid.New()
+	ruleID := uuid.New()
+
+	repo := &mockAlertRepo{
+		getStatusTransitionsSinceFn: func(_ context.Context, _ time.Time) ([]db.StatusTransitionRow, error) {
+			return []db.StatusTransitionRow{
+				{HostID: hostID, FromStatus: db.HostStatusDown, ToStatus: db.HostStatusUp, ChangedAt: time.Now()},
+			}, nil
+		},
+		listAlertRulesFn: func(_ context.Context) ([]*db.AlertRule, error) {
+			return []*db.AlertRule{
+				{
+					ID: ruleID, HostID: &hostID, Trigger: db.AlertTriggerOnline,
+					ChannelURL: "https://x.com", Enabled: false,
+				},
+			}, nil
+		},
+	}
+	deliverCalled := false
+	webhook := &mockWebhookDeliverer{
+		deliverToURLFn: func(_ context.Context, _ string, _ WebhookEvent) error {
+			deliverCalled = true
+			return nil
+		},
+	}
+	svc := newTestAlertService(repo, webhook)
+
+	err := svc.EvaluateAlerts(context.Background(), time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, deliverCalled, "Deliver should not be called for a disabled rule")
+}
+
+func TestAlertService_EvaluateAlerts_TagMatching(t *testing.T) {
+	hostID := uuid.New()
+	ruleID := uuid.New()
+	tag := "server"
+
+	repo := &mockAlertRepo{
+		getStatusTransitionsSinceFn: func(_ context.Context, _ time.Time) ([]db.StatusTransitionRow, error) {
+			return []db.StatusTransitionRow{
+				{
+					HostID:     hostID,
+					FromStatus: db.HostStatusDown,
+					ToStatus:   db.HostStatusUp,
+					ChangedAt:  time.Now(),
+					Tags:       []string{"server", "prod"},
+				},
+			}, nil
+		},
+		listAlertRulesFn: func(_ context.Context) ([]*db.AlertRule, error) {
+			return []*db.AlertRule{
+				{ID: ruleID, Tag: &tag, Trigger: db.AlertTriggerOnline, ChannelURL: "https://x.com", Enabled: true},
+			}, nil
+		},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	delivered := make(chan WebhookEvent, 1)
+	webhook := &mockWebhookDeliverer{
+		deliverToURLFn: func(_ context.Context, _ string, event WebhookEvent) error {
+			delivered <- event
+			wg.Done()
+			return nil
+		},
+	}
+	svc := newTestAlertService(repo, webhook)
+
+	err := svc.EvaluateAlerts(context.Background(), time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+
+	select {
+	case event := <-delivered:
+		assert.Equal(t, EventHostOnline, event.Type)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for webhook delivery via tag matching")
+	}
+}
+
+func TestAlertService_EvaluateAlerts_TargetedDeliveryToChannelURL(t *testing.T) {
+	hostID := uuid.New()
+	ruleID := uuid.New()
+	wantURL := "https://alerts.example.com/hook"
+
+	repo := &mockAlertRepo{
+		getStatusTransitionsSinceFn: func(_ context.Context, _ time.Time) ([]db.StatusTransitionRow, error) {
+			return []db.StatusTransitionRow{
+				{HostID: hostID, FromStatus: db.HostStatusDown, ToStatus: db.HostStatusUp, ChangedAt: time.Now()},
+			}, nil
+		},
+		listAlertRulesFn: func(_ context.Context) ([]*db.AlertRule, error) {
+			return []*db.AlertRule{
+				{ID: ruleID, HostID: &hostID, Trigger: db.AlertTriggerOnline, ChannelURL: wantURL, Enabled: true},
+			}, nil
+		},
+	}
+
+	gotURL := make(chan string, 1)
+	webhook := &mockWebhookDeliverer{
+		deliverToURLFn: func(_ context.Context, url string, _ WebhookEvent) error {
+			gotURL <- url
+			return nil
+		},
+	}
+	svc := newTestAlertService(repo, webhook)
+
+	err := svc.EvaluateAlerts(context.Background(), time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+
+	select {
+	case url := <-gotURL:
+		assert.Equal(t, wantURL, url, "DeliverToURL should target the rule's channel_url, not a fan-out")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for targeted webhook delivery")
+	}
+}
+
+func TestAlertService_EvaluateAlerts_TriggerMismatch(t *testing.T) {
+	hostID := uuid.New()
+	ruleID := uuid.New()
+
+	repo := &mockAlertRepo{
+		getStatusTransitionsSinceFn: func(_ context.Context, _ time.Time) ([]db.StatusTransitionRow, error) {
+			return []db.StatusTransitionRow{
+				// Host went down, but rule only fires on online.
+				{HostID: hostID, FromStatus: db.HostStatusUp, ToStatus: db.HostStatusDown, ChangedAt: time.Now()},
+			}, nil
+		},
+		listAlertRulesFn: func(_ context.Context) ([]*db.AlertRule, error) {
+			return []*db.AlertRule{
+				{
+					ID: ruleID, HostID: &hostID,
+					Trigger: db.AlertTriggerOnline, ChannelURL: "https://x.com", Enabled: true,
+				},
+			}, nil
+		},
+	}
+	deliverCalled := false
+	webhook := &mockWebhookDeliverer{
+		deliverToURLFn: func(_ context.Context, _ string, _ WebhookEvent) error {
+			deliverCalled = true
+			return nil
+		},
+	}
+	svc := newTestAlertService(repo, webhook)
+
+	err := svc.EvaluateAlerts(context.Background(), time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, deliverCalled, "Deliver should not be called when trigger direction does not match")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper function unit tests (same package → unexported functions accessible)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestTriggerMatchesTransition(t *testing.T) {
+	tests := []struct {
+		trigger  string
+		toStatus string
+		want     bool
+	}{
+		{db.AlertTriggerOnline, db.HostStatusUp, true},
+		{db.AlertTriggerOnline, db.HostStatusDown, false},
+		{db.AlertTriggerOffline, db.HostStatusDown, true},
+		{db.AlertTriggerOffline, db.HostStatusUp, false},
+		{db.AlertTriggerBoth, db.HostStatusUp, true},
+		{db.AlertTriggerBoth, db.HostStatusDown, true},
+		{"unknown", db.HostStatusUp, false},
+		{"", db.HostStatusDown, false},
+	}
+	for _, tc := range tests {
+		got := triggerMatchesTransition(tc.trigger, tc.toStatus)
+		assert.Equal(t, tc.want, got, "trigger=%q toStatus=%q", tc.trigger, tc.toStatus)
+	}
+}
+
+func TestRuleMatchesTransition_HostID(t *testing.T) {
+	hostID := uuid.New()
+	otherID := uuid.New()
+
+	rule := &db.AlertRule{HostID: &hostID}
+	matching := &db.StatusTransitionRow{HostID: hostID}
+	notMatching := &db.StatusTransitionRow{HostID: otherID}
+
+	assert.True(t, ruleMatchesTransition(rule, matching))
+	assert.False(t, ruleMatchesTransition(rule, notMatching))
+}
+
+func TestRuleMatchesTransition_Tag(t *testing.T) {
+	tag := "web"
+	rule := &db.AlertRule{Tag: &tag}
+
+	withTag := &db.StatusTransitionRow{HostID: uuid.New(), Tags: []string{"web", "prod"}}
+	withoutTag := &db.StatusTransitionRow{HostID: uuid.New(), Tags: []string{"db", "prod"}}
+	noTags := &db.StatusTransitionRow{HostID: uuid.New(), Tags: []string{}}
+
+	assert.True(t, ruleMatchesTransition(rule, withTag))
+	assert.False(t, ruleMatchesTransition(rule, withoutTag))
+	assert.False(t, ruleMatchesTransition(rule, noTags))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// fireAlert — log on delivery failure (no panic, no return value)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestAlertService_FireAlert_LogsOnDeliveryFailure(t *testing.T) {
+	hostID := uuid.New()
+	ruleID := uuid.New()
+	rule := &db.AlertRule{ID: ruleID, Trigger: db.AlertTriggerOnline, ChannelURL: "https://x.com"}
+	transition := &db.StatusTransitionRow{HostID: hostID, ToStatus: db.HostStatusUp}
+
+	done := make(chan struct{})
+	webhook := &mockWebhookDeliverer{
+		deliverToURLFn: func(_ context.Context, _ string, _ WebhookEvent) error {
+			defer close(done)
+			return errors.New("delivery failed")
+		},
+	}
+	svc := newTestAlertService(&mockAlertRepo{}, webhook)
+
+	// Must not panic even when Deliver returns an error.
+	svc.fireAlert(rule, transition)
+
+	select {
+	case <-done:
+		// goroutine ran and returned error — logger swallowed it
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for fireAlert goroutine")
+	}
+}

--- a/internal/services/networks.go
+++ b/internal/services/networks.go
@@ -852,3 +852,26 @@ func (s *NetworkService) ListNetworks(ctx context.Context, activeOnly bool) ([]*
 
 	return networks, nil
 }
+
+// SearchNetworks returns networks whose name or CIDR matches the given query.
+func (s *NetworkService) SearchNetworks(ctx context.Context, query string, limit int) ([]*db.Network, error) {
+	q := `
+		SELECT
+			id, name, cidr, description, discovery_method,
+			is_active, scan_enabled, last_discovery, last_scan,
+			host_count, active_host_count, created_at, updated_at, created_by
+		FROM networks
+		WHERE name ILIKE $1 OR cidr::text ILIKE $1
+		ORDER BY name
+		LIMIT $2`
+
+	pattern := "%" + query + "%"
+	var networks []*db.Network
+	if err := s.database.SelectContext(ctx, &networks, q, pattern, limit); err != nil {
+		return nil, fmt.Errorf("search networks: %w", err)
+	}
+	if networks == nil {
+		networks = []*db.Network{}
+	}
+	return networks, nil
+}

--- a/internal/services/scan.go
+++ b/internal/services/scan.go
@@ -5,6 +5,8 @@ package services
 
 import (
 	"context"
+	"database/sql"
+	stderrors "errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -87,6 +89,8 @@ type scanRepository interface {
 	StopScan(ctx context.Context, id uuid.UUID, errMsg ...string) error
 	CompleteScan(ctx context.Context, id uuid.UUID) error
 	GetScanResults(ctx context.Context, scanID uuid.UUID, offset, limit int) ([]*db.ScanResult, int64, error)
+	GetAllScanResults(ctx context.Context, scanID uuid.UUID) ([]*db.ScanResult, error)
+	GetHostForScan(ctx context.Context, scanID uuid.UUID) (uuid.UUID, error)
 	GetScanSummary(ctx context.Context, scanID uuid.UUID) (*db.ScanSummary, error)
 	GetProfile(ctx context.Context, id string) (*db.ScanProfile, error)
 }
@@ -208,6 +212,223 @@ func (s *ScanService) GetScanSummary(ctx context.Context, scanID uuid.UUID) (*db
 // GetProfile retrieves a scan profile by its string ID.
 func (s *ScanService) GetProfile(ctx context.Context, id string) (*db.ScanProfile, error) {
 	return s.repo.GetProfile(ctx, id)
+}
+
+// portKey is used to index port scan results by (port, protocol).
+type portKey struct {
+	port     int
+	protocol string
+}
+
+// diffStatusOrder maps a diff status to a sort priority (lower = first).
+var diffStatusOrder = map[string]int{
+	db.DiffStatusNew:       0,
+	db.DiffStatusClosed:    1,
+	db.DiffStatusChanged:   2,
+	db.DiffStatusUnchanged: 3,
+}
+
+// GetScanDiff computes the diff between two scans of the same host.
+// It returns all ports classified as new, closed, changed, or unchanged.
+func (s *ScanService) GetScanDiff(ctx context.Context, scanAID, scanBID uuid.UUID) (*db.ScanDiff, error) {
+	// Verify both scans exist by looking up results (GetScan is also an option
+	// but GetAllScanResults covers both existence and data in one call).
+	resultsA, err := s.repo.GetAllScanResults(ctx, scanAID)
+	if err != nil {
+		return nil, fmt.Errorf("get scan A results: %w", err)
+	}
+
+	resultsB, err := s.repo.GetAllScanResults(ctx, scanBID)
+	if err != nil {
+		return nil, fmt.Errorf("get scan B results: %w", err)
+	}
+
+	// Resolve host IDs.
+	hostA, hostB, err := resolveHostIDs(ctx, s.repo, scanAID, scanBID, resultsA, resultsB)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build indexes.
+	indexA := indexResults(resultsA)
+	indexB := indexResults(resultsB)
+
+	diff := &db.ScanDiff{
+		ScanAID: scanAID,
+		ScanBID: scanBID,
+		HostID:  hostA,
+		Ports:   make([]db.ScanDiffEntry, 0),
+	}
+
+	// Ports present in scan B.
+	for key, b := range indexB {
+		entry := buildDiffEntry(b, indexA[key])
+		diff.Ports = append(diff.Ports, entry)
+		incrementCount(diff, entry.Status)
+	}
+
+	// Ports present only in scan A → closed.
+	for key, a := range indexA {
+		if _, inB := indexB[key]; !inB {
+			svcName := ptrString(a.Service)
+			entry := db.ScanDiffEntry{
+				Port:               a.Port,
+				Protocol:           a.Protocol,
+				State:              a.State,
+				ServiceName:        nil,
+				ServiceVersion:     nil,
+				Status:             db.DiffStatusClosed,
+				PrevState:          ptrString(a.State),
+				PrevServiceName:    svcName,
+				PrevServiceVersion: nil,
+			}
+			diff.Ports = append(diff.Ports, entry)
+			diff.ClosedCount++
+		}
+	}
+
+	// Sort: new → closed → changed → unchanged, then by port number.
+	sortDiffEntries(diff.Ports)
+
+	// OS diff: compare OS from first result in each scan.
+	diff.OSChanged, diff.PrevOSName, diff.CurrOSName = computeOSDiff(resultsA, resultsB)
+
+	// Use host B for HostID when host A is nil (scan A had no results).
+	if diff.HostID == (uuid.UUID{}) {
+		diff.HostID = hostB
+	}
+
+	return diff, nil
+}
+
+// resolveHostIDs resolves and validates host IDs from both scans.
+func resolveHostIDs(
+	ctx context.Context,
+	repo scanRepository,
+	scanAID, scanBID uuid.UUID,
+	resultsA, resultsB []*db.ScanResult,
+) (hostA, hostB uuid.UUID, err error) {
+	// Prefer host from results (already loaded); fall back to DB query.
+	if len(resultsA) > 0 {
+		hostA = resultsA[0].HostID
+	} else {
+		var err error
+		hostA, err = repo.GetHostForScan(ctx, scanAID)
+		if err != nil && !isNoRows(err) {
+			return uuid.Nil, uuid.Nil, fmt.Errorf("get host for scan A: %w", err)
+		}
+	}
+
+	if len(resultsB) > 0 {
+		hostB = resultsB[0].HostID
+	} else {
+		var err error
+		hostB, err = repo.GetHostForScan(ctx, scanBID)
+		if err != nil && !isNoRows(err) {
+			return uuid.Nil, uuid.Nil, fmt.Errorf("get host for scan B: %w", err)
+		}
+	}
+
+	if hostA != (uuid.UUID{}) && hostB != (uuid.UUID{}) && hostA != hostB {
+		return uuid.Nil, uuid.Nil,
+			errors.NewScanError(errors.CodeValidation, "scans belong to different hosts")
+	}
+	return hostA, hostB, nil
+}
+
+// isNoRows reports whether err wraps sql.ErrNoRows.
+func isNoRows(err error) bool {
+	return stderrors.Is(err, sql.ErrNoRows)
+}
+
+// indexResults builds a map from (port, protocol) → *ScanResult.
+func indexResults(results []*db.ScanResult) map[portKey]*db.ScanResult {
+	idx := make(map[portKey]*db.ScanResult, len(results))
+	for _, r := range results {
+		idx[portKey{r.Port, r.Protocol}] = r
+	}
+	return idx
+}
+
+// ptrString returns a non-nil pointer to s, or nil when s is empty.
+func ptrString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// buildDiffEntry constructs a ScanDiffEntry comparing b (current) against a (previous).
+// a may be nil when the port is new.
+func buildDiffEntry(b, a *db.ScanResult) db.ScanDiffEntry {
+	entry := db.ScanDiffEntry{
+		Port:        b.Port,
+		Protocol:    b.Protocol,
+		State:       b.State,
+		ServiceName: ptrString(b.Service),
+	}
+
+	if a == nil {
+		entry.Status = db.DiffStatusNew
+		return entry
+	}
+
+	// Compare state and service.
+	if a.State != b.State || a.Service != b.Service {
+		entry.Status = db.DiffStatusChanged
+		entry.PrevState = ptrString(a.State)
+		entry.PrevServiceName = ptrString(a.Service)
+	} else {
+		entry.Status = db.DiffStatusUnchanged
+	}
+	return entry
+}
+
+// incrementCount updates the appropriate counter on diff.
+func incrementCount(diff *db.ScanDiff, status string) {
+	switch status {
+	case db.DiffStatusNew:
+		diff.NewCount++
+	case db.DiffStatusClosed:
+		diff.ClosedCount++
+	case db.DiffStatusChanged:
+		diff.ChangedCount++
+	case db.DiffStatusUnchanged:
+		diff.UnchangedCount++
+	}
+}
+
+// sortDiffEntries sorts entries by status priority then port number.
+func sortDiffEntries(entries []db.ScanDiffEntry) {
+	n := len(entries)
+	for i := 1; i < n; i++ {
+		for j := i; j > 0; j-- {
+			a, b := entries[j-1], entries[j]
+			aOrd := diffStatusOrder[a.Status]
+			bOrd := diffStatusOrder[b.Status]
+			if aOrd > bOrd || (aOrd == bOrd && a.Port > b.Port) {
+				entries[j-1], entries[j] = entries[j], entries[j-1]
+			} else {
+				break
+			}
+		}
+	}
+}
+
+// computeOSDiff compares the OS observed in two scan result sets.
+func computeOSDiff(resultsA, resultsB []*db.ScanResult) (changed bool, prevOS, currOS *string) {
+	prevName := ""
+	currName := ""
+	if len(resultsA) > 0 {
+		prevName = resultsA[0].OSName
+	}
+	if len(resultsB) > 0 {
+		currName = resultsB[0].OSName
+	}
+	if prevName == currName {
+		return false, nil, nil
+	}
+	return true, ptrString(prevName), ptrString(currName)
 }
 
 // -- Input validation --

--- a/internal/services/scan_test.go
+++ b/internal/services/scan_test.go
@@ -27,17 +27,19 @@ import (
 // zero values so callers that don't care about a particular method need not
 // configure it.
 type mockScanRepo struct {
-	listScans      func(context.Context, db.ScanFilters, int, int) ([]*db.Scan, int64, error)
-	createScan     func(context.Context, db.CreateScanInput) (*db.Scan, error)
-	getScan        func(context.Context, uuid.UUID) (*db.Scan, error)
-	updateScan     func(context.Context, uuid.UUID, db.UpdateScanInput) (*db.Scan, error)
-	deleteScan     func(context.Context, uuid.UUID) error
-	startScan      func(context.Context, uuid.UUID) error
-	stopScan       func(context.Context, uuid.UUID, ...string) error
-	completeScan   func(context.Context, uuid.UUID) error
-	getScanResults func(context.Context, uuid.UUID, int, int) ([]*db.ScanResult, int64, error)
-	getScanSummary func(context.Context, uuid.UUID) (*db.ScanSummary, error)
-	getProfile     func(context.Context, string) (*db.ScanProfile, error)
+	listScans         func(context.Context, db.ScanFilters, int, int) ([]*db.Scan, int64, error)
+	createScan        func(context.Context, db.CreateScanInput) (*db.Scan, error)
+	getScan           func(context.Context, uuid.UUID) (*db.Scan, error)
+	updateScan        func(context.Context, uuid.UUID, db.UpdateScanInput) (*db.Scan, error)
+	deleteScan        func(context.Context, uuid.UUID) error
+	startScan         func(context.Context, uuid.UUID) error
+	stopScan          func(context.Context, uuid.UUID, ...string) error
+	completeScan      func(context.Context, uuid.UUID) error
+	getScanResults    func(context.Context, uuid.UUID, int, int) ([]*db.ScanResult, int64, error)
+	getAllScanResults func(context.Context, uuid.UUID) ([]*db.ScanResult, error)
+	getHostForScan    func(context.Context, uuid.UUID) (uuid.UUID, error)
+	getScanSummary    func(context.Context, uuid.UUID) (*db.ScanSummary, error)
+	getProfile        func(context.Context, string) (*db.ScanProfile, error)
 }
 
 func (m *mockScanRepo) ListScans(
@@ -112,6 +114,20 @@ func (m *mockScanRepo) GetScanSummary(ctx context.Context, scanID uuid.UUID) (*d
 		return m.getScanSummary(ctx, scanID)
 	}
 	return nil, nil
+}
+
+func (m *mockScanRepo) GetAllScanResults(ctx context.Context, scanID uuid.UUID) ([]*db.ScanResult, error) {
+	if m.getAllScanResults != nil {
+		return m.getAllScanResults(ctx, scanID)
+	}
+	return make([]*db.ScanResult, 0), nil
+}
+
+func (m *mockScanRepo) GetHostForScan(ctx context.Context, scanID uuid.UUID) (uuid.UUID, error) {
+	if m.getHostForScan != nil {
+		return m.getHostForScan(ctx, scanID)
+	}
+	return uuid.Nil, nil
 }
 
 func (m *mockScanRepo) GetProfile(ctx context.Context, id string) (*db.ScanProfile, error) {
@@ -1296,4 +1312,175 @@ func TestValidatePortNumber(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "must be a number")
 	})
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GetScanDiff tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+func svcPtr(s string) *string { return &s }
+
+func makeResult(hostID uuid.UUID, port int, svc string) *db.ScanResult {
+	return &db.ScanResult{
+		HostID:   hostID,
+		Port:     port,
+		Protocol: "tcp",
+		State:    "open",
+		Service:  svc,
+	}
+}
+
+func TestGetScanDiff_NewAndClosedPorts(t *testing.T) {
+	ctx := context.Background()
+	hostID := uuid.New()
+	scanA := uuid.New()
+	scanB := uuid.New()
+
+	// Scan A has port 22, scan B has port 22 (unchanged) + port 80 (new).
+	resultsA := []*db.ScanResult{makeResult(hostID, 22, "ssh")}
+	resultsB := []*db.ScanResult{
+		makeResult(hostID, 22, "ssh"),
+		makeResult(hostID, 80, "http"),
+	}
+
+	svc := NewScanService(&mockScanRepo{
+		getAllScanResults: func(_ context.Context, id uuid.UUID) ([]*db.ScanResult, error) {
+			if id == scanA {
+				return resultsA, nil
+			}
+			return resultsB, nil
+		},
+	}, slog.Default())
+
+	diff, err := svc.GetScanDiff(ctx, scanA, scanB)
+	require.NoError(t, err)
+	assert.Equal(t, hostID, diff.HostID)
+	assert.Equal(t, 1, diff.NewCount)
+	assert.Equal(t, 0, diff.ClosedCount)
+	assert.Equal(t, 0, diff.ChangedCount)
+	assert.Equal(t, 1, diff.UnchangedCount)
+
+	statuses := make(map[int]string)
+	for _, p := range diff.Ports {
+		statuses[p.Port] = p.Status
+	}
+	assert.Equal(t, db.DiffStatusNew, statuses[80])
+	assert.Equal(t, db.DiffStatusUnchanged, statuses[22])
+}
+
+func TestGetScanDiff_ClosedPorts(t *testing.T) {
+	ctx := context.Background()
+	hostID := uuid.New()
+	scanA := uuid.New()
+	scanB := uuid.New()
+
+	// Scan A has port 443; scan B doesn't → closed.
+	resultsA := []*db.ScanResult{makeResult(hostID, 443, "https")}
+
+	svc := NewScanService(&mockScanRepo{
+		getAllScanResults: func(_ context.Context, id uuid.UUID) ([]*db.ScanResult, error) {
+			if id == scanA {
+				return resultsA, nil
+			}
+			return make([]*db.ScanResult, 0), nil
+		},
+		getHostForScan: func(_ context.Context, id uuid.UUID) (uuid.UUID, error) {
+			return hostID, nil
+		},
+	}, slog.Default())
+
+	diff, err := svc.GetScanDiff(ctx, scanA, scanB)
+	require.NoError(t, err)
+	assert.Equal(t, 0, diff.NewCount)
+	assert.Equal(t, 1, diff.ClosedCount)
+	assert.Equal(t, db.DiffStatusClosed, diff.Ports[0].Status)
+}
+
+func TestGetScanDiff_ChangedService(t *testing.T) {
+	ctx := context.Background()
+	hostID := uuid.New()
+	scanA := uuid.New()
+	scanB := uuid.New()
+
+	// Same port, different service name → changed.
+	resultsA := []*db.ScanResult{makeResult(hostID, 8080, "http-old")}
+	resultsB := []*db.ScanResult{makeResult(hostID, 8080, "http-new")}
+
+	svc := NewScanService(&mockScanRepo{
+		getAllScanResults: func(_ context.Context, id uuid.UUID) ([]*db.ScanResult, error) {
+			if id == scanA {
+				return resultsA, nil
+			}
+			return resultsB, nil
+		},
+	}, slog.Default())
+
+	diff, err := svc.GetScanDiff(ctx, scanA, scanB)
+	require.NoError(t, err)
+	assert.Equal(t, 1, diff.ChangedCount)
+	require.Len(t, diff.Ports, 1)
+	assert.Equal(t, db.DiffStatusChanged, diff.Ports[0].Status)
+	assert.Equal(t, svcPtr("http-old"), diff.Ports[0].PrevServiceName)
+}
+
+func TestGetScanDiff_DifferentHosts(t *testing.T) {
+	ctx := context.Background()
+	hostA := uuid.New()
+	hostB := uuid.New()
+	scanA := uuid.New()
+	scanB := uuid.New()
+
+	svc := NewScanService(&mockScanRepo{
+		getAllScanResults: func(_ context.Context, id uuid.UUID) ([]*db.ScanResult, error) {
+			if id == scanA {
+				return []*db.ScanResult{makeResult(hostA, 22, "ssh")}, nil
+			}
+			return []*db.ScanResult{makeResult(hostB, 80, "http")}, nil
+		},
+	}, slog.Default())
+
+	_, err := svc.GetScanDiff(ctx, scanA, scanB)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "different hosts")
+}
+
+func TestGetScanDiff_RepoError(t *testing.T) {
+	ctx := context.Background()
+	svc := NewScanService(&mockScanRepo{
+		getAllScanResults: func(_ context.Context, _ uuid.UUID) ([]*db.ScanResult, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}, slog.Default())
+
+	_, err := svc.GetScanDiff(ctx, uuid.New(), uuid.New())
+	require.Error(t, err)
+}
+
+func TestGetScanDiff_OSChanged(t *testing.T) {
+	ctx := context.Background()
+	host := uuid.New()
+	scanA := uuid.New()
+	scanB := uuid.New()
+
+	resultA := makeResult(host, 22, "ssh")
+	resultA.OSName = "Linux"
+	resultB := makeResult(host, 22, "ssh")
+	resultB.OSName = "Windows"
+
+	svc := NewScanService(&mockScanRepo{
+		getAllScanResults: func(_ context.Context, id uuid.UUID) ([]*db.ScanResult, error) {
+			if id == scanA {
+				return []*db.ScanResult{resultA}, nil
+			}
+			return []*db.ScanResult{resultB}, nil
+		},
+	}, slog.Default())
+
+	diff, err := svc.GetScanDiff(ctx, scanA, scanB)
+	require.NoError(t, err)
+	assert.True(t, diff.OSChanged)
+	require.NotNil(t, diff.PrevOSName)
+	require.NotNil(t, diff.CurrOSName)
+	assert.Equal(t, "Linux", *diff.PrevOSName)
+	assert.Equal(t, "Windows", *diff.CurrOSName)
 }

--- a/internal/services/search_service.go
+++ b/internal/services/search_service.go
@@ -1,0 +1,265 @@
+// Package services provides business logic services for Scanorama.
+// This file implements the unified cross-entity search service.
+package services
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/anstrom/scanorama/internal/db"
+	apierrors "github.com/anstrom/scanorama/internal/errors"
+)
+
+const (
+	searchTypeHost    = "host"
+	searchTypeNetwork = "network"
+	searchTypeScan    = "scan"
+	searchTypeProfile = "profile"
+
+	searchMinQueryLen = 2
+	searchMaxQueryLen = 100
+	searchMaxLimit    = 50
+	searchDefaultLmt  = 10
+
+	// scanSortCreatedAt is the ScanFilters.SortBy value for chronological order.
+	scanSortCreatedAt = "created_at"
+)
+
+// searchHostRepo is the subset of HostRepository used by SearchService.
+type searchHostRepo interface {
+	ListHosts(ctx context.Context, filters *db.HostFilters, offset, limit int) ([]*db.Host, int64, error)
+}
+
+// searchScanRepo is the subset of ScanRepository used by SearchService.
+type searchScanRepo interface {
+	ListScans(ctx context.Context, filters db.ScanFilters, offset, limit int) ([]*db.Scan, int64, error)
+}
+
+// searchProfileRepo is the subset of ProfileRepository used by SearchService.
+type searchProfileRepo interface {
+	ListProfiles(ctx context.Context, filters db.ProfileFilters, offset, limit int) ([]*db.ScanProfile, int64, error)
+}
+
+// searchNetworkRepo runs network-specific search queries.
+type searchNetworkRepo interface {
+	SearchNetworks(ctx context.Context, query string, limit int) ([]*db.Network, error)
+}
+
+// SearchService provides unified search across all entity types.
+type SearchService struct {
+	hosts    searchHostRepo
+	scans    searchScanRepo
+	profiles searchProfileRepo
+	networks searchNetworkRepo
+	logger   *slog.Logger
+}
+
+// NewSearchService constructs a SearchService wired to the given repositories.
+func NewSearchService(
+	hosts searchHostRepo,
+	scans searchScanRepo,
+	profiles searchProfileRepo,
+	networks searchNetworkRepo,
+	logger *slog.Logger,
+) *SearchService {
+	return &SearchService{
+		hosts:    hosts,
+		scans:    scans,
+		profiles: profiles,
+		networks: networks,
+		logger:   logger.With("service", "search"),
+	}
+}
+
+// Search executes a cross-entity search for q, returning at most limit results
+// per entity type. q must be between 2 and 100 characters.
+func (s *SearchService) Search(ctx context.Context, q string, limit int) (*db.SearchResults, error) {
+	if len(q) < searchMinQueryLen {
+		return nil, apierrors.NewScanError(
+			apierrors.CodeValidation,
+			fmt.Sprintf("query must be at least %d characters", searchMinQueryLen),
+		)
+	}
+	if len(q) > searchMaxQueryLen {
+		return nil, apierrors.NewScanError(
+			apierrors.CodeValidation,
+			fmt.Sprintf("query must be at most %d characters", searchMaxQueryLen),
+		)
+	}
+	if limit <= 0 {
+		limit = searchDefaultLmt
+	}
+	if limit > searchMaxLimit {
+		limit = searchMaxLimit
+	}
+
+	out := &db.SearchResults{
+		Results: map[string][]db.SearchResult{
+			searchTypeHost:    make([]db.SearchResult, 0),
+			searchTypeNetwork: make([]db.SearchResult, 0),
+			searchTypeScan:    make([]db.SearchResult, 0),
+			searchTypeProfile: make([]db.SearchResult, 0),
+		},
+	}
+
+	hosts, err := s.searchHosts(ctx, q, limit)
+	if err != nil {
+		s.logger.Warn("host search failed", "error", err)
+	} else {
+		out.Results[searchTypeHost] = hosts
+	}
+
+	networks, err := s.searchNetworks(ctx, q, limit)
+	if err != nil {
+		s.logger.Warn("network search failed", "error", err)
+	} else {
+		out.Results[searchTypeNetwork] = networks
+	}
+
+	scans, err := s.searchScans(ctx, q, limit)
+	if err != nil {
+		s.logger.Warn("scan search failed", "error", err)
+	} else {
+		out.Results[searchTypeScan] = scans
+	}
+
+	profiles, err := s.searchProfiles(ctx, q, limit)
+	if err != nil {
+		s.logger.Warn("profile search failed", "error", err)
+	} else {
+		out.Results[searchTypeProfile] = profiles
+	}
+
+	for _, results := range out.Results {
+		out.Total += len(results)
+	}
+
+	return out, nil
+}
+
+func (s *SearchService) searchHosts(ctx context.Context, q string, limit int) ([]db.SearchResult, error) {
+	hosts, _, err := s.hosts.ListHosts(ctx, &db.HostFilters{Search: q}, 0, limit)
+	if err != nil {
+		return nil, fmt.Errorf("search hosts: %w", err)
+	}
+
+	results := make([]db.SearchResult, 0, len(hosts))
+	for _, h := range hosts {
+		results = append(results, db.SearchResult{
+			ID:    h.ID.String(),
+			Label: hostLabel(h),
+			URL:   "/hosts/" + h.ID.String(),
+			Type:  searchTypeHost,
+		})
+	}
+	return results, nil
+}
+
+// hostLabel returns "ip (hostname)" when a hostname is known, otherwise "ip".
+func hostLabel(h *db.Host) string {
+	ip := h.IPAddress.String()
+	if h.Hostname != nil && *h.Hostname != "" {
+		return ip + " (" + *h.Hostname + ")"
+	}
+	return ip
+}
+
+func (s *SearchService) searchNetworks(ctx context.Context, q string, limit int) ([]db.SearchResult, error) {
+	networks, err := s.networks.SearchNetworks(ctx, q, limit)
+	if err != nil {
+		return nil, fmt.Errorf("search networks: %w", err)
+	}
+
+	results := make([]db.SearchResult, 0, len(networks))
+	for _, n := range networks {
+		results = append(results, db.SearchResult{
+			ID:    n.ID.String(),
+			Label: n.Name + " (" + n.CIDR.String() + ")",
+			URL:   "/networks/" + n.ID.String(),
+			Type:  searchTypeNetwork,
+		})
+	}
+	return results, nil
+}
+
+func (s *SearchService) searchScans(ctx context.Context, q string, limit int) ([]db.SearchResult, error) {
+	scans, _, err := s.scans.ListScans(
+		ctx,
+		db.ScanFilters{SortBy: scanSortCreatedAt, SortOrder: "desc"},
+		0,
+		// Fetch more so we can client-side filter by target match.
+		// Profiles are filtered client-side; for scans we need a wider net.
+		limit*scanFetchMultiplier,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("search scans: %w", err)
+	}
+
+	lower := strings.ToLower(q)
+	results := make([]db.SearchResult, 0)
+	for _, sc := range scans {
+		if len(results) >= limit {
+			break
+		}
+		matched := false
+		for _, t := range sc.Targets {
+			if strings.Contains(strings.ToLower(t), lower) {
+				matched = true
+				break
+			}
+		}
+		if sc.Name != "" && strings.Contains(strings.ToLower(sc.Name), lower) {
+			matched = true
+		}
+		if !matched {
+			continue
+		}
+		results = append(results, db.SearchResult{
+			ID:    sc.ID.String(),
+			Label: scanLabel(sc),
+			URL:   "/scans/" + sc.ID.String(),
+			Type:  searchTypeScan,
+		})
+	}
+	return results, nil
+}
+
+// scanFetchMultiplier is how many more scans to fetch from the DB than limit,
+// because we filter client-side by target name match.
+const scanFetchMultiplier = 5
+
+// scanLabel builds "target1,target2 — status".
+func scanLabel(sc *db.Scan) string {
+	label := strings.Join(sc.Targets, ",")
+	if label == "" {
+		label = sc.Name
+	}
+	return label + " — " + sc.Status
+}
+
+func (s *SearchService) searchProfiles(ctx context.Context, q string, limit int) ([]db.SearchResult, error) {
+	// Profiles are few (<100 typically). Fetch all and filter client-side.
+	profiles, _, err := s.profiles.ListProfiles(ctx, db.ProfileFilters{}, 0, searchMaxLimit)
+	if err != nil {
+		return nil, fmt.Errorf("search profiles: %w", err)
+	}
+
+	lower := strings.ToLower(q)
+	results := make([]db.SearchResult, 0)
+	for _, p := range profiles {
+		if len(results) >= limit {
+			break
+		}
+		if strings.Contains(strings.ToLower(p.Name), lower) {
+			results = append(results, db.SearchResult{
+				ID:    p.ID,
+				Label: p.Name,
+				URL:   "/profiles/" + p.ID,
+				Type:  searchTypeProfile,
+			})
+		}
+	}
+	return results, nil
+}

--- a/internal/services/search_service_test.go
+++ b/internal/services/search_service_test.go
@@ -1,0 +1,296 @@
+// Package services contains unit tests for the search service.
+package services
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+type mockSearchHostRepo struct {
+	listHostsFn func(context.Context, *db.HostFilters, int, int) ([]*db.Host, int64, error)
+}
+
+func (m *mockSearchHostRepo) ListHosts(
+	ctx context.Context, filters *db.HostFilters, offset, limit int,
+) ([]*db.Host, int64, error) {
+	if m.listHostsFn != nil {
+		return m.listHostsFn(ctx, filters, offset, limit)
+	}
+	return make([]*db.Host, 0), 0, nil
+}
+
+type mockSearchScanRepo struct {
+	listScansFn func(context.Context, db.ScanFilters, int, int) ([]*db.Scan, int64, error)
+}
+
+func (m *mockSearchScanRepo) ListScans(
+	ctx context.Context, filters db.ScanFilters, offset, limit int,
+) ([]*db.Scan, int64, error) {
+	if m.listScansFn != nil {
+		return m.listScansFn(ctx, filters, offset, limit)
+	}
+	return make([]*db.Scan, 0), 0, nil
+}
+
+type mockSearchProfileRepo struct {
+	listProfilesFn func(context.Context, db.ProfileFilters, int, int) ([]*db.ScanProfile, int64, error)
+}
+
+func (m *mockSearchProfileRepo) ListProfiles(
+	ctx context.Context, filters db.ProfileFilters, offset, limit int,
+) ([]*db.ScanProfile, int64, error) {
+	if m.listProfilesFn != nil {
+		return m.listProfilesFn(ctx, filters, offset, limit)
+	}
+	return make([]*db.ScanProfile, 0), 0, nil
+}
+
+type mockSearchNetworkRepo struct {
+	searchFn func(context.Context, string, int) ([]*db.Network, error)
+}
+
+func (m *mockSearchNetworkRepo) SearchNetworks(
+	ctx context.Context, query string, limit int,
+) ([]*db.Network, error) {
+	if m.searchFn != nil {
+		return m.searchFn(ctx, query, limit)
+	}
+	return make([]*db.Network, 0), nil
+}
+
+// ── Helper ─────────────────────────────────────────────────────────────────────
+
+func newTestSearchService(
+	hosts searchHostRepo,
+	scans searchScanRepo,
+	profiles searchProfileRepo,
+	networks searchNetworkRepo,
+) *SearchService {
+	logger := slog.Default()
+	return NewSearchService(hosts, scans, profiles, networks, logger)
+}
+
+func defaultMocks() (
+	*mockSearchHostRepo,
+	*mockSearchScanRepo,
+	*mockSearchProfileRepo,
+	*mockSearchNetworkRepo,
+) {
+	return &mockSearchHostRepo{},
+		&mockSearchScanRepo{},
+		&mockSearchProfileRepo{},
+		&mockSearchNetworkRepo{}
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+func TestSearchService_QueryTooShort(t *testing.T) {
+	h, s, p, n := defaultMocks()
+	svc := newTestSearchService(h, s, p, n)
+
+	_, err := svc.Search(context.Background(), "x", 10)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least 2")
+}
+
+func TestSearchService_QueryTooLong(t *testing.T) {
+	h, s, p, n := defaultMocks()
+	svc := newTestSearchService(h, s, p, n)
+
+	longQ := ""
+	for i := 0; i < searchMaxQueryLen+1; i++ {
+		longQ += "a"
+	}
+	_, err := svc.Search(context.Background(), longQ, 10)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at most 100")
+}
+
+func TestSearchService_HostsFound(t *testing.T) {
+	hostname := "myserver"
+	id := uuid.New()
+
+	hostRepo := &mockSearchHostRepo{
+		listHostsFn: func(_ context.Context, filters *db.HostFilters, _, _ int) ([]*db.Host, int64, error) {
+			assert.Equal(t, "myserver", filters.Search)
+			h := &db.Host{}
+			h.ID = id
+			h.IPAddress = db.IPAddr{}
+			h.Hostname = &hostname
+			return []*db.Host{h}, 1, nil
+		},
+	}
+	_, s, p, n := defaultMocks()
+	svc := newTestSearchService(hostRepo, s, p, n)
+
+	results, err := svc.Search(context.Background(), "myserver", 10)
+
+	require.NoError(t, err)
+	require.Len(t, results.Results["host"], 1)
+	assert.Equal(t, id.String(), results.Results["host"][0].ID)
+	assert.Contains(t, results.Results["host"][0].Label, "myserver")
+	assert.Equal(t, "host", results.Results["host"][0].Type)
+	assert.Equal(t, 1, results.Total)
+}
+
+func TestSearchService_NetworksFound(t *testing.T) {
+	id := uuid.New()
+
+	netRepo := &mockSearchNetworkRepo{
+		searchFn: func(_ context.Context, query string, _ int) ([]*db.Network, error) {
+			assert.Equal(t, "office", query)
+			n := &db.Network{Name: "Office LAN"}
+			n.ID = id
+			return []*db.Network{n}, nil
+		},
+	}
+	h, s, p, _ := defaultMocks()
+	svc := newTestSearchService(h, s, p, netRepo)
+
+	results, err := svc.Search(context.Background(), "office", 10)
+
+	require.NoError(t, err)
+	require.Len(t, results.Results["network"], 1)
+	assert.Equal(t, id.String(), results.Results["network"][0].ID)
+	assert.Equal(t, "network", results.Results["network"][0].Type)
+}
+
+func TestSearchService_ScansFound(t *testing.T) {
+	id := uuid.New()
+
+	scanRepo := &mockSearchScanRepo{
+		listScansFn: func(_ context.Context, _ db.ScanFilters, _, _ int) ([]*db.Scan, int64, error) {
+			sc := &db.Scan{
+				Targets: []string{"192.168.1.0/24"},
+				Status:  "completed",
+			}
+			sc.ID = id
+			return []*db.Scan{sc}, 1, nil
+		},
+	}
+	h, _, p, n := defaultMocks()
+	svc := newTestSearchService(h, scanRepo, p, n)
+
+	results, err := svc.Search(context.Background(), "192.168", 10)
+
+	require.NoError(t, err)
+	require.Len(t, results.Results["scan"], 1)
+	assert.Equal(t, id.String(), results.Results["scan"][0].ID)
+	assert.Contains(t, results.Results["scan"][0].Label, "completed")
+}
+
+func TestSearchService_ProfilesFound(t *testing.T) {
+	profileRepo := &mockSearchProfileRepo{
+		listProfilesFn: func(_ context.Context, _ db.ProfileFilters, _, _ int) ([]*db.ScanProfile, int64, error) {
+			return []*db.ScanProfile{
+				{ID: "quick-scan", Name: "Quick Scan"},
+				{ID: "full-scan", Name: "Full Scan"},
+			}, 2, nil
+		},
+	}
+	h, s, _, n := defaultMocks()
+	svc := newTestSearchService(h, s, profileRepo, n)
+
+	results, err := svc.Search(context.Background(), "quick", 10)
+
+	require.NoError(t, err)
+	require.Len(t, results.Results["profile"], 1)
+	assert.Equal(t, "quick-scan", results.Results["profile"][0].ID)
+	assert.Equal(t, "Quick Scan", results.Results["profile"][0].Label)
+}
+
+func TestSearchService_EmptyResults(t *testing.T) {
+	h, s, p, n := defaultMocks()
+	svc := newTestSearchService(h, s, p, n)
+
+	results, err := svc.Search(context.Background(), "xyznotfound", 10)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, results.Total)
+	assert.Empty(t, results.Results["host"])
+	assert.Empty(t, results.Results["network"])
+	assert.Empty(t, results.Results["scan"])
+	assert.Empty(t, results.Results["profile"])
+}
+
+func TestSearchService_LimitDefault(t *testing.T) {
+	var gotLimit int
+	hostRepo := &mockSearchHostRepo{
+		listHostsFn: func(_ context.Context, _ *db.HostFilters, _, limit int) ([]*db.Host, int64, error) {
+			gotLimit = limit
+			return make([]*db.Host, 0), 0, nil
+		},
+	}
+	_, s, p, n := defaultMocks()
+	svc := newTestSearchService(hostRepo, s, p, n)
+
+	_, err := svc.Search(context.Background(), "test", 0)
+
+	require.NoError(t, err)
+	assert.Equal(t, searchDefaultLmt, gotLimit)
+}
+
+func TestSearchService_LimitCapped(t *testing.T) {
+	var gotLimit int
+	hostRepo := &mockSearchHostRepo{
+		listHostsFn: func(_ context.Context, _ *db.HostFilters, _, limit int) ([]*db.Host, int64, error) {
+			gotLimit = limit
+			return make([]*db.Host, 0), 0, nil
+		},
+	}
+	_, s, p, n := defaultMocks()
+	svc := newTestSearchService(hostRepo, s, p, n)
+
+	_, err := svc.Search(context.Background(), "test", 999)
+
+	require.NoError(t, err)
+	assert.Equal(t, searchMaxLimit, gotLimit)
+}
+
+func TestSearchService_HostRepoError_DoesNotFailOtherSections(t *testing.T) {
+	hostRepo := &mockSearchHostRepo{
+		listHostsFn: func(_ context.Context, _ *db.HostFilters, _, _ int) ([]*db.Host, int64, error) {
+			return nil, 0, fmt.Errorf("db error")
+		},
+	}
+	_, s, p, n := defaultMocks()
+	svc := newTestSearchService(hostRepo, s, p, n)
+
+	results, err := svc.Search(context.Background(), "test", 10)
+
+	// Search should succeed overall — individual failures are logged, not surfaced.
+	require.NoError(t, err)
+	assert.NotNil(t, results)
+}
+
+func TestSearchService_ResultsHaveCorrectURLs(t *testing.T) {
+	id := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+
+	hostRepo := &mockSearchHostRepo{
+		listHostsFn: func(_ context.Context, _ *db.HostFilters, _, _ int) ([]*db.Host, int64, error) {
+			h := &db.Host{}
+			h.ID = id
+			return []*db.Host{h}, 1, nil
+		},
+	}
+	_, s, p, n := defaultMocks()
+	svc := newTestSearchService(hostRepo, s, p, n)
+
+	results, err := svc.Search(context.Background(), "00", 10)
+
+	require.NoError(t, err)
+	require.Len(t, results.Results["host"], 1)
+	assert.Equal(t, "/hosts/"+id.String(), results.Results["host"][0].URL)
+}

--- a/internal/services/smartscan_test.go
+++ b/internal/services/smartscan_test.go
@@ -97,6 +97,12 @@ func (m *mockSmartScanRepo) GetScanResults(_ context.Context, _ uuid.UUID, _, _ 
 func (m *mockSmartScanRepo) GetScanSummary(_ context.Context, _ uuid.UUID) (*db.ScanSummary, error) {
 	return nil, nil
 }
+func (m *mockSmartScanRepo) GetAllScanResults(_ context.Context, _ uuid.UUID) ([]*db.ScanResult, error) {
+	return make([]*db.ScanResult, 0), nil
+}
+func (m *mockSmartScanRepo) GetHostForScan(_ context.Context, _ uuid.UUID) (uuid.UUID, error) {
+	return uuid.Nil, nil
+}
 func (m *mockSmartScanRepo) GetProfile(_ context.Context, _ string) (*db.ScanProfile, error) {
 	return nil, nil
 }

--- a/internal/services/webhook_service.go
+++ b/internal/services/webhook_service.go
@@ -54,6 +54,8 @@ type WebhookEvent struct {
 }
 
 // webhookRepository defines the data-access interface used by WebhookService.
+//
+//nolint:dupl // interface mirrors mock struct in tests by design
 type webhookRepository interface {
 	ListWebhooks(ctx context.Context) ([]*db.WebhookEndpoint, error)
 	CreateWebhook(ctx context.Context, input db.CreateWebhookInput) (*db.WebhookEndpoint, error)

--- a/internal/services/webhook_service.go
+++ b/internal/services/webhook_service.go
@@ -1,0 +1,296 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+// Supported event type constants for webhook subscriptions.
+const (
+	EventHostOnline         = "host.online"
+	EventHostOffline        = "host.offline"
+	EventScanStarted        = "scan.started"
+	EventScanCompleted      = "scan.completed"
+	EventDiscoveryCompleted = "discovery.completed"
+	eventWebhookTest        = "webhook.test"
+)
+
+// AllowedWebhookEvents is the set of event types that endpoints may subscribe to.
+var AllowedWebhookEvents = map[string]struct{}{
+	EventHostOnline:         {},
+	EventHostOffline:        {},
+	EventScanStarted:        {},
+	EventScanCompleted:      {},
+	EventDiscoveryCompleted: {},
+}
+
+const (
+	webhookSecretBytes   = 32
+	webhookMaxRetries    = 3
+	webhookFirstAttempt  = 1
+	webhookClientTimeout = 10 * time.Second
+	webhookSigHeader     = "X-Scanorama-Signature"
+	webhookSigPrefix     = "sha256="
+)
+
+// WebhookEvent represents a fired event to be delivered to subscribers.
+type WebhookEvent struct {
+	Type    string    `json:"type"`
+	Payload any       `json:"payload"`
+	FiredAt time.Time `json:"fired_at"`
+}
+
+// webhookRepository defines the data-access interface used by WebhookService.
+type webhookRepository interface {
+	ListWebhooks(ctx context.Context) ([]*db.WebhookEndpoint, error)
+	CreateWebhook(ctx context.Context, input db.CreateWebhookInput) (*db.WebhookEndpoint, error)
+	GetWebhook(ctx context.Context, id uuid.UUID) (*db.WebhookEndpoint, error)
+	UpdateWebhook(ctx context.Context, id uuid.UUID, input db.UpdateWebhookInput) (*db.WebhookEndpoint, error)
+	DeleteWebhook(ctx context.Context, id uuid.UUID) error
+	ListWebhooksByEvent(ctx context.Context, eventType string) ([]*db.WebhookEndpoint, error)
+	CreateDeliveryLog(ctx context.Context, log db.WebhookDeliveryLog) error
+	ListDeliveryLogs(ctx context.Context, endpointID uuid.UUID, limit int) ([]*db.WebhookDeliveryLog, error)
+}
+
+// WebhookService handles webhook management and event delivery.
+type WebhookService struct {
+	repo   webhookRepository
+	client *http.Client
+	logger *slog.Logger
+}
+
+// NewWebhookService creates a new WebhookService with a 10-second HTTP timeout.
+func NewWebhookService(repo webhookRepository, logger *slog.Logger) *WebhookService {
+	return &WebhookService{
+		repo:   repo,
+		client: &http.Client{Timeout: webhookClientTimeout},
+		logger: logger.With("service", "webhook"),
+	}
+}
+
+// ListWebhooks returns all registered webhook endpoints.
+func (s *WebhookService) ListWebhooks(ctx context.Context) ([]*db.WebhookEndpoint, error) {
+	return s.repo.ListWebhooks(ctx)
+}
+
+// CreateWebhook registers a new webhook endpoint. When input.Secret is empty,
+// a random 32-byte hex-encoded secret is generated automatically.
+func (s *WebhookService) CreateWebhook(
+	ctx context.Context, input db.CreateWebhookInput,
+) (*db.WebhookEndpoint, error) {
+	if input.Secret == "" {
+		secret, err := generateSecret()
+		if err != nil {
+			return nil, fmt.Errorf("generate webhook secret: %w", err)
+		}
+		input.Secret = secret
+	}
+	return s.repo.CreateWebhook(ctx, input)
+}
+
+// GetWebhook returns a single webhook endpoint by ID.
+func (s *WebhookService) GetWebhook(ctx context.Context, id uuid.UUID) (*db.WebhookEndpoint, error) {
+	return s.repo.GetWebhook(ctx, id)
+}
+
+// UpdateWebhook applies partial updates to a webhook endpoint.
+func (s *WebhookService) UpdateWebhook(
+	ctx context.Context, id uuid.UUID, input db.UpdateWebhookInput,
+) (*db.WebhookEndpoint, error) {
+	return s.repo.UpdateWebhook(ctx, id, input)
+}
+
+// DeleteWebhook removes a webhook endpoint.
+func (s *WebhookService) DeleteWebhook(ctx context.Context, id uuid.UUID) error {
+	return s.repo.DeleteWebhook(ctx, id)
+}
+
+// SendTestDelivery fires a synchronous test event to the given endpoint.
+// Returns an error if the endpoint responds with a non-2xx status.
+func (s *WebhookService) SendTestDelivery(ctx context.Context, id uuid.UUID) error {
+	ep, err := s.repo.GetWebhook(ctx, id)
+	if err != nil {
+		return fmt.Errorf("get webhook for test: %w", err)
+	}
+
+	event := WebhookEvent{
+		Type:    eventWebhookTest,
+		Payload: map[string]string{"message": "This is a test delivery from Scanorama."},
+		FiredAt: time.Now().UTC(),
+	}
+
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal test event: %w", err)
+	}
+
+	code, deliveryErr := s.deliver(ctx, ep.URL, ep.Secret, payload)
+	now := time.Now().UTC()
+
+	log := db.WebhookDeliveryLog{
+		EndpointID:   id,
+		EventType:    eventWebhookTest,
+		Payload:      payload,
+		AttemptCount: webhookFirstAttempt,
+		CreatedAt:    now,
+	}
+	if deliveryErr != nil {
+		errMsg := deliveryErr.Error()
+		log.LastError = &errMsg
+	} else {
+		log.StatusCode = &code
+		log.DeliveredAt = &now
+	}
+	_ = s.repo.CreateDeliveryLog(ctx, log)
+
+	return deliveryErr
+}
+
+// ListDeliveryLogs returns delivery logs for a webhook endpoint.
+func (s *WebhookService) ListDeliveryLogs(
+	ctx context.Context, endpointID uuid.UUID, limit int,
+) ([]*db.WebhookDeliveryLog, error) {
+	return s.repo.ListDeliveryLogs(ctx, endpointID, limit)
+}
+
+// DeliverToURL delivers a webhook event directly to a single URL, bypassing
+// the subscriber registry. Used for targeted alert rule delivery where the
+// destination is specified on the rule itself rather than the endpoint list.
+// The POST is signed with an empty secret (no HMAC validation on the receiver
+// side). DeliverToURL is synchronous; callers are responsible for goroutine
+// dispatch if needed.
+func (s *WebhookService) DeliverToURL(ctx context.Context, url string, event WebhookEvent) error {
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal alert event: %w", err)
+	}
+	_, err = s.deliver(ctx, url, "", payload)
+	return err
+}
+
+// Deliver looks up all enabled endpoints subscribed to event.Type and fires
+// async goroutines to deliver the event to each. It returns immediately.
+func (s *WebhookService) Deliver(ctx context.Context, event WebhookEvent) error {
+	endpoints, err := s.repo.ListWebhooksByEvent(ctx, event.Type)
+	if err != nil {
+		return fmt.Errorf("list webhooks for event %s: %w", event.Type, err)
+	}
+
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal webhook event: %w", err)
+	}
+
+	for _, ep := range endpoints {
+		go s.deliverToEndpoint(ep, payload, event.Type)
+	}
+	return nil
+}
+
+// deliverToEndpoint delivers a payload to one endpoint with retry logic and
+// records the result in the delivery log. It is safe to call as a goroutine.
+func (s *WebhookService) deliverToEndpoint(ep *db.WebhookEndpoint, payload []byte, eventType string) {
+	ctx, cancel := context.WithTimeout(context.Background(), webhookClientTimeout)
+	defer cancel()
+
+	var (
+		lastCode       *int
+		lastErr        *string
+		delivered      *time.Time
+		successAttempt int
+	)
+
+	for attempt := webhookFirstAttempt; attempt <= webhookMaxRetries; attempt++ {
+		code, err := s.deliver(ctx, ep.URL, ep.Secret, payload)
+		if err == nil {
+			now := time.Now().UTC()
+			lastCode = &code
+			delivered = &now
+			lastErr = nil
+			successAttempt = attempt
+			break
+		}
+		msg := err.Error()
+		lastErr = &msg
+		s.logger.Warn("webhook delivery attempt failed",
+			"endpoint_id", ep.ID,
+			"url", ep.URL,
+			"attempt", attempt,
+			"error", err,
+		)
+	}
+
+	attemptCount := webhookMaxRetries
+	if delivered != nil {
+		attemptCount = successAttempt
+	}
+	log := db.WebhookDeliveryLog{
+		EndpointID:   ep.ID,
+		EventType:    eventType,
+		Payload:      payload,
+		StatusCode:   lastCode,
+		AttemptCount: attemptCount,
+		LastError:    lastErr,
+		DeliveredAt:  delivered,
+	}
+
+	logCtx, logCancel := context.WithTimeout(context.Background(), webhookClientTimeout)
+	defer logCancel()
+	if err := s.repo.CreateDeliveryLog(logCtx, log); err != nil {
+		s.logger.Error("failed to record webhook delivery log",
+			"endpoint_id", ep.ID,
+			"error", err,
+		)
+	}
+}
+
+// deliver sends a single HTTP POST with HMAC-SHA256 signature to url.
+// Returns the status code and an error when the status is non-2xx.
+func (s *WebhookService) deliver(ctx context.Context, url, secret string, payload []byte) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return 0, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(webhookSigHeader, webhookSigPrefix+computeHMAC(secret, payload))
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("http post: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return resp.StatusCode, fmt.Errorf("non-2xx response: %d", resp.StatusCode)
+	}
+	return resp.StatusCode, nil
+}
+
+// computeHMAC returns the hex-encoded HMAC-SHA256 of payload using secret.
+func computeHMAC(secret string, payload []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// generateSecret returns a random 32-byte hex-encoded secret string.
+func generateSecret() (string, error) {
+	b := make([]byte, webhookSecretBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/services/webhook_service_test.go
+++ b/internal/services/webhook_service_test.go
@@ -1,0 +1,413 @@
+// Package services — unit tests for WebhookService.
+// These run without a live database or external HTTP server.
+package services
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+// ---------------------------------------------------------------------------
+// Hand-rolled mock for webhookRepository
+// ---------------------------------------------------------------------------
+
+type mockWebhookRepo struct {
+	listWebhooksFn  func(ctx context.Context) ([]*db.WebhookEndpoint, error)
+	createWebhookFn func(ctx context.Context, input db.CreateWebhookInput) (*db.WebhookEndpoint, error)
+	getWebhookFn    func(ctx context.Context, id uuid.UUID) (*db.WebhookEndpoint, error)
+	updateWebhookFn func(
+		ctx context.Context, id uuid.UUID, input db.UpdateWebhookInput,
+	) (*db.WebhookEndpoint, error)
+	deleteWebhookFn       func(ctx context.Context, id uuid.UUID) error
+	listWebhooksByEventFn func(ctx context.Context, eventType string) ([]*db.WebhookEndpoint, error)
+	createDeliveryLogFn   func(ctx context.Context, log db.WebhookDeliveryLog) error
+	listDeliveryLogsFn    func(ctx context.Context, endpointID uuid.UUID, limit int) ([]*db.WebhookDeliveryLog, error)
+}
+
+func (m *mockWebhookRepo) ListWebhooks(ctx context.Context) ([]*db.WebhookEndpoint, error) {
+	if m.listWebhooksFn != nil {
+		return m.listWebhooksFn(ctx)
+	}
+	return make([]*db.WebhookEndpoint, 0), nil
+}
+
+func (m *mockWebhookRepo) CreateWebhook(
+	ctx context.Context, input db.CreateWebhookInput,
+) (*db.WebhookEndpoint, error) {
+	if m.createWebhookFn != nil {
+		return m.createWebhookFn(ctx, input)
+	}
+	return nil, nil
+}
+
+func (m *mockWebhookRepo) GetWebhook(ctx context.Context, id uuid.UUID) (*db.WebhookEndpoint, error) {
+	if m.getWebhookFn != nil {
+		return m.getWebhookFn(ctx, id)
+	}
+	return nil, nil
+}
+
+func (m *mockWebhookRepo) UpdateWebhook(
+	ctx context.Context, id uuid.UUID, input db.UpdateWebhookInput,
+) (*db.WebhookEndpoint, error) {
+	if m.updateWebhookFn != nil {
+		return m.updateWebhookFn(ctx, id, input)
+	}
+	return nil, nil
+}
+
+func (m *mockWebhookRepo) DeleteWebhook(ctx context.Context, id uuid.UUID) error {
+	if m.deleteWebhookFn != nil {
+		return m.deleteWebhookFn(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockWebhookRepo) ListWebhooksByEvent(
+	ctx context.Context, eventType string,
+) ([]*db.WebhookEndpoint, error) {
+	if m.listWebhooksByEventFn != nil {
+		return m.listWebhooksByEventFn(ctx, eventType)
+	}
+	return make([]*db.WebhookEndpoint, 0), nil
+}
+
+func (m *mockWebhookRepo) CreateDeliveryLog(ctx context.Context, log db.WebhookDeliveryLog) error {
+	if m.createDeliveryLogFn != nil {
+		return m.createDeliveryLogFn(ctx, log)
+	}
+	return nil
+}
+
+func (m *mockWebhookRepo) ListDeliveryLogs(
+	ctx context.Context, endpointID uuid.UUID, limit int,
+) ([]*db.WebhookDeliveryLog, error) {
+	if m.listDeliveryLogsFn != nil {
+		return m.listDeliveryLogsFn(ctx, endpointID, limit)
+	}
+	return make([]*db.WebhookDeliveryLog, 0), nil
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+func webhookDiscardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// ---------------------------------------------------------------------------
+// CreateWebhook
+// ---------------------------------------------------------------------------
+
+func TestWebhookService_CreateWebhook_GeneratesSecret(t *testing.T) {
+	var captured db.CreateWebhookInput
+
+	repo := &mockWebhookRepo{
+		createWebhookFn: func(_ context.Context, input db.CreateWebhookInput) (*db.WebhookEndpoint, error) {
+			captured = input
+			return &db.WebhookEndpoint{
+				ID:     uuid.New(),
+				URL:    input.URL,
+				Secret: input.Secret,
+				Events: input.Events,
+			}, nil
+		},
+	}
+	svc := NewWebhookService(repo, webhookDiscardLogger())
+
+	_, err := svc.CreateWebhook(context.Background(), db.CreateWebhookInput{
+		URL:    "https://example.com/hook",
+		Events: []string{EventHostOnline},
+	})
+	require.NoError(t, err)
+
+	// Secret must be auto-generated: 32 bytes = 64 hex chars.
+	assert.NotEmpty(t, captured.Secret)
+	assert.Len(t, captured.Secret, 64)
+}
+
+func TestWebhookService_CreateWebhook_UsesProvidedSecret(t *testing.T) {
+	var captured db.CreateWebhookInput
+
+	repo := &mockWebhookRepo{
+		createWebhookFn: func(_ context.Context, input db.CreateWebhookInput) (*db.WebhookEndpoint, error) {
+			captured = input
+			return &db.WebhookEndpoint{
+				ID:     uuid.New(),
+				URL:    input.URL,
+				Secret: input.Secret,
+				Events: input.Events,
+			}, nil
+		},
+	}
+	svc := NewWebhookService(repo, webhookDiscardLogger())
+
+	_, err := svc.CreateWebhook(context.Background(), db.CreateWebhookInput{
+		URL:    "https://example.com/hook",
+		Secret: "mysecret",
+		Events: []string{EventHostOnline},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "mysecret", captured.Secret)
+}
+
+// ---------------------------------------------------------------------------
+// ListWebhooks
+// ---------------------------------------------------------------------------
+
+func TestWebhookService_ListWebhooks(t *testing.T) {
+	ep1 := &db.WebhookEndpoint{ID: uuid.New(), URL: "https://a.example.com"}
+	ep2 := &db.WebhookEndpoint{ID: uuid.New(), URL: "https://b.example.com"}
+
+	repo := &mockWebhookRepo{
+		listWebhooksFn: func(_ context.Context) ([]*db.WebhookEndpoint, error) {
+			return []*db.WebhookEndpoint{ep1, ep2}, nil
+		},
+	}
+	svc := NewWebhookService(repo, webhookDiscardLogger())
+
+	result, err := svc.ListWebhooks(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, ep1.ID, result[0].ID)
+	assert.Equal(t, ep2.ID, result[1].ID)
+}
+
+// ---------------------------------------------------------------------------
+// GetWebhook
+// ---------------------------------------------------------------------------
+
+func TestWebhookService_GetWebhook(t *testing.T) {
+	id := uuid.New()
+	ep := &db.WebhookEndpoint{ID: id, URL: "https://example.com"}
+
+	repo := &mockWebhookRepo{
+		getWebhookFn: func(_ context.Context, got uuid.UUID) (*db.WebhookEndpoint, error) {
+			assert.Equal(t, id, got)
+			return ep, nil
+		},
+	}
+	svc := NewWebhookService(repo, webhookDiscardLogger())
+
+	result, err := svc.GetWebhook(context.Background(), id)
+	require.NoError(t, err)
+	assert.Equal(t, ep, result)
+}
+
+// ---------------------------------------------------------------------------
+// DeleteWebhook
+// ---------------------------------------------------------------------------
+
+func TestWebhookService_DeleteWebhook(t *testing.T) {
+	id := uuid.New()
+	var deletedID uuid.UUID
+
+	repo := &mockWebhookRepo{
+		deleteWebhookFn: func(_ context.Context, got uuid.UUID) error {
+			deletedID = got
+			return nil
+		},
+	}
+	svc := NewWebhookService(repo, webhookDiscardLogger())
+
+	require.NoError(t, svc.DeleteWebhook(context.Background(), id))
+	assert.Equal(t, id, deletedID)
+}
+
+// ---------------------------------------------------------------------------
+// Deliver
+// ---------------------------------------------------------------------------
+
+func TestWebhookService_Deliver_FansOutToSubscribers(t *testing.T) {
+	// Track how many POST requests arrive at each test server.
+	var hits atomic.Int32
+
+	makeServer := func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+			assert.NotEmpty(t, r.Header.Get(webhookSigHeader))
+			hits.Add(1)
+			w.WriteHeader(http.StatusOK)
+		}))
+	}
+
+	ts1 := makeServer()
+	defer ts1.Close()
+	ts2 := makeServer()
+	defer ts2.Close()
+
+	ep1 := &db.WebhookEndpoint{ID: uuid.New(), URL: ts1.URL, Secret: "sec1", Enabled: true}
+	ep2 := &db.WebhookEndpoint{ID: uuid.New(), URL: ts2.URL, Secret: "sec2", Enabled: true}
+
+	// Channel to detect when both delivery logs have been written.
+	logsDone := make(chan struct{}, 2)
+
+	repo := &mockWebhookRepo{
+		listWebhooksByEventFn: func(_ context.Context, _ string) ([]*db.WebhookEndpoint, error) {
+			return []*db.WebhookEndpoint{ep1, ep2}, nil
+		},
+		createDeliveryLogFn: func(_ context.Context, _ db.WebhookDeliveryLog) error {
+			logsDone <- struct{}{}
+			return nil
+		},
+	}
+	svc := NewWebhookService(repo, webhookDiscardLogger())
+
+	err := svc.Deliver(context.Background(), WebhookEvent{
+		Type:    EventHostOnline,
+		Payload: map[string]string{"host": "10.0.0.1"},
+		FiredAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	// Wait for both goroutines to finish (via delivery log writes).
+	for i := 0; i < 2; i++ {
+		select {
+		case <-logsDone:
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for webhook delivery goroutines")
+		}
+	}
+
+	assert.Equal(t, int32(2), hits.Load())
+}
+
+func TestWebhookService_Deliver_EmptySubscriberList(t *testing.T) {
+	var httpCalls atomic.Int32
+
+	repo := &mockWebhookRepo{
+		listWebhooksByEventFn: func(_ context.Context, _ string) ([]*db.WebhookEndpoint, error) {
+			return make([]*db.WebhookEndpoint, 0), nil
+		},
+		createDeliveryLogFn: func(_ context.Context, _ db.WebhookDeliveryLog) error {
+			httpCalls.Add(1)
+			return nil
+		},
+	}
+	svc := NewWebhookService(repo, webhookDiscardLogger())
+
+	err := svc.Deliver(context.Background(), WebhookEvent{
+		Type:    EventScanCompleted,
+		Payload: nil,
+		FiredAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	// Give goroutines time to run (there should be none).
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(0), httpCalls.Load())
+}
+
+func TestWebhookService_Deliver_RepoError(t *testing.T) {
+	repo := &mockWebhookRepo{
+		listWebhooksByEventFn: func(_ context.Context, _ string) ([]*db.WebhookEndpoint, error) {
+			return nil, errList
+		},
+	}
+	svc := NewWebhookService(repo, webhookDiscardLogger())
+
+	err := svc.Deliver(context.Background(), WebhookEvent{
+		Type:    EventHostOnline,
+		Payload: nil,
+		FiredAt: time.Now().UTC(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list webhooks for event")
+}
+
+// errList is a sentinel error used in tests.
+var errList = newSentinelError("list error")
+
+type sentinelError struct{ msg string }
+
+func (e sentinelError) Error() string { return e.msg }
+
+func newSentinelError(msg string) sentinelError { return sentinelError{msg: msg} }
+
+// ---------------------------------------------------------------------------
+// SendTestDelivery
+// ---------------------------------------------------------------------------
+
+func TestWebhookService_SendTestDelivery_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	endpointID := uuid.New()
+	var logCreated bool
+	var loggedCode *int
+
+	repo := &mockWebhookRepo{
+		getWebhookFn: func(_ context.Context, _ uuid.UUID) (*db.WebhookEndpoint, error) {
+			return &db.WebhookEndpoint{ID: endpointID, URL: ts.URL, Secret: "secret"}, nil
+		},
+		createDeliveryLogFn: func(_ context.Context, log db.WebhookDeliveryLog) error {
+			logCreated = true
+			loggedCode = log.StatusCode
+			return nil
+		},
+	}
+	svc := NewWebhookService(repo, webhookDiscardLogger())
+
+	err := svc.SendTestDelivery(context.Background(), endpointID)
+	require.NoError(t, err)
+	assert.True(t, logCreated)
+	require.NotNil(t, loggedCode)
+	assert.Equal(t, http.StatusOK, *loggedCode)
+}
+
+func TestWebhookService_SendTestDelivery_Non2xx(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	endpointID := uuid.New()
+
+	repo := &mockWebhookRepo{
+		getWebhookFn: func(_ context.Context, _ uuid.UUID) (*db.WebhookEndpoint, error) {
+			return &db.WebhookEndpoint{ID: endpointID, URL: ts.URL, Secret: "secret"}, nil
+		},
+		createDeliveryLogFn: func(_ context.Context, _ db.WebhookDeliveryLog) error {
+			return nil
+		},
+	}
+	svc := NewWebhookService(repo, webhookDiscardLogger())
+
+	err := svc.SendTestDelivery(context.Background(), endpointID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-2xx")
+}
+
+// ---------------------------------------------------------------------------
+// computeHMAC
+// ---------------------------------------------------------------------------
+
+func TestComputeHMAC(t *testing.T) {
+	secret := "my-secret"
+	payload := []byte(`{"type":"host.online"}`)
+
+	sig1 := computeHMAC(secret, payload)
+	sig2 := computeHMAC(secret, payload)
+
+	assert.Equal(t, sig1, sig2, "HMAC must be deterministic")
+	assert.NotEmpty(t, sig1)
+
+	// Different secret → different signature.
+	sigOther := computeHMAC("other-secret", payload)
+	assert.NotEqual(t, sig1, sigOther)
+}


### PR DESCRIPTION
## What

Implements all remaining features in the v0.27 UX Polish milestone, completing 10 GitHub issues in one cohesive PR.

## Changes

### Webhook delivery service (#806)
- `WebhookEndpoint` DB model, migration, and repository
- `WebhookService` with event fanout, HMAC-SHA256 signature, retry logic, and delivery logging
- New admin tab in the frontend for managing webhook endpoints

### Alert rules (#807, #808)
- `AlertRule` DB model with host/tag targeting and trigger configuration
- `AlertService` with post-scan evaluation hook that delivers directly to `channel_url` (not subscriber fanout)
- Deduplication cursor so each transition fires at most once across scan cycles
- Alert rules UI on the host detail page (create, delete, toggle)
- `group_id` alerts rejected at API layer until group matching is implemented

### Export (#809)
- `GET /api/v1/hosts/export` and `GET /api/v1/scans/export` — chunked CSV/JSON download
- `ExportButton` component wired into hosts and scans toolbars

### Scan diff (#810)
- `GET /api/v1/scans/diff` — compare two scans to detect port/service changes
- Dedicated diff comparison page with Compare button on scan history

### Dark mode (#811)
- `useTheme` hook with localStorage and `prefers-color-scheme` system fallback
- `ThemeToggle` component in topbar; smooth CSS transition

### Inline editing (#812)
- Hostname, notes, and tags editable inline on host detail (click-to-edit, save on blur/Enter)
- Keyboard shortcut system with `?` help overlay and `⌘K` command palette (#695)

### Global search & command palette (#695)
- `GET /api/v1/search` endpoint with unified host/network/scan results
- Command palette with recent pages and live search, driven by the new endpoint

### Onboarding wizard (#813)
- First-run 3-step modal: add network → run discovery → review results
- Auto-dismissed when networks exist or user clicks Skip; localStorage persistence

## Test plan

- [ ] Verify webhook delivery fires when a scan transitions a monitored host (requires real scan run)
- [ ] Verify alert rules set to `channel_url` POST to that URL directly, not to all webhook subscribers
- [ ] Verify dark mode persists across page reloads and follows system preference on first visit
- [ ] Verify onboarding wizard only appears when no networks exist and hides after skip/completion
- [ ] Verify CSV export downloads are non-empty for a populated installation

Closes #735, #806, #807, #808, #809, #810, #811, #812, #813
Mentions #695