### PR TITLE
chore(deps): bump Go toolchain to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anstrom/scanorama
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## What

Bumps the Go toolchain directive in `go.mod` from `1.26.3` to `1.26.4`.

## Why

The **Vulnerability Scan** CI job (govulncheck, source mode) has been failing on `main` since ~2026-06-05, flagging two Go **standard library** CVEs fixed in go1.26.4:

- **GO-2026-5039** — unescaped inputs in errors in `net/textproto`
- **GO-2026-5037** — inefficient candidate hostname parsing in `crypto/x509`

All workflows resolve the version via `go-version-file: go.mod`, so this single directive change propagates to every CI job.

## Verification

- `govulncheck -mode source ./...` → **No vulnerabilities found** (was failing before the bump)
- `go build ./...` → clean
- `go test -race ./internal/...` → all packages pass

Closes #866