### PR TITLE
feat(deploy): systemd unit, install script, deb/rpm packaging, and zero-password DB bootstrap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,37 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+nfpms:
+  - id: scanorama
+    package_name: scanorama
+    vendor: Andreas Strøm
+    homepage: https://github.com/anstrom/scanorama
+    maintainer: Andreas Strøm <33042658+anstrom@users.noreply.github.com>
+    description: |-
+      Self-hosted network scanning and asset management.
+      Scanorama discovers hosts, runs nmap-based scans, and tracks network
+      inventory over time, exposing a REST API and web dashboard.
+    license: MIT
+    formats:
+      - deb
+      - rpm
+    # Binary lands at /usr/bin/scanorama — matches ExecStart in the unit.
+    bindir: /usr/bin
+    dependencies:
+      - nmap
+    contents:
+      - src: deploy/scanorama.service
+        dst: /usr/lib/systemd/system/scanorama.service
+      - src: deploy/config.example.yaml
+        dst: /etc/scanorama/config.yaml
+        type: "config|noreplace"
+        file_info:
+          mode: 0640
+    scripts:
+      postinstall: deploy/packaging/postinstall.sh
+      preremove: deploy/packaging/preremove.sh
+      postremove: deploy/packaging/postremove.sh
+
 dockers:
   - image_templates:
       - "ghcr.io/anstrom/scanorama:latest"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,8 +50,17 @@ nfpms:
       - rpm
     # Binary lands at /usr/bin/scanorama — matches ExecStart in the unit.
     bindir: /usr/bin
+    # nmap is the scan engine; PostgreSQL is the datastore. The package targets a
+    # local-Postgres install (peer auth, no passwords), so the DB server is a hard
+    # dependency. The package name differs per distro, hence the format overrides.
     dependencies:
       - nmap
+      - postgresql
+    overrides:
+      rpm:
+        dependencies:
+          - nmap
+          - postgresql-server
     contents:
       - src: deploy/scanorama.service
         dst: /usr/lib/systemd/system/scanorama.service

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -20,6 +20,8 @@ const (
 	defaultDatabasePort         = 5432 // PostgreSQL default port
 	defaultMaxConcurrentTargets = 100  // default max concurrent scan targets
 	defaultConfigFile           = "config.yaml"
+	// appName is the binary name and the default database role/database name.
+	appName = "scanorama"
 )
 
 var (
@@ -36,7 +38,7 @@ var (
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
-	Use:   "scanorama",
+	Use:   appName,
 	Short: "Advanced Network Scanner",
 	Long: `Scanorama is an advanced network scanning and discovery tool designed for
 continuous network monitoring with OS-aware scanning capabilities, automated
@@ -104,8 +106,8 @@ func setConfigDefaults() {
 	// Database configuration
 	viper.SetDefault("database.host", "localhost")
 	viper.SetDefault("database.port", defaultDatabasePort)
-	viper.SetDefault("database.database", "scanorama")
-	viper.SetDefault("database.username", "scanorama")
+	viper.SetDefault("database.database", appName)
+	viper.SetDefault("database.username", appName)
 	viper.SetDefault("database.ssl_mode", "require")
 
 	// Scanning configuration

--- a/cmd/cli/setup.go
+++ b/cmd/cli/setup.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+// Defaults for `scanorama setup`. They mirror the packaged systemd layout: the
+// daemon connects as the scanorama role over the local PostgreSQL socket using
+// peer authentication, so the bootstrap creates a matching role and database.
+const (
+	defaultSocketDir     = "/var/run/postgresql"
+	defaultSuperuser     = "postgres"
+	defaultMaintenanceDB = "postgres"
+)
+
+var (
+	setupRole          string
+	setupDBName        string
+	setupHost          string
+	setupPort          int
+	setupSuperuser     string
+	setupMaintenanceDB string
+)
+
+var setupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Bootstrap the local PostgreSQL role and database",
+	Long: `Create the PostgreSQL role and database the daemon needs, using peer
+authentication over the local socket so no password is stored anywhere.
+
+Run it as the postgres superuser so it can create the role and database:
+
+  sudo -u postgres scanorama setup
+
+It is idempotent — re-running it when the role and database already exist does
+nothing. The package postinstall invokes it automatically on a fresh install.`,
+	SilenceUsage: true,
+	RunE:         runSetup,
+}
+
+func runSetup(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// Privileged connection to the maintenance database as the superuser. Peer
+	// auth keys on the OS user, so this must run as the superuser's OS account.
+	conn, err := db.Connect(ctx, &db.Config{
+		Host:     setupHost,
+		Port:     setupPort,
+		Database: setupMaintenanceDB,
+		Username: setupSuperuser,
+		SSLMode:  "disable",
+	})
+	if err != nil {
+		return fmt.Errorf("connecting to PostgreSQL as %q over %s: %w", setupSuperuser, setupHost, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	res, err := db.EnsureRoleAndDatabase(ctx, conn, setupRole, setupDBName)
+	if err != nil {
+		return err
+	}
+
+	reportSetup(cmd, res)
+	return nil
+}
+
+// reportSetup prints what changed so a fresh bootstrap is distinguishable from a
+// no-op re-run.
+func reportSetup(cmd *cobra.Command, res db.BootstrapResult) {
+	var msg string
+	switch {
+	case res.RoleCreated && res.DatabaseCreated:
+		msg = fmt.Sprintf("Created role %q and database %q.\n", setupRole, setupDBName)
+	case res.DatabaseCreated:
+		msg = fmt.Sprintf("Role %q already existed; created database %q.\n", setupRole, setupDBName)
+	case res.RoleCreated:
+		msg = fmt.Sprintf("Created role %q; database %q already existed.\n", setupRole, setupDBName)
+	default:
+		msg = fmt.Sprintf("Role %q and database %q already exist; nothing to do.\n", setupRole, setupDBName)
+	}
+	_, _ = fmt.Fprint(cmd.OutOrStdout(), msg)
+}
+
+func init() {
+	rootCmd.AddCommand(setupCmd)
+
+	setupCmd.Flags().StringVar(&setupRole, "role", appName, "login role to create for the daemon")
+	setupCmd.Flags().StringVar(&setupDBName, "database", appName, "database to create, owned by the role")
+	setupCmd.Flags().StringVar(&setupHost, "host", defaultSocketDir,
+		"PostgreSQL host or socket directory to connect to")
+	setupCmd.Flags().IntVar(&setupPort, "port", defaultDatabasePort, "PostgreSQL port")
+	setupCmd.Flags().StringVar(&setupSuperuser, "superuser", defaultSuperuser,
+		"superuser role used to create the role and database")
+	setupCmd.Flags().StringVar(&setupMaintenanceDB, "maintenance-db", defaultMaintenanceDB,
+		"existing database to connect to while bootstrapping")
+}

--- a/cmd/cli/setup_test.go
+++ b/cmd/cli/setup_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anstrom/scanorama/internal/db"
+)
+
+func TestReportSetup(t *testing.T) {
+	origRole, origDB := setupRole, setupDBName
+	t.Cleanup(func() { setupRole, setupDBName = origRole, origDB })
+	setupRole = "scanorama"
+	setupDBName = "scanorama"
+
+	cases := []struct {
+		name   string
+		result db.BootstrapResult
+		want   string
+	}{
+		{"both created", db.BootstrapResult{RoleCreated: true, DatabaseCreated: true},
+			"Created role \"scanorama\" and database \"scanorama\".\n"},
+		{"database only", db.BootstrapResult{DatabaseCreated: true},
+			"Role \"scanorama\" already existed; created database \"scanorama\".\n"},
+		{"role only", db.BootstrapResult{RoleCreated: true},
+			"Created role \"scanorama\"; database \"scanorama\" already existed.\n"},
+		{"nothing to do", db.BootstrapResult{},
+			"Role \"scanorama\" and database \"scanorama\" already exist; nothing to do.\n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			cmd := &cobra.Command{}
+			cmd.SetOut(&buf)
+
+			reportSetup(cmd, tc.result)
+
+			assert.Equal(t, tc.want, buf.String())
+		})
+	}
+}
+
+func TestSetupCommandDefaults(t *testing.T) {
+	require.NoError(t, setupCmd.Flags().Parse(nil))
+
+	assert.Equal(t, "scanorama", setupCmd.Flags().Lookup("role").DefValue)
+	assert.Equal(t, "scanorama", setupCmd.Flags().Lookup("database").DefValue)
+	assert.Equal(t, defaultSocketDir, setupCmd.Flags().Lookup("host").DefValue)
+	assert.Equal(t, defaultSuperuser, setupCmd.Flags().Lookup("superuser").DefValue)
+	assert.Equal(t, defaultMaintenanceDB, setupCmd.Flags().Lookup("maintenance-db").DefValue)
+}

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -1,0 +1,57 @@
+# Scanorama configuration — production / systemd layout.
+#
+# Installed to /etc/scanorama/config.yaml. Must not be world-readable
+# (scanorama rejects permissions broader than 0640): chmod 640.
+#
+# Every value can also be set via SCANORAMA_* environment variables (e.g. an
+# EnvironmentFile referenced from the systemd unit). See docs/DEPLOYMENT.md.
+
+daemon:
+  pid_file: /run/scanorama/scanorama.pid   # matches the unit's RuntimeDirectory
+  work_dir: /var/lib/scanorama
+  daemonize: false                         # systemd runs the daemon in the foreground
+  shutdown_timeout: 30s
+  # Leave user/group empty: the systemd unit drops privileges via User=/Group=.
+  user: ""
+  group: ""
+
+database:
+  host: localhost
+  port: 5432
+  database: scanorama
+  username: scanorama
+  password: CHANGE_ME            # match the PostgreSQL role you created
+  ssl_mode: disable              # local socket/loopback; use require for remote DBs
+  max_open_conns: 25
+  max_idle_conns: 5
+  conn_max_lifetime: 5m
+  conn_max_idle_time: 5m
+
+api:
+  enabled: true
+  host: 127.0.0.1                # bind to loopback; front with a reverse proxy for remote access
+  port: 8080
+  auth_enabled: false           # set true and add api_keys before exposing beyond localhost
+  api_keys: []
+  enable_cors: true
+  cors_origins:
+    - "*"                       # restrict to your frontend origin in production
+  rate_limit_enabled: true
+  rate_limit_requests: 100
+  rate_limit_window: 1m
+  tls:
+    enabled: false
+    cert_file: ""
+    key_file: ""
+
+scanning:
+  worker_pool_size: 10
+  default_ports: "22,80,443,8080,8443"
+  scan_mode: connect            # connect needs no privilege; syn/stealth/aggressive need nmap raw sockets
+  max_scan_timeout: 10m
+  max_concurrent_targets: 100
+
+logging:
+  level: info                   # debug | info | warn | error
+  format: json                  # text | json
+  output: stdout                # captured by journald under systemd

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -16,12 +16,17 @@ daemon:
   group: ""
 
 database:
-  host: localhost
+  # Local PostgreSQL over the Unix socket with peer authentication: the daemon
+  # runs as the scanorama OS user, so a scanorama DB role authenticates with no
+  # password. `scanorama setup` (run by the package postinstall) creates the role
+  # and database. For a remote DB, set host to its address, add a password, and
+  # switch ssl_mode to require.
+  host: /var/run/postgresql      # socket directory; peer auth keyed on the OS user
   port: 5432
   database: scanorama
   username: scanorama
-  password: CHANGE_ME            # match the PostgreSQL role you created
-  ssl_mode: disable              # local socket/loopback; use require for remote DBs
+  password: ""                   # empty: peer auth over the local socket
+  ssl_mode: disable              # not used over the Unix socket; require for remote
   max_open_conns: 25
   max_idle_conns: 5
   conn_max_lifetime: 5m

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Scanorama bare-metal installer: binary + systemd unit + production layout.
+#
+# Use this when installing from a release tarball (no .deb/.rpm). It is
+# idempotent — safe to re-run to upgrade the binary or unit in place.
+#
+# Usage:
+#   sudo ./deploy/install.sh [/path/to/scanorama]
+#
+# If the binary path is omitted, the script looks next to itself and in the
+# current directory.
+set -euo pipefail
+
+BIN_DST="/usr/bin/scanorama"
+UNIT_DST="/etc/systemd/system/scanorama.service"
+CONF_DIR="/etc/scanorama"
+CONF_FILE="${CONF_DIR}/config.yaml"
+STATE_DIR="/var/lib/scanorama"
+SVC_USER="scanorama"
+SVC_GROUP="scanorama"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BINARY_SRC="${1:-}"
+
+die() { echo "error: $*" >&2; exit 1; }
+info() { echo "==> $*"; }
+
+[ "$(id -u)" -eq 0 ] || die "must run as root (try: sudo $0)"
+
+# Locate the binary: explicit arg, alongside the script, or in the cwd.
+if [ -z "${BINARY_SRC}" ]; then
+  for candidate in "${SCRIPT_DIR}/scanorama" "${SCRIPT_DIR}/../scanorama" "./scanorama"; do
+    if [ -x "${candidate}" ]; then BINARY_SRC="${candidate}"; break; fi
+  done
+fi
+[ -n "${BINARY_SRC}" ] && [ -x "${BINARY_SRC}" ] || \
+  die "scanorama binary not found; pass its path: $0 /path/to/scanorama"
+
+command -v nmap >/dev/null 2>&1 || \
+  echo "warning: nmap not found on PATH — install it before scanning (e.g. apt-get install nmap)" >&2
+
+info "Creating ${SVC_USER} system user and group"
+getent group "${SVC_GROUP}" >/dev/null || groupadd --system "${SVC_GROUP}"
+getent passwd "${SVC_USER}" >/dev/null || useradd --system --gid "${SVC_GROUP}" \
+  --home-dir "${STATE_DIR}" --shell /usr/sbin/nologin --comment "Scanorama daemon" "${SVC_USER}"
+
+info "Creating directories"
+install -d -o "${SVC_USER}" -g "${SVC_GROUP}" -m 0750 "${STATE_DIR}"
+install -d -o root -g "${SVC_GROUP}" -m 0750 "${CONF_DIR}"
+
+info "Installing binary -> ${BIN_DST}"
+install -o root -g root -m 0755 "${BINARY_SRC}" "${BIN_DST}"
+
+info "Installing systemd unit -> ${UNIT_DST}"
+install -o root -g root -m 0644 "${SCRIPT_DIR}/scanorama.service" "${UNIT_DST}"
+
+if [ ! -f "${CONF_FILE}" ]; then
+  info "Installing default config -> ${CONF_FILE}"
+  install -o root -g "${SVC_GROUP}" -m 0640 "${SCRIPT_DIR}/config.example.yaml" "${CONF_FILE}"
+else
+  info "Keeping existing config ${CONF_FILE}"
+fi
+
+if command -v setcap >/dev/null 2>&1 && command -v nmap >/dev/null 2>&1; then
+  info "Granting raw-socket capability to the nmap binary"
+  setcap cap_net_raw,cap_net_admin+eip "$(command -v nmap)"
+else
+  echo "warning: setcap or nmap missing — SYN/ACK/UDP scans stay unavailable until you run:" >&2
+  echo "         setcap cap_net_raw,cap_net_admin+eip \"\$(command -v nmap)\"" >&2
+fi
+
+info "Reloading systemd"
+systemctl daemon-reload
+
+cat <<EOF
+
+Scanorama installed.
+
+Next steps:
+  1. Create the database and role (local PostgreSQL):
+       sudo -u postgres psql -c "CREATE USER scanorama WITH PASSWORD 'changeme';"
+       sudo -u postgres psql -c "CREATE DATABASE scanorama OWNER scanorama;"
+  2. Set the same password in ${CONF_FILE} (database.password).
+  3. Start the service:
+       sudo systemctl enable --now scanorama
+       systemctl status scanorama
+EOF

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -46,8 +46,8 @@ getent passwd "${SVC_USER}" >/dev/null || useradd --system --gid "${SVC_GROUP}" 
   --home-dir "${STATE_DIR}" --shell /usr/sbin/nologin --comment "Scanorama daemon" "${SVC_USER}"
 
 info "Creating directories"
-install -d -o "${SVC_USER}" -g "${SVC_GROUP}" -m 0750 "${STATE_DIR}"
-install -d -o root -g "${SVC_GROUP}" -m 0750 "${CONF_DIR}"
+install -d -o "${SVC_USER}" -g "${SVC_GROUP}" -m 0755 "${STATE_DIR}"
+install -d -o root -g root -m 0755 "${CONF_DIR}"
 
 info "Installing binary -> ${BIN_DST}"
 install -o root -g root -m 0755 "${BINARY_SRC}" "${BIN_DST}"
@@ -73,16 +73,24 @@ fi
 info "Reloading systemd"
 systemctl daemon-reload
 
-cat <<EOF
+# Bootstrap the database via peer auth (the scanorama role authenticates as the
+# scanorama OS user over the local socket — no password). Needs a running local
+# PostgreSQL; if absent, print the manual steps instead of failing.
+if command -v runuser >/dev/null 2>&1 && getent passwd postgres >/dev/null 2>&1 \
+   && runuser -u postgres -- "${BIN_DST}" setup; then
+  info "Enabling and starting the service"
+  systemctl enable --now scanorama
+  cat <<EOF
 
-Scanorama installed.
-
-Next steps:
-  1. Create the database and role (local PostgreSQL):
-       sudo -u postgres psql -c "CREATE USER scanorama WITH PASSWORD 'changeme';"
-       sudo -u postgres psql -c "CREATE DATABASE scanorama OWNER scanorama;"
-  2. Set the same password in ${CONF_FILE} (database.password).
-  3. Start the service:
-       sudo systemctl enable --now scanorama
-       systemctl status scanorama
+Scanorama installed and started. Check it with:
+  systemctl status scanorama
 EOF
+else
+  cat <<EOF
+
+Scanorama installed, but the database was not bootstrapped (PostgreSQL not found
+or not running). Once a local PostgreSQL is running, finish with:
+  sudo -u postgres ${BIN_DST} setup
+  sudo systemctl enable --now scanorama
+EOF
+fi

--- a/deploy/packaging/postinstall.sh
+++ b/deploy/packaging/postinstall.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# nfpm postinstall: create the service account, fix config ownership, grant nmap
+# the raw-socket capability, and reload systemd. Idempotent.
+set -e
+
+SVC_USER="scanorama"
+SVC_GROUP="scanorama"
+STATE_DIR="/var/lib/scanorama"
+CONF_FILE="/etc/scanorama/config.yaml"
+
+if ! getent group "${SVC_GROUP}" >/dev/null 2>&1; then
+  groupadd --system "${SVC_GROUP}"
+fi
+if ! getent passwd "${SVC_USER}" >/dev/null 2>&1; then
+  useradd --system --gid "${SVC_GROUP}" --home-dir "${STATE_DIR}" \
+    --shell /usr/sbin/nologin --comment "Scanorama daemon" "${SVC_USER}"
+fi
+
+# /var/lib/scanorama is also created by the unit's StateDirectory, but create it
+# here too so a one-shot CLI run before first start has a home.
+install -d -o "${SVC_USER}" -g "${SVC_GROUP}" -m 0750 "${STATE_DIR}"
+
+# The packaged config ships as root:root; hand read access to the service group.
+if [ -f "${CONF_FILE}" ]; then
+  chown root:"${SVC_GROUP}" "${CONF_FILE}"
+  chmod 0640 "${CONF_FILE}"
+fi
+
+# Let nmap open raw sockets (SYN/ACK/UDP scans) while scanorama stays unprivileged.
+if command -v setcap >/dev/null 2>&1 && command -v nmap >/dev/null 2>&1; then
+  setcap cap_net_raw,cap_net_admin+eip "$(command -v nmap)" || true
+fi
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl daemon-reload || true
+fi
+
+echo "Scanorama installed. Edit /etc/scanorama/config.yaml (set database.password),"
+echo "then: sudo systemctl enable --now scanorama"
+
+exit 0

--- a/deploy/packaging/postinstall.sh
+++ b/deploy/packaging/postinstall.sh
@@ -1,13 +1,26 @@
 #!/bin/sh
 #
 # nfpm postinstall: create the service account, fix config ownership, grant nmap
-# the raw-socket capability, and reload systemd. Idempotent.
+# the raw-socket capability, bootstrap the local database, and (on a fresh
+# install) enable and start the service. Idempotent.
 set -e
 
 SVC_USER="scanorama"
 SVC_GROUP="scanorama"
 STATE_DIR="/var/lib/scanorama"
 CONF_FILE="/etc/scanorama/config.yaml"
+PG_SUPERUSER="postgres"
+
+# bootstrap_database creates the scanorama role and database via `scanorama setup`,
+# run as the postgres superuser so peer authentication over the local socket
+# succeeds. Returns non-zero (without failing the install) when PostgreSQL is not
+# present or not yet initialized — e.g. an RPM host where the cluster needs a
+# manual `postgresql-setup --initdb` first.
+bootstrap_database() {
+  command -v runuser >/dev/null 2>&1 || return 1
+  getent passwd "${PG_SUPERUSER}" >/dev/null 2>&1 || return 1
+  runuser -u "${PG_SUPERUSER}" -- /usr/bin/scanorama setup
+}
 
 if ! getent group "${SVC_GROUP}" >/dev/null 2>&1; then
   groupadd --system "${SVC_GROUP}"
@@ -19,7 +32,7 @@ fi
 
 # /var/lib/scanorama is also created by the unit's StateDirectory, but create it
 # here too so a one-shot CLI run before first start has a home.
-install -d -o "${SVC_USER}" -g "${SVC_GROUP}" -m 0750 "${STATE_DIR}"
+install -d -o "${SVC_USER}" -g "${SVC_GROUP}" -m 0755 "${STATE_DIR}"
 
 # The packaged config ships as root:root; hand read access to the service group.
 if [ -f "${CONF_FILE}" ]; then
@@ -36,7 +49,41 @@ if command -v systemctl >/dev/null 2>&1; then
   systemctl daemon-reload || true
 fi
 
-echo "Scanorama installed. Edit /etc/scanorama/config.yaml (set database.password),"
-echo "then: sudo systemctl enable --now scanorama"
+# Detect an upgrade vs a fresh install. nfpm passes the package manager's native
+# args: rpm sends a numeric count ($1>=2 on upgrade), dpkg sends "configure" with
+# the previously-installed version in $2 (empty on a fresh install).
+is_upgrade=false
+if [ "${1:-0}" -ge 2 ] 2>/dev/null || [ -n "${2:-}" ]; then
+  is_upgrade=true
+fi
+
+if [ "${is_upgrade}" = true ]; then
+  # Pick up the new binary without disturbing an already-configured service.
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl try-restart scanorama.service >/dev/null 2>&1 || true
+    # If a prior install never finished bootstrapping (the unit is not enabled),
+    # try-restart is a no-op — remind how to finish rather than stay silent.
+    if ! systemctl is-enabled scanorama.service >/dev/null 2>&1; then
+      echo "Scanorama upgraded but not yet running. Finish setup with:"
+      echo "  sudo -u postgres scanorama setup"
+      echo "  sudo systemctl enable --now scanorama"
+    fi
+  fi
+  exit 0
+fi
+
+# Fresh install: bootstrap the database, then enable and start the service. If
+# PostgreSQL isn't ready, leave the service stopped and print the manual steps.
+if bootstrap_database; then
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl enable --now scanorama.service >/dev/null 2>&1 || true
+  fi
+  echo "Scanorama installed and started. Check it with: systemctl status scanorama"
+else
+  echo "Scanorama installed, but the database was not bootstrapped (PostgreSQL not"
+  echo "found or not initialized). Once PostgreSQL is running, finish with:"
+  echo "  sudo -u postgres scanorama setup"
+  echo "  sudo systemctl enable --now scanorama"
+fi
 
 exit 0

--- a/deploy/packaging/postremove.sh
+++ b/deploy/packaging/postremove.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# nfpm postremove: reload systemd after unit removal. The scanorama user, its
+# data in /var/lib/scanorama, and /etc/scanorama/config.yaml are intentionally
+# left in place so an uninstall does not destroy scan history or configuration.
+set -e
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl daemon-reload >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/deploy/packaging/preremove.sh
+++ b/deploy/packaging/preremove.sh
@@ -1,11 +1,18 @@
 #!/bin/sh
 #
-# nfpm preremove: stop and disable the service before the files go away.
+# nfpm preremove: stop and disable the service on a real removal only.
+#
+# During an upgrade the old package's preremove runs before the new files unpack;
+# stopping/disabling there would turn off a service the user had enabled. nfpm
+# passes the package manager's native args: rpm sends "0" on final removal ("1"
+# on upgrade), dpkg sends "remove" on removal ("upgrade" on upgrade).
 set -e
 
-if command -v systemctl >/dev/null 2>&1; then
-  systemctl stop scanorama.service >/dev/null 2>&1 || true
-  systemctl disable scanorama.service >/dev/null 2>&1 || true
+if [ "${1:-}" = remove ] || [ "${1:-}" = 0 ]; then
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl stop scanorama.service    >/dev/null 2>&1 || true
+    systemctl disable scanorama.service >/dev/null 2>&1 || true
+  fi
 fi
 
 exit 0

--- a/deploy/packaging/preremove.sh
+++ b/deploy/packaging/preremove.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# nfpm preremove: stop and disable the service before the files go away.
+set -e
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl stop scanorama.service >/dev/null 2>&1 || true
+  systemctl disable scanorama.service >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/deploy/scanorama.service
+++ b/deploy/scanorama.service
@@ -1,0 +1,55 @@
+[Unit]
+Description=Scanorama network scanner daemon
+Documentation=https://github.com/anstrom/scanorama
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=scanorama
+Group=scanorama
+ExecStart=/usr/bin/scanorama daemon start --background=false --config /etc/scanorama/config.yaml
+Restart=on-failure
+RestartSec=5s
+TimeoutStopSec=35s
+KillMode=mixed
+EnvironmentFile=-/etc/scanorama/env
+
+# Directories managed by systemd (created with the right ownership on start):
+#   StateDirectory     -> /var/lib/scanorama
+#   RuntimeDirectory   -> /run/scanorama        (holds the PID file)
+#   ConfigurationDir   -> /etc/scanorama
+StateDirectory=scanorama
+StateDirectoryMode=0750
+RuntimeDirectory=scanorama
+RuntimeDirectoryMode=0750
+ConfigurationDirectory=scanorama
+ConfigurationDirectoryMode=0750
+WorkingDirectory=/var/lib/scanorama
+
+# Raw-socket privilege for SYN/ACK/UDP scans.
+#
+# Recommended: grant the capability to the *nmap* binary (the install script and
+# the package postinstall do this), keeping scanorama itself fully unprivileged:
+#     setcap cap_net_raw,cap_net_admin+eip "$(command -v nmap)"
+#
+# NoNewPrivileges is intentionally NOT enabled — nmap relies on file
+# capabilities, which NoNewPrivileges would block.
+#
+# Alternative: grant the capabilities to this service instead (uncomment the two
+# lines below), in which case the nmap setcap step is unnecessary:
+# AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN
+# CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN
+
+# Hardening (kept compatible with nmap raw-socket scanning — do not add
+# RestrictAddressFamilies or NoNewPrivileges, both of which break scans).
+ProtectSystem=full
+ProtectHome=true
+PrivateTmp=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+RestrictSUIDSGID=true
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/scanorama.service
+++ b/deploy/scanorama.service
@@ -16,15 +16,18 @@ KillMode=mixed
 EnvironmentFile=-/etc/scanorama/env
 
 # Directories managed by systemd (created with the right ownership on start):
-#   StateDirectory     -> /var/lib/scanorama
+#   StateDirectory     -> /var/lib/scanorama   (writable by the daemon)
 #   RuntimeDirectory   -> /run/scanorama        (holds the PID file)
-#   ConfigurationDir   -> /etc/scanorama
+#
+# /etc/scanorama is deliberately NOT a ConfigurationDirectory: the daemon only
+# reads its config, never writes it, so the directory is laid down by the
+# installer/package (root-owned) rather than chowned to the service user here.
+# 0755 is intentional: scan results live in PostgreSQL, not these directories, so
+# they hold no secrets; the config file (0640) is what guards the DB credentials.
 StateDirectory=scanorama
-StateDirectoryMode=0750
+StateDirectoryMode=0755
 RuntimeDirectory=scanorama
-RuntimeDirectoryMode=0750
-ConfigurationDirectory=scanorama
-ConfigurationDirectoryMode=0750
+RuntimeDirectoryMode=0755
 WorkingDirectory=/var/lib/scanorama
 
 # Raw-socket privilege for SYN/ACK/UDP scans.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -241,7 +241,27 @@ All configuration values can be set or overridden using environment variables pr
 
 ## Database Setup
 
-### Create the Database and User
+### Local PostgreSQL (recommended) — `scanorama setup`
+
+The package and install script target a local PostgreSQL using **peer
+authentication**: the daemon runs as the `scanorama` OS user and connects over
+the Unix socket as a `scanorama` database role, so there is no password to store
+or rotate. `scanorama setup` creates the role and database idempotently:
+
+```sh
+# Run as the postgres superuser so peer auth can create the role and database.
+sudo -u postgres scanorama setup
+```
+
+The package postinstall (and `deploy/install.sh`) run this for you on a fresh
+install. Re-running it is a no-op. The matching config is the default in
+`/etc/scanorama/config.yaml`: `host: /var/run/postgresql`, `username: scanorama`,
+empty `password`.
+
+### Remote or password-authenticated PostgreSQL
+
+For a remote database, create the role and database manually and use password
+auth instead of peer:
 
 ```sql
 -- Run as a PostgreSQL superuser
@@ -249,6 +269,9 @@ CREATE USER scanorama WITH PASSWORD 'changeme';
 CREATE DATABASE scanorama OWNER scanorama;
 GRANT ALL PRIVILEGES ON DATABASE scanorama TO scanorama;
 ```
+
+Then set `database.host` to the server address, `database.password` to the role
+password, and `database.ssl_mode` to `require` in `/etc/scanorama/config.yaml`.
 
 ### Migrations
 
@@ -323,7 +346,8 @@ All three install methods below use the same committed unit
 
 Each release publishes Debian and RPM packages that install the binary to `/usr/bin/scanorama`, drop in
 the systemd unit and a default `/etc/scanorama/config.yaml`, create the `scanorama` system user, and grant
-the nmap binary raw-socket capability. The package depends on `nmap` and pulls it in automatically.
+the nmap binary raw-socket capability. The package depends on `nmap` and PostgreSQL (`postgresql` on
+Debian, `postgresql-server` on RHEL) and pulls them in automatically.
 
 ```sh
 # Debian / Ubuntu
@@ -333,11 +357,19 @@ sudo apt-get install ./scanorama_<version>_linux_amd64.deb
 sudo dnf install ./scanorama-<version>.x86_64.rpm
 ```
 
+On Debian/Ubuntu the postinstall bootstraps the database (`scanorama setup`) and
+enables and starts the service, so a fresh install comes up working with no
+further steps. On RHEL/Fedora the PostgreSQL cluster is not initialized by the
+package; run `sudo postgresql-setup --initdb && sudo systemctl enable --now
+postgresql`, then `sudo -u postgres scanorama setup` and `sudo systemctl enable
+--now scanorama`.
+
 #### Option B — Install script (from the release tarball)
 
 If you installed from the `.tar.gz`, run the bundled installer as root. It is idempotent and performs the
 same steps as the package: creates the service user, lays out `/etc/scanorama` and `/var/lib/scanorama`,
-installs the binary and unit, installs a default config, and sets the nmap capability.
+installs the binary and unit, installs a default config, sets the nmap capability, and — when a local
+PostgreSQL is running — bootstraps the database and starts the service.
 
 ```sh
 sudo ./deploy/install.sh ./scanorama
@@ -351,14 +383,18 @@ to `/etc/systemd/system/`, and create the `scanorama` user, directories, and nma
 
 #### Start it
 
+The package (Option A on Debian/Ubuntu) and the install script (Option B) bootstrap the database and start
+the service for you. You only need this for Option C, or after a manual `scanorama setup`:
+
 ```sh
 sudo systemctl daemon-reload          # only needed for Option C
 sudo systemctl enable --now scanorama
 sudo systemctl status scanorama
 ```
 
-Before the first start, set `database.password` in `/etc/scanorama/config.yaml` to match the PostgreSQL
-role you created (see [Database Setup](#database-setup)).
+The default config uses local peer authentication, so there is no password to set before the first start
+(see [Database Setup](#database-setup)). For a remote database, set `database.host`/`password`/`ssl_mode`
+in `/etc/scanorama/config.yaml` before starting.
 
 > **Privilege drop:** the unit runs scanorama directly as the `scanorama` user via systemd's
 > `User=`/`Group=` directives. Prefer this over the `daemon.user`/`daemon.group` config fields — let

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -314,48 +314,60 @@ Use `server` subcommands when you want only the REST API without the cron schedu
 ./scanorama server logs [--follow]
 ```
 
-### systemd Service (Recommended for Production)
+### Installing as a systemd Service (Recommended for Production)
 
-Create `/etc/systemd/system/scanorama.service`:
+All three install methods below use the same committed unit
+([`deploy/scanorama.service`](../deploy/scanorama.service)) and the same production layout. Pick one.
 
-```ini
-[Unit]
-Description=Scanorama Network Scanner Daemon
-After=network.target postgresql.service
-Requires=postgresql.service
+#### Option A — Distribution package (`.deb` / `.rpm`)
 
-[Service]
-Type=simple
-User=scanorama
-Group=scanorama
-WorkingDirectory=/var/lib/scanorama
-ExecStart=/usr/local/bin/scanorama daemon start --background=false --config /etc/scanorama/config.yaml
-ExecStop=/usr/local/bin/scanorama daemon stop
-Restart=on-failure
-RestartSec=5s
-
-# Environment (alternative to config file for secrets)
-EnvironmentFile=-/etc/scanorama/env
-
-# Allow nmap to use raw sockets for SYN scans (remove if using connect scans only)
-AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN
-CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN
-
-[Install]
-WantedBy=multi-user.target
-```
+Each release publishes Debian and RPM packages that install the binary to `/usr/bin/scanorama`, drop in
+the systemd unit and a default `/etc/scanorama/config.yaml`, create the `scanorama` system user, and grant
+the nmap binary raw-socket capability. The package depends on `nmap` and pulls it in automatically.
 
 ```sh
-sudo systemctl daemon-reload
-sudo systemctl enable scanorama
-sudo systemctl start scanorama
+# Debian / Ubuntu
+sudo apt-get install ./scanorama_<version>_linux_amd64.deb
+
+# RHEL / Fedora
+sudo dnf install ./scanorama-<version>.x86_64.rpm
+```
+
+#### Option B — Install script (from the release tarball)
+
+If you installed from the `.tar.gz`, run the bundled installer as root. It is idempotent and performs the
+same steps as the package: creates the service user, lays out `/etc/scanorama` and `/var/lib/scanorama`,
+installs the binary and unit, installs a default config, and sets the nmap capability.
+
+```sh
+sudo ./deploy/install.sh ./scanorama
+```
+
+#### Option C — Manual
+
+Copy the binary to `/usr/bin/scanorama`, install [`deploy/scanorama.service`](../deploy/scanorama.service)
+to `/etc/systemd/system/`, and create the `scanorama` user, directories, and nmap capability yourself —
+`deploy/install.sh` documents the exact commands.
+
+#### Start it
+
+```sh
+sudo systemctl daemon-reload          # only needed for Option C
+sudo systemctl enable --now scanorama
 sudo systemctl status scanorama
 ```
 
-> **Privilege drop:** the unit above runs scanorama directly as the `scanorama` user via systemd's
+Before the first start, set `database.password` in `/etc/scanorama/config.yaml` to match the PostgreSQL
+role you created (see [Database Setup](#database-setup)).
+
+> **Privilege drop:** the unit runs scanorama directly as the `scanorama` user via systemd's
 > `User=`/`Group=` directives. Prefer this over the `daemon.user`/`daemon.group` config fields — let
 > systemd perform the privilege drop at `exec` time and leave those config fields unset. (The in-process
 > drop is being hardened separately; see issue #554.)
+>
+> SYN/ACK/UDP scans need raw sockets: the package and install script `setcap` the **nmap** binary for you
+> (see [nmap Privileges](#nmap-privileges)). The unit also ships a commented `AmbientCapabilities`
+> alternative if you prefer to grant the capability to the service instead.
 
 ---
 
@@ -565,9 +577,9 @@ The `daemon stop` command sends `SIGTERM` and waits up to 30 seconds. If the dae
     server.crt
     server.key
 
-/var/lib/scanorama/    # working directory (daemon.work_dir)
-/var/run/scanorama/    # PID file directory
-/var/log/scanorama/    # log files (if logging.output points here)
+/var/lib/scanorama/    # working directory (daemon.work_dir; systemd StateDirectory)
+/run/scanorama/        # PID file directory (systemd RuntimeDirectory)
+/var/log/scanorama/    # log files (only if logging.output points here; default is journald)
 
-/usr/local/bin/scanorama   # binary
+/usr/bin/scanorama     # binary (package and install.sh location)
 ```

--- a/internal/db/bootstrap.go
+++ b/internal/db/bootstrap.go
@@ -1,0 +1,91 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/lib/pq"
+)
+
+// maxIdentifierLen is PostgreSQL's default identifier length limit (NAMEDATALEN-1).
+const maxIdentifierLen = 63
+
+// identifierPattern matches a safe, unquoted SQL identifier: a leading letter or
+// underscore followed by letters, digits, or underscores. CREATE ROLE/DATABASE
+// cannot bind the object name as a parameter, so names are validated here and
+// quoted at use; this keeps `scanorama setup` from passing anything injectable.
+var identifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// BootstrapResult reports what EnsureRoleAndDatabase changed, so callers can tell
+// a fresh bootstrap from a no-op re-run.
+type BootstrapResult struct {
+	RoleCreated     bool
+	DatabaseCreated bool
+}
+
+// validateIdentifier ensures name is a plain SQL identifier of acceptable length.
+func validateIdentifier(name string) error {
+	if len(name) > maxIdentifierLen {
+		return fmt.Errorf("identifier %q exceeds %d characters", name, maxIdentifierLen)
+	}
+	if !identifierPattern.MatchString(name) {
+		return fmt.Errorf("identifier %q is not a valid SQL identifier", name)
+	}
+	return nil
+}
+
+// EnsureRoleAndDatabase idempotently creates a LOGIN role and a database it owns.
+// It backs `scanorama setup`: bootstrapping a fresh local PostgreSQL so the
+// unprivileged daemon can connect over the Unix socket via peer authentication.
+//
+// conn must be authenticated as a superuser (the postgres role). The role is
+// created with LOGIN and no password — authentication is peer-based, keyed on the
+// connecting OS user, so there is no secret to store. Re-running is a no-op.
+func EnsureRoleAndDatabase(ctx context.Context, conn *DB, role, database string) (BootstrapResult, error) {
+	var res BootstrapResult
+
+	if err := validateIdentifier(role); err != nil {
+		return res, fmt.Errorf("invalid role name: %w", err)
+	}
+	if err := validateIdentifier(database); err != nil {
+		return res, fmt.Errorf("invalid database name: %w", err)
+	}
+
+	roleExists, err := existsQuery(ctx, conn,
+		"SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)", role)
+	if err != nil {
+		return res, fmt.Errorf("checking role %q: %w", role, err)
+	}
+	if !roleExists {
+		if _, err := conn.ExecContext(ctx, "CREATE ROLE "+pq.QuoteIdentifier(role)+" LOGIN"); err != nil {
+			return res, fmt.Errorf("creating role %q: %w", role, err)
+		}
+		res.RoleCreated = true
+	}
+
+	dbExists, err := existsQuery(ctx, conn,
+		"SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)", database)
+	if err != nil {
+		return res, fmt.Errorf("checking database %q: %w", database, err)
+	}
+	if !dbExists {
+		stmt := fmt.Sprintf("CREATE DATABASE %s OWNER %s",
+			pq.QuoteIdentifier(database), pq.QuoteIdentifier(role))
+		if _, err := conn.ExecContext(ctx, stmt); err != nil {
+			return res, fmt.Errorf("creating database %q: %w", database, err)
+		}
+		res.DatabaseCreated = true
+	}
+
+	return res, nil
+}
+
+// existsQuery runs an EXISTS probe and returns its boolean result.
+func existsQuery(ctx context.Context, conn *DB, query string, args ...any) (bool, error) {
+	var exists bool
+	if err := conn.GetContext(ctx, &exists, query, args...); err != nil {
+		return false, err
+	}
+	return exists, nil
+}

--- a/internal/db/bootstrap_test.go
+++ b/internal/db/bootstrap_test.go
@@ -1,0 +1,111 @@
+// Package db provides unit tests for the local PostgreSQL bootstrap helpers.
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// existsRows returns a single-column boolean result set as the EXISTS probes do.
+func existsRows(exists bool) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"exists"}).AddRow(exists)
+}
+
+func TestEnsureRoleAndDatabase(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("creates role and database when neither exists", func(t *testing.T) {
+		db, mock := newMockDB(t)
+
+		mock.ExpectQuery("pg_roles").WithArgs("scanorama").WillReturnRows(existsRows(false))
+		mock.ExpectExec("CREATE ROLE \"scanorama\" LOGIN").WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectQuery("pg_database").WithArgs("scanorama").WillReturnRows(existsRows(false))
+		mock.ExpectExec("CREATE DATABASE \"scanorama\" OWNER \"scanorama\"").
+			WillReturnResult(sqlmock.NewResult(0, 0))
+
+		res, err := EnsureRoleAndDatabase(ctx, db, "scanorama", "scanorama")
+
+		require.NoError(t, err)
+		assert.True(t, res.RoleCreated)
+		assert.True(t, res.DatabaseCreated)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("no-op when role and database already exist", func(t *testing.T) {
+		db, mock := newMockDB(t)
+
+		mock.ExpectQuery("pg_roles").WithArgs("scanorama").WillReturnRows(existsRows(true))
+		mock.ExpectQuery("pg_database").WithArgs("scanorama").WillReturnRows(existsRows(true))
+
+		res, err := EnsureRoleAndDatabase(ctx, db, "scanorama", "scanorama")
+
+		require.NoError(t, err)
+		assert.False(t, res.RoleCreated)
+		assert.False(t, res.DatabaseCreated)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("creates only the database when the role already exists", func(t *testing.T) {
+		db, mock := newMockDB(t)
+
+		mock.ExpectQuery("pg_roles").WithArgs("scanorama").WillReturnRows(existsRows(true))
+		mock.ExpectQuery("pg_database").WithArgs("scanorama").WillReturnRows(existsRows(false))
+		mock.ExpectExec("CREATE DATABASE \"scanorama\" OWNER \"scanorama\"").
+			WillReturnResult(sqlmock.NewResult(0, 0))
+
+		res, err := EnsureRoleAndDatabase(ctx, db, "scanorama", "scanorama")
+
+		require.NoError(t, err)
+		assert.False(t, res.RoleCreated)
+		assert.True(t, res.DatabaseCreated)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("wraps a query error", func(t *testing.T) {
+		db, mock := newMockDB(t)
+
+		mock.ExpectQuery("pg_roles").WithArgs("scanorama").WillReturnError(errors.New("connection refused"))
+
+		_, err := EnsureRoleAndDatabase(ctx, db, "scanorama", "scanorama")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "scanorama")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("rejects an invalid role identifier before touching the database", func(t *testing.T) {
+		db, _ := newMockDB(t)
+
+		_, err := EnsureRoleAndDatabase(ctx, db, "scan; DROP DATABASE x", "scanorama")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "role")
+	})
+
+	t.Run("rejects an invalid database identifier", func(t *testing.T) {
+		db, mock := newMockDB(t)
+		// Both identifiers are validated before any query, so no queries run.
+		_, err := EnsureRoleAndDatabase(ctx, db, "scanorama", "bad name")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "database")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestValidateIdentifier(t *testing.T) {
+	valid := []string{"scanorama", "app_db", "_x", "Role1"}
+	for _, id := range valid {
+		assert.NoError(t, validateIdentifier(id), "expected %q to be valid", id)
+	}
+
+	invalid := []string{"", "1abc", "has space", "drop;table", "a-b", "töet"}
+	for _, id := range invalid {
+		assert.Error(t, validateIdentifier(id), "expected %q to be rejected", id)
+	}
+}


### PR DESCRIPTION
## Summary

Makes a bare-metal Linux install of Scanorama a single command that comes up working — no manual database setup, no passwords. Adds committed deploy artifacts, `.deb`/`.rpm` packaging, and a `scanorama setup` command that bootstraps a local PostgreSQL using peer authentication.

Target model: static binary + systemd + local PostgreSQL, scanorama running **unprivileged**, the raw-socket capability on the **nmap** binary, and the database reached over the Unix socket via **peer auth** (the daemon runs as the `scanorama` OS user, which maps to a `scanorama` DB role — so there is no password anywhere).

## What's included

- **`scanorama setup`** (`cmd/cli/setup.go`, `internal/db/bootstrap.go`) — connects as the postgres superuser over the local socket and idempotently creates the `scanorama` LOGIN role and owned database. Identifiers are validated and quoted (CREATE ROLE/DATABASE can't bind the object name). Unit-tested with sqlmock.
- **`deploy/scanorama.service`** — canonical unit. Runs as `User=scanorama`/`Group=scanorama`, manages `/var/lib/scanorama` and `/run/scanorama`, documents the nmap-capability options. Deliberately omits `NoNewPrivileges`/`RestrictAddressFamilies` (both break nmap raw-socket scans) and no longer claims `/etc/scanorama` as a `ConfigurationDirectory` (the daemon only reads its config).
- **`deploy/config.example.yaml`** — peer-auth defaults: `host: /var/run/postgresql`, empty `password`, `ssl_mode: disable`.
- **`deploy/install.sh`** — idempotent tarball installer: service user, dirs, binary, unit, default config, `setcap` nmap, then bootstraps the DB and starts the service when a local PostgreSQL is running.
- **nfpm packaging (`.goreleaser.yml`)** — every tag builds `.deb`/`.rpm` that install binary → `/usr/bin/scanorama`, the unit, and a `config|noreplace` default config; depend on `nmap` and PostgreSQL (`postgresql` on deb, `postgresql-server` on rpm). Maintainer scripts create the user, `setcap` nmap, bootstrap the DB, and manage the service lifecycle (upgrade-aware `try-restart`; stop/disable only on real removal). Uninstall preserves the user, data, and config.
- **`docs/DEPLOYMENT.md`** — peer-auth model, `scanorama setup`, package auto-start on Debian, the RHEL `initdb` step, and the remote-DB fallback with password auth.

## Privilege & auth model

- scanorama daemon: **never root** — runs as the `scanorama` user via systemd `User=`/`Group=`.
- nmap: `scanorama` uid + `CAP_NET_RAW`/`CAP_NET_ADMIN` file capabilities (set on the system nmap binary).
- database: peer auth over the Unix socket — no password stored, generated, or rotated. Remote DBs use password auth via a manual config edit.

## Validation

- `go test -race ./internal/db/ ./cmd/cli/` pass; bootstrap and setup covered (happy/no-op/partial/error/invalid-identifier; report branches; flag defaults).
- `goreleaser check` passes; nfpm section validates (only pre-existing `dockers` deprecation warnings).
- `shellcheck` clean on `install.sh` and all maintainer scripts; deb/rpm `$1`/`$2` upgrade-vs-removal handling verified.
- golangci-lint clean; no swagger drift.
- Agent review: no blockers (SQL-injection vector closed, shell lifecycle logic correct, nfpm override correct, peer-auth model coherent end-to-end).

## Test plan

Package build + install behaviour needs one manual pass on clean hosts (can't run in CI without a Linux VM and a real package build):

- [ ] `goreleaser release --snapshot --clean` produces a `.deb` and `.rpm`
- [ ] `apt-get install ./scanorama_*_amd64.deb` on Debian/Ubuntu pulls nmap + postgresql, creates the `scanorama` user, `getcap $(command -v nmap)` shows `cap_net_raw,cap_net_admin`, bootstraps the DB, and the service is **enabled and running** with no further steps
- [ ] `connect` and `syn` scans both succeed against the auto-created local DB
- [ ] On RHEL/Fedora: after `postgresql-setup --initdb` + starting postgres, `scanorama setup` + `systemctl enable --now scanorama` brings it up
- [ ] `apt-get remove scanorama` stops/disables the service and leaves `/var/lib/scanorama` + `/etc/scanorama/config.yaml` intact; an upgrade does **not** stop the service
- [ ] `deploy/install.sh ./scanorama` performs the same install + bootstrap from an extracted tarball

Closes #858
Closes #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)