### PR TITLE
chore(gomod): add toolchain directive and let Renovate track it

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,6 @@ run:
   tests: true
   modules-download-mode: readonly
   allow-parallel-runners: true
-  go: "1.26.2"
 
 linters:
   default: none

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/anstrom/scanorama
 
-go 1.26.4
+go 1.26.0
+
+toolchain go1.26.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/renovate.json
+++ b/renovate.json
@@ -17,24 +17,18 @@
   "gomod": {
     "postUpdateOptions": ["gomodTidy"]
   },
-  "customManagers": [
-    {
-      "description": "Sync GO_VERSION in CI workflows with go.mod",
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
-      "matchStrings": [
-        "# renovate: datasource=golang-version depName=go\\s+GO_VERSION: \"(?<currentValue>[^\"]+)\""
-      ],
-      "datasourceTemplate": "golang-version",
-      "depNameTemplate": "go",
-      "versioningTemplate": "semver-coerced"
-    }
-  ],
   "packageRules": [
     {
-      "matchManagers": ["gomod", "custom.regex"],
+      "matchManagers": ["gomod"],
       "groupName": "Go modules",
       "labels": ["dependencies", "go"]
+    },
+    {
+      "description": "Keep toolchain bumps separate — they carry stdlib security fixes",
+      "matchManagers": ["gomod"],
+      "matchDatasources": ["golang-version"],
+      "groupName": "Go toolchain",
+      "labels": ["dependencies", "go", "security"]
     },
     {
       "matchManagers": ["npm"],


### PR DESCRIPTION
Makes the Go build toolchain a tracked dependency so stdlib security fixes stop being invisible
to automation.

Mentions #945

## Why

`main`'s nightly Security run has been red since 2026-07-14 on `GO-2026-5856` (`crypto/tls`, fixed
in go1.26.5). No dependency PR could ever fix it — the stdlib is not a module, so Dependabot and
Renovate are structurally blind to it.

`renovate.json` already had a `customManagers` regex meant to solve exactly this, syncing a
`GO_VERSION` env var in the workflows. It matched nothing: no workflow defines `GO_VERSION`, they
all use `go-version-file: go.mod`. It has been dead config.

## Approach

Renovate updates the `toolchain` directive by default, and `actions/setup-go` prefers `toolchain`
over `go` when reading `go-version-file`. So `go.mod` stays the single source of truth and **no
workflow file changes** — all 10+ `setup-go` call sites keep working as-is.

```
go 1.26.0

toolchain go1.26.4
```

The `go` directive drops to 1.26.0 deliberately. `go mod tidy` **deletes a `toolchain` line equal
to the `go` directive**, and `renovate.json` sets `postUpdateOptions: ["gomodTidy"]` — so
`toolchain go1.26.4` alongside `go 1.26.4` would silently vanish on the next Go dep PR. Verified:

| go.mod before tidy | after tidy |
|---|---|
| `go 1.26.4` + `toolchain go1.26.4` | `go 1.26.4` — toolchain stripped |
| `go 1.26.0` + `toolchain go1.26.4` | both survive |

This also splits the two concerns correctly: `go` is the language floor (minor granularity),
`toolchain` is the exact build version. Lowering the floor only widens compatibility — there are no
language changes across patch releases.

## Toolchain deliberately stays at 1.26.4

This PR does **not** bump to 1.26.5, so #945 stays open. Holding at the current version proves the
mechanism end-to-end: Renovate should now open a separate "Go toolchain" PR bumping
`toolchain go1.26.4` → `go1.26.5`. That bump closes #945.

Trade-off: the security fix waits for Renovate rather than landing now. `renovate.json` uses
`schedule:weekly`, so trigger a run from the Dependency Dashboard (#5) to see it sooner.

## Also

- Removes the dead `GO_VERSION` custom manager and its `custom.regex` reference in `packageRules`.
- Groups toolchain bumps separately from Go modules — they carry stdlib security fixes and should
  not queue behind unrelated dependency updates.
- `.golangci.yml` pinned `go: "1.26.2"`, already drifted from go.mod. Omitting it lets
  golangci-lint read the `go` directive, removing the third place a Go version could drift.

## Test plan

Config-only change with no application logic; build, vet, lint, and `go test -race ./internal/...`
all pass and are covered by CI. The remaining checks are things CI cannot verify:

- [ ] After merge, confirm Renovate opens a "Go toolchain" PR for `go1.26.4` → `go1.26.5`
- [ ] Confirm that PR carries the `security` label and is separate from the "Go modules" group
- [ ] After that PR merges, confirm the nightly Security run on `main` goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)